### PR TITLE
Filter isDeleted nodes out of MCP list tools

### DIFF
--- a/source/mcp/epiq-api.ts
+++ b/source/mcp/epiq-api.ts
@@ -277,7 +277,7 @@ export const listBoards = async (input: ToolInput = {}) => {
 	if (isFail(stateResult)) return stateResult;
 
 	const boards = Object.values(stateResult.value.nodes)
-		.filter(n => n.context === 'BOARD')
+		.filter(n => n.context === 'BOARD' && !n.isDeleted)
 		.map(n => ({
 			id: n.id,
 			ref: nodeRef(n.id),
@@ -297,7 +297,7 @@ export const listSwimlanes = async (input: ListSwimlanesInput = {}) => {
 	if (isFail(stateResult)) return stateResult;
 
 	const swimlanes = Object.values(stateResult.value.nodes)
-		.filter(n => n.context === 'SWIMLANE')
+		.filter(n => n.context === 'SWIMLANE' && !n.isDeleted)
 		.filter(n => !input.boardId || n.parentNodeId === input.boardId)
 		.map(n => ({
 			id: n.id,
@@ -321,6 +321,7 @@ export const listIssues = async (input: ListIssuesInput) => {
 
 	const issues: ApiIssue[] = Object.values(nodes)
 		.filter(isTicketNode)
+		.filter(n => !n.isDeleted)
 		.filter(n => input.includeClosed || n.parentNodeId !== CLOSED_SWIMLANE_ID)
 		.filter(n => {
 			if (!input.boardId) return true;

--- a/source/mcp/test/epiq-api.test.ts
+++ b/source/mcp/test/epiq-api.test.ts
@@ -202,6 +202,34 @@ const nodes: Record<string, Partial<NavNode<AnyContext>>> = {
 		rank: 'a0',
 		props: {description: '', tags: [], assignees: []},
 	},
+	'deleted-board': {
+		id: 'deleted-board',
+		title: 'Deleted board',
+		context: 'BOARD',
+		parentNodeId: 'workspace-1',
+		readonly: false,
+		isDeleted: true,
+		rank: 'c0',
+	},
+	'deleted-swimlane': {
+		id: 'deleted-swimlane',
+		title: 'Deleted swimlane',
+		context: 'SWIMLANE',
+		parentNodeId: 'board-1',
+		readonly: false,
+		isDeleted: true,
+		rank: 'd0',
+	},
+	'deleted-issue': {
+		id: 'deleted-issue',
+		title: 'Deleted issue',
+		context: 'TICKET',
+		parentNodeId: 'swimlane-1',
+		readonly: false,
+		isDeleted: true,
+		rank: 'e0',
+		props: {description: '', tags: [], assignees: []},
+	},
 };
 
 vi.mock('../../lib/state/state.js', async importOriginal => {
@@ -551,6 +579,30 @@ describe('mcp tools', () => {
 					}),
 				]),
 			);
+		}
+	});
+
+	it('excludes deleted (tombstoned) nodes from boards, swimlanes, and issues', async () => {
+		const boards = await tools.listBoards({repoRoot: '/repo'});
+		const swimlanes = await tools.listSwimlanes({repoRoot: '/repo'});
+		const issues = await tools.listIssues({
+			repoRoot: '/repo',
+			includeClosed: true,
+		});
+
+		expect(isFail(boards)).toBe(false);
+		expect(isFail(swimlanes)).toBe(false);
+		expect(isFail(issues)).toBe(false);
+		if (!isFail(boards)) {
+			expect(boards.value.some(b => b.id === 'deleted-board')).toBe(false);
+		}
+		if (!isFail(swimlanes)) {
+			expect(swimlanes.value.some(s => s.id === 'deleted-swimlane')).toBe(
+				false,
+			);
+		}
+		if (!isFail(issues)) {
+			expect(issues.value.some(i => i.id === 'deleted-issue')).toBe(false);
 		}
 	});
 


### PR DESCRIPTION
## Summary
Found during manual verification of the #79-82 fixes on `main`: `listBoards`/`listSwimlanes`/`listIssues` never checked `isDeleted`, unlike the TUI's real rendering path (`buildChildIndex`). So `epiq_swimlane_delete` (from #81) "succeeds" but the deleted swimlane and its issues kept showing up in list calls.

Fix: add `!n.isDeleted` to the filter chain in all three MCP list functions.

## Test plan
- [x] New regression test with deleted board/swimlane/issue fixtures, asserting they're excluded
- [x] Full unit suite: 253/253
- [x] Full e2e suite (Docker): 7/7
- [x] Manually verified end-to-end against a real built binary: create → rename → move → delete swimlane, atomic issue create, confirmed deleted issue no longer listed