### PR TITLE
Do not collect tests from worktrees inside the repo

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,13 @@
-import {defineConfig} from 'vitest/config';
+import {configDefaults, defineConfig} from 'vitest/config';
 
 export default defineConfig({
 	test: {
 		// Fails a test that aims git at the checkout instead of a temp dir.
 		setupFiles: ['source/test/setup/no-git-outside-tmp.ts'],
+		// Worktrees live under `.claude/worktrees`, and a checkout of a code
+		// branch there carries its own copy of every test. Without this they run
+		// twice, and the e2e ones run on the host rather than in their container.
+		exclude: [...configDefaults.exclude, '.claude/**'],
 		coverage: {
 			provider: 'v8',
 			reporter: ['text-summary', 'html', 'lcov'],


### PR DESCRIPTION
`npm test` was globbing test files inside `.claude/worktrees/*`. A worktree holding a code branch carries its own copy of every test, so they ran twice — and the e2e ones ran **on the host** rather than in their container, which is the same exposure as `AA0F7P`.

The exclude patterns in the npm scripts are relative (`source/test/e2e/**`), so they never matched the nested paths.

Fix: `exclude: [...configDefaults.exclude, '.claude/**']` in `vitest.config.ts`.

Verified rather than assumed: planted a deliberately-failing canary test under `.claude/` and confirmed it does not run. That also proves CLI `--exclude` flags merge with the config exclude rather than replacing it, which the scripts rely on.

Missed originally because I ran every suite from *inside* the worktrees, where no nested copy exists, and CI runs a fresh clone with no worktrees at all — so neither could see it.

591 unit · 11 e2e · 4 collaboration · 43 playwright.