### PR TITLE
CN20VH0 stop the gate failing on other worktrees and on terminal colour

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+# Worktrees are checked out inside the repo, so the format check would other-
+# wise scan another branch's working copy and fail on code that is not ours.
+.claude/

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,10 @@ export default defineConfig({
 		// branch there carries its own copy of every test. Without this they run
 		// twice, and the e2e ones run on the host rather than in their container.
 		exclude: [...configDefaults.exclude, '.claude/**'],
+		// Assertions compare rendered strings, so chalk must not decide on its
+		// own whether to add escape codes. Terminals that export FORCE_COLOR
+		// otherwise fail the suite that a plain shell passes.
+		env: {FORCE_COLOR: '0'},
 		coverage: {
 			provider: 'v8',
 			reporter: ['text-summary', 'html', 'lcov'],


### PR DESCRIPTION
Two ways the push gate failed on work that was fine. Both make the suite depend on the developer's machine rather than on the branch under test.

## The format check walked into other people's worktrees

`npm test` starts with `prettier --check "**/*.{ts,tsx}"`, and that glob descends into `.claude/worktrees/`. Worktrees are checked out inside the repo, so the check was reading another session's working copy and failing on its unformatted work in progress:

```
[warn] .claude/worktrees/commit-ref-prefix-tool/source/gui/client/App.tsx
[warn] Code style issues found in the above file.
```

Same hole #107 closed for vitest, which added `.claude/**` to the exclude list. Prettier was missed, and there was no `.prettierignore` in the repo at all — so this adds one containing `.claude/`.

Worth recording: prettier resolves ignore patterns relative to **the ignore file's own directory**. Passing `--ignore-path` a file outside the repo silently matches nothing, which is a confusing way to spend ten minutes.

## The suite failed in terminals that export FORCE_COLOR

`command-validation.test.ts` compares rendered strings to plain text, but chalk decides on its own whether to emit escape codes. Ghostty and the Claude Code harness both export `FORCE_COLOR=3`, and under it 11 tests fail:

```
expected '[2m<ENTER> to confirm[22m' to be '<ENTER> to confirm'
```

The same commit passes in a plain shell. So the gate was rejecting good pushes based on which terminal you happened to be in — and any Claude Code session pushing from this repo hit it.

`env: {FORCE_COLOR: '0'}` in `vitest.config.ts` settles it, so assertions no longer depend on ambient colour detection.

**This one is pre-existing, and I had been masking it.** It reproduces at `cd2946f0`, before #108 and before #109. My timing runs used `FORCE_COLOR=0` on the command line, which is exactly what hides it — so when #109 reported "591 tests pass", that was true under `FORCE_COLOR=0` and would not have been true in a bare terminal of this session. Worth knowing when reading that PR's numbers.

## Verification

Pushed for real, with `FORCE_COLOR=3` still set in the environment — the precise condition that was failing. The full gate passed: 593 unit, 11 e2e, 4 collaboration, 43 playwright.

Before the fix, the same push failed with 11 tests red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
