### PR TITLE
Fix unscrollable kanban columns (gui)

### DIFF
--- a/source/gui/client/components/Panel.tsx
+++ b/source/gui/client/components/Panel.tsx
@@ -83,6 +83,9 @@ export const Panel = <T extends ElementType = 'div'>({
 					position: 'relative',
 					zIndex: 1,
 					height: '100%',
+					display: 'flex',
+					flexDirection: 'column',
+					minHeight: 0,
 				}}
 			>
 				{children}

--- a/source/gui/client/components/SwimlaneColumn.tsx
+++ b/source/gui/client/components/SwimlaneColumn.tsx
@@ -86,6 +86,7 @@ export const SwimlaneColumn = ({
 			<header
 				style={{
 					height: 48,
+					flexShrink: 0,
 					display: 'flex',
 					fontSize: 12,
 					justifyContent: 'space-between',
@@ -127,7 +128,7 @@ export const SwimlaneColumn = ({
 				</div>
 			</header>
 
-			<div style={{overflow: 'auto', paddingTop: 4, flex: 1}}>
+			<div style={{overflow: 'auto', paddingTop: 4, flex: 1, minHeight: 0}}>
 				{swimlane.issues.length === 0 ? (
 					<>
 						{dropIndex === 0 && <DropIndicator />}


### PR DESCRIPTION
## Context

Kanban columns in the web GUI aren't scrollable, only the issues that fit on screen are visible, and the rest are cut off with no way to reach them. This PR fixes #74.

## This Change

`SwimlaneColumn` already had `overflow: auto; flex: 1` set on the issue list, but since `Panel` wraps its children in a block-box div, that `flex: 1` had no flex parent to work with, causing the list to be clipped rather than scrollable. The wrapper now forwards the panel's column layout properly so the flex behavior actually takes effect.

`Header` is the only other component that consumes `Panel`, and it's unaffected by this change.

## Test Plan

- `npm run build:gui` (typecheck + bundle) passes
- Manually tested in the GUI: columns with more issues than fit on screen now scroll correctly, and drag-and-drop across columns still works as expected

https://github.com/user-attachments/assets/1868d4a8-0072-49d7-94d8-e2a9ec8653ea