### PR TITLE
NBNR4SF skip repo hooks on epiq's own internal git commit/push

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -115,6 +115,7 @@ epiq gui
 > - Authoritative Git state at `~/.epiq-global/worktrees/<id>`
 > - Updates your `.gitignore` to ignore local-only `.epiq/log/`
 >   Epiq manages a dedicated Git state branch and worktree automatically as the source of truth for synchronization.
+> - A local debug log at `.epiq/log/epiq.log` — check it first if sync, boot, or a Git operation is misbehaving.
 
 ## Usage Guide (TUI)
 

--- a/source/git/git-commands.ts
+++ b/source/git/git-commands.ts
@@ -7,6 +7,12 @@ export const git = {
 	// `pathspec` commits only those paths and ignores the rest of the index.
 	// Without it a commit takes whatever the user happened to have staged, which
 	// in their own repo means committing work that is not ours to commit.
+	//
+	// `--no-verify`: every call here is epiq's own bookkeeping — the state
+	// branch, or `.epiq/project.json` on init — never the user's application
+	// changes, so a repo's pre-commit hook has nothing of ours to check. On the
+	// state branch it is actively wrong: that worktree holds only `.epiq/`, no
+	// package.json, so a hook built for the user's repo fails outright there.
 	commit: ({
 		cwd,
 		message,
@@ -21,6 +27,7 @@ export const git = {
 		execGit({
 			args: [
 				'commit',
+				'--no-verify',
 				...(allowEmpty ? ['--allow-empty'] : []),
 				'-m',
 				message,
@@ -60,6 +67,10 @@ export const git = {
 	checkout: ({cwd, branch}: {cwd: string; branch: string}) =>
 		execGit({args: ['checkout', branch], cwd}),
 
+	// `--no-verify`: same reasoning as `commit` above — this is epiq's own state
+	// branch push, and this repo's pre-push hook (lint/build/test/e2e/gui) has
+	// no business running against that storage-only worktree. It currently
+	// fails there outright, since `npm run` finds no package.json to work with.
 	push: ({
 		cwd,
 		remote,
@@ -73,8 +84,14 @@ export const git = {
 	}) => {
 		const args =
 			remote && branch
-				? ['push', ...(setUpstream ? ['-u'] : []), remote, branch]
-				: ['push'];
+				? [
+						'push',
+						'--no-verify',
+						...(setUpstream ? ['-u'] : []),
+						remote,
+						branch,
+				  ]
+				: ['push', '--no-verify'];
 
 		return execGit({args, cwd});
 	},

--- a/source/test/git-commands.test.ts
+++ b/source/test/git-commands.test.ts
@@ -1,0 +1,113 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {afterEach, describe, expect, it} from 'vitest';
+import {execGit} from '../git/git-utils.js';
+import {git} from '../git/git-commands.js';
+import {isFail} from '../lib/model/result-types.js';
+
+const tempDirs: string[] = [];
+
+const makeTempDir = (): string => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'epiq-git-commands-'));
+	tempDirs.push(dir);
+	return dir;
+};
+
+const configureIdentity = async (repoRoot: string): Promise<void> => {
+	for (const [key, value] of [
+		['user.name', 'Test User'],
+		['user.email', 'test@example.com'],
+	] as const) {
+		const result = await execGit({args: ['config', key, value], cwd: repoRoot});
+		if (isFail(result)) throw new Error(result.message);
+	}
+};
+
+const initRepo = async (repoRoot: string): Promise<void> => {
+	const initResult = await execGit({
+		args: ['init', '-b', 'main'],
+		cwd: repoRoot,
+	});
+	if (isFail(initResult)) throw new Error(initResult.message);
+	await configureIdentity(repoRoot);
+};
+
+// Stands in for a host repo's own hook (lint, tests, whatever) — epiq's
+// bookkeeping commits and pushes are not the user's changes and must not be
+// subject to it. Always rejects, so a passing test proves it never ran.
+const writeRejectingHook = (
+	repoRoot: string,
+	name: 'pre-commit' | 'pre-push',
+): void => {
+	fs.writeFileSync(
+		path.join(repoRoot, '.git', 'hooks', name),
+		'#!/bin/sh\nexit 1\n',
+		{mode: 0o755},
+	);
+};
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) {
+		fs.rmSync(dir, {recursive: true, force: true});
+	}
+});
+
+describe('git.commit', () => {
+	it('bypasses a repo pre-commit hook', async () => {
+		const repoRoot = makeTempDir();
+		await initRepo(repoRoot);
+		writeRejectingHook(repoRoot, 'pre-commit');
+
+		fs.writeFileSync(path.join(repoRoot, 'a.txt'), 'hello\n', 'utf8');
+		const stageResult = await git.stage({cwd: repoRoot, pathspec: ['a.txt']});
+		if (isFail(stageResult)) throw new Error(stageResult.message);
+
+		const commitResult = await git.commit({
+			cwd: repoRoot,
+			message: '[epiq:test]',
+			pathspec: ['a.txt'],
+		});
+
+		expect(isFail(commitResult)).toBe(false);
+	});
+});
+
+describe('git.push', () => {
+	it('bypasses a repo pre-push hook', async () => {
+		const remoteRoot = makeTempDir();
+		const initBareResult = await execGit({
+			args: ['init', '--bare', '-b', 'main'],
+			cwd: remoteRoot,
+		});
+		if (isFail(initBareResult)) throw new Error(initBareResult.message);
+
+		const repoRoot = makeTempDir();
+		const cloneResult = await execGit({
+			args: ['clone', remoteRoot, repoRoot],
+			cwd: remoteRoot,
+		});
+		if (isFail(cloneResult)) throw new Error(cloneResult.message);
+		await configureIdentity(repoRoot);
+
+		fs.writeFileSync(path.join(repoRoot, 'a.txt'), 'hello\n', 'utf8');
+		const addResult = await execGit({args: ['add', 'a.txt'], cwd: repoRoot});
+		if (isFail(addResult)) throw new Error(addResult.message);
+		const commitResult = await execGit({
+			args: ['commit', '-m', 'initial'],
+			cwd: repoRoot,
+		});
+		if (isFail(commitResult)) throw new Error(commitResult.message);
+
+		writeRejectingHook(repoRoot, 'pre-push');
+
+		const pushResult = await git.push({
+			cwd: repoRoot,
+			remote: 'origin',
+			branch: 'main',
+			setUpstream: true,
+		});
+
+		expect(isFail(pushResult)).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary
- `epiq_sync` was never reaching the remote — every state-branch push failed with `npm error Missing script: "lint:err"`.
- Cause: `core.hooksPath` is an absolute path, so it applies to every worktree of this repo, including the internal state-branch storage worktree at `~/.epiq-global/worktrees/<projectId>`. `git.commit`/`git.push` didn't pass `--no-verify`, so this repo's `.husky/pre-push` (lint/build/test/e2e/collab/gui) ran against that worktree, which holds only `.epiq/` — no `package.json` — so `npm run` walked up and found an unrelated `~/package.json` lacking the script, and failed outright.
- Fix: `git.commit`/`git.push` in `source/git/git-commands.ts` are only ever used for epiq's own bookkeeping (state-branch commits/push, `.epiq/project.json` init commit), never the user's application changes, so they now always run with `--no-verify`.
- Also documents `.epiq/log/epiq.log` in the readme as the place to check when sync/boot/git misbehaves — that's how this was diagnosed.

Ref: NBNR4SF

## Test plan
- [x] New `source/test/git-commands.test.ts`: a real rejecting pre-commit/pre-push hook is installed in a temp repo; confirmed red without the fix, green with it.
- [x] `npx vitest run source/test/git-commands.test.ts source/test/git.test.ts source/test/git-utils.test.ts source/test/git-safety.test.ts` — all pass.
- [x] `npx eslint` / `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)