### PR TITLE
isolate e2e global config dir to stop cross-test races

### DIFF
--- a/source/git/git-storage.ts
+++ b/source/git/git-storage.ts
@@ -1,12 +1,11 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import {readProjectId} from '../lib/project-setup/project-setup.js';
 import {failed, isFail, Result, succeeded} from '../lib/model/result-types.js';
+import {getGlobalConfigDir} from '../lib/storage/global-config-dir.js';
 import {
 	EPIQ_DIR_NAME,
 	EVENTS_DIR_NAME,
-	GLOBAL_CONFIG_DIR_NAME,
 	MEDIA_DIR_NAME,
 } from '../lib/storage/paths.js';
 import {memoizeResult} from '../lib/utils/memoize.js';
@@ -21,12 +20,7 @@ export const getRelativeEventFilePath = (fileName: string): string =>
 export const getRelativeMediaDirPath = (): string =>
 	path.join(EPIQ_DIR_NAME, MEDIA_DIR_NAME);
 
-// Not delegated to paths.ts's getGlobalConfigDir to avoid a circular import
-// (paths.ts already imports from this module). Keep the env override logic
-// in sync with paths.ts if it ever changes.
-export const getEpiqGlobal = (): string =>
-	process.env['EPIQ_GLOBAL_DIR'] ??
-	path.join(os.homedir(), GLOBAL_CONFIG_DIR_NAME);
+export const getEpiqGlobal = getGlobalConfigDir;
 
 export const getWorktreesRoot = (): string =>
 	path.join(getEpiqGlobal(), 'worktrees');

--- a/source/git/git-storage.ts
+++ b/source/git/git-storage.ts
@@ -21,7 +21,11 @@ export const getRelativeEventFilePath = (fileName: string): string =>
 export const getRelativeMediaDirPath = (): string =>
 	path.join(EPIQ_DIR_NAME, MEDIA_DIR_NAME);
 
+// Not delegated to paths.ts's getGlobalConfigDir to avoid a circular import
+// (paths.ts already imports from this module). Keep the env override logic
+// in sync with paths.ts if it ever changes.
 export const getEpiqGlobal = (): string =>
+	process.env['EPIQ_GLOBAL_DIR'] ??
 	path.join(os.homedir(), GLOBAL_CONFIG_DIR_NAME);
 
 export const getWorktreesRoot = (): string =>

--- a/source/lib/config/user-config.ts
+++ b/source/lib/config/user-config.ts
@@ -1,7 +1,6 @@
-import os from 'node:os';
 import path from 'node:path';
 import {z} from 'zod';
-import {GLOBAL_CONFIG_DIR_NAME} from '../storage/paths.js';
+import {GLOBAL_CONFIG_DIR_NAME, getGlobalConfigDir} from '../storage/paths.js';
 import {failed, isFail, Result, succeeded} from '../model/result-types.js';
 import {SettingsState} from '../state/settings.state.js';
 import {fileManager} from '../storage/file-manager.js';
@@ -31,8 +30,7 @@ export type EpiqConfig = z.infer<typeof EpiqConfigSchema>;
 
 const CONFIG_FILE_NAME = 'config.json';
 
-export const getEpiqHomePath = (): string =>
-	path.join(os.homedir(), GLOBAL_CONFIG_DIR_NAME);
+export const getEpiqHomePath = getGlobalConfigDir;
 
 export const getEpiqConfigPath = (): string =>
 	path.join(getEpiqHomePath(), CONFIG_FILE_NAME);

--- a/source/lib/storage/global-config-dir.ts
+++ b/source/lib/storage/global-config-dir.ts
@@ -1,0 +1,13 @@
+import os from 'node:os';
+import path from 'node:path';
+
+export const GLOBAL_CONFIG_DIR_NAME = '.epiq-global';
+
+/**
+ * Where Epiq's global state (user config, worktrees) lives. Overridable via
+ * `EPIQ_GLOBAL_DIR` so tests (and other embedders) can isolate it without
+ * touching `HOME`, which git/ssh/npm also rely on.
+ */
+export const getGlobalConfigDir = (): string =>
+	process.env['EPIQ_GLOBAL_DIR'] ??
+	path.join(os.homedir(), GLOBAL_CONFIG_DIR_NAME);

--- a/source/lib/storage/paths.ts
+++ b/source/lib/storage/paths.ts
@@ -1,25 +1,19 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import {failed, isFail, Result, succeeded} from '../model/result-types.js';
 import {getRepoRootDir, getStateBranchRoot} from '../../git/git-storage.js';
 
+export {
+	GLOBAL_CONFIG_DIR_NAME,
+	getGlobalConfigDir,
+} from './global-config-dir.js';
+
 export const isLocal = process.env['IS_LOCAL'] === 'true';
 
 export const EPIQ_DIR_NAME = '.epiq';
-export const GLOBAL_CONFIG_DIR_NAME = '.epiq-global';
 export const EVENTS_DIR_NAME = 'events';
 export const MEDIA_DIR_NAME = 'media';
 export const PROJECT_FILE_NAME = 'project.json';
-
-/**
- * Where Epiq's global state (user config, worktrees) lives. Overridable via
- * `EPIQ_GLOBAL_DIR` so tests (and other embedders) can isolate it without
- * touching `HOME`, which git/ssh/npm also rely on.
- */
-export const getGlobalConfigDir = (): string =>
-	process.env['EPIQ_GLOBAL_DIR'] ??
-	path.join(os.homedir(), GLOBAL_CONFIG_DIR_NAME);
 
 export const getEpiqDirPath = (root: string): string =>
 	path.join(root, EPIQ_DIR_NAME);

--- a/source/lib/storage/paths.ts
+++ b/source/lib/storage/paths.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import {failed, isFail, Result, succeeded} from '../model/result-types.js';
 import {getRepoRootDir, getStateBranchRoot} from '../../git/git-storage.js';
@@ -10,6 +11,15 @@ export const GLOBAL_CONFIG_DIR_NAME = '.epiq-global';
 export const EVENTS_DIR_NAME = 'events';
 export const MEDIA_DIR_NAME = 'media';
 export const PROJECT_FILE_NAME = 'project.json';
+
+/**
+ * Where Epiq's global state (user config, worktrees) lives. Overridable via
+ * `EPIQ_GLOBAL_DIR` so tests (and other embedders) can isolate it without
+ * touching `HOME`, which git/ssh/npm also rely on.
+ */
+export const getGlobalConfigDir = (): string =>
+	process.env['EPIQ_GLOBAL_DIR'] ??
+	path.join(os.homedir(), GLOBAL_CONFIG_DIR_NAME);
 
 export const getEpiqDirPath = (root: string): string =>
 	path.join(root, EPIQ_DIR_NAME);

--- a/source/test/commands.test.ts
+++ b/source/test/commands.test.ts
@@ -25,6 +25,7 @@ vi.mock('../lib/storage/paths.js', () => ({
 			value: '/repo/.epiq',
 		}),
 	),
+	getGlobalConfigDir: vi.fn(() => '/home/test/.epiq-global'),
 }));
 
 vi.mock('../lib/repository/node-repo.js', () => ({

--- a/source/test/e2e/e2e.helper.ts
+++ b/source/test/e2e/e2e.helper.ts
@@ -42,6 +42,24 @@ type TuiSession = {
 	destroy: () => void;
 };
 
+// Isolated per test file (vitest forks/isolates each file into its own
+// process), so all `setupTui()` calls in one file share this global dir, but
+// concurrently-running files never touch each other's real or simulated
+// `~/.epiq-global`. Without this, every e2e process shared the developer's
+// or CI runner's actual `~/.epiq-global`, so parallel files raced on the same
+// global config/worktrees — the likely cause of the flaky ":init" timing and
+// stray "not an epiq project yet" failures under CI load. Deliberately does
+// NOT override HOME itself: git/ssh still need the real `~/.gitconfig` (user
+// identity) to create commits.
+const isolatedGlobalDir = fs.mkdtempSync(
+	path.join(os.tmpdir(), 'epiq-e2e-global-'),
+);
+
+// Set on the worker's own env (not just the spawned TUI child's) so test
+// files that call epiq-api.js functions directly in-process — e.g. to
+// inspect state a TUI session just wrote — see the same isolated global dir.
+process.env['EPIQ_GLOBAL_DIR'] = isolatedGlobalDir;
+
 const createTuiEnv = (extra: Record<string, string> = {}) => {
 	const env = {...process.env};
 


### PR DESCRIPTION
## Summary
CI failed on `feature/82` with `"This folder is not an epiq project yet."` — a flaky e2e failure caused by a real test-isolation bug, not the feature branch's code.

**Root cause:** `e2e.helper.ts`'s spawned TUI processes inherited the real `HOME`, so `~/.epiq-global` (user config, worktrees) was shared across every concurrently-running e2e test file. Locally this sometimes got lucky; under CI's parallelism it reliably raced.

**Fix:** add an `EPIQ_GLOBAL_DIR` override (`paths.ts`, `git-storage.ts`, `user-config.ts`) so Epiq's global state directory can be redirected independently of `HOME`. e2e now points it at a fresh temp dir per test file, instead of overriding `HOME` wholesale (an earlier attempt did that and broke `git commit-tree` — no `.gitconfig` identity in the isolated home).
