### PR TITLE
Inline commit diffs: scrubber dot click and a ticket's Code tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
 	"name": "epiq",
-	"version": "1.3.5",
+	"version": "1.5.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "epiq",
-			"version": "1.3.5",
+			"version": "1.5.0",
 			"license": "MIT",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.29.0",
+				"@pierre/diffs": "^1.3.6",
 				"@xterm/headless": "^6.0.0",
 				"ink": "^6.8.0",
 				"meow": "^14.1.0",
@@ -1273,6 +1274,73 @@
 				"url": "https://github.com/sponsors/Boshen"
 			}
 		},
+		"node_modules/@pierre/diffs": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/@pierre/diffs/-/diffs-1.3.6.tgz",
+			"integrity": "sha512-a3woaW2QHy78JDxPJK0OJzwZUN4xoQLLIS/pceO8X6+L8gA5D682mP7/w3YxxEVRPXOaoe/p/RJ5Oj/3nrEzew==",
+			"license": "apache-2.0",
+			"dependencies": {
+				"@pierre/theme": "2.0.0",
+				"@pierre/theming": "1.0.1",
+				"@shikijs/transformers": "^3.0.0 || ^4.0.0",
+				"diff": "9.0.0",
+				"hast-util-to-html": "9.0.5",
+				"lru_map": "0.4.1",
+				"shiki": "^3.0.0 || ^4.0.0"
+			},
+			"peerDependencies": {
+				"react": "^18.3.1 || ^19.0.0",
+				"react-dom": "^18.3.1 || ^19.0.0"
+			}
+		},
+		"node_modules/@pierre/diffs/node_modules/diff": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+			"integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/@pierre/theme": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@pierre/theme/-/theme-2.0.0.tgz",
+			"integrity": "sha512-yNDd9GYLQl1mEUJR8AneJ5e4ohLIHQd/wZLWr4fagt78vS2RwwZNW530vVgHqXFAyFVcFlRmGUD5ramXH46OXw==",
+			"license": "apache-2.0",
+			"engines": {
+				"vscode": "^1.0.0"
+			}
+		},
+		"node_modules/@pierre/theming": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@pierre/theming/-/theming-1.0.1.tgz",
+			"integrity": "sha512-WCI5Qd7iprDpISL9fBYOLe8RV53+b7mFNA3bPzl60/2CKCSrsKN8zEcep6Y3BAzvARlmca50zGjDodqPGiTUKA==",
+			"license": "apache-2.0",
+			"peerDependencies": {
+				"@pierre/theme": "^1.1.0 || ^2.0.0",
+				"@shikijs/themes": "^3.0.0 || ^4.0.0",
+				"react": "^18.3.1 || ^19.0.0",
+				"react-dom": "^18.3.1 || ^19.0.0",
+				"shiki": "^3.0.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@pierre/theme": {
+					"optional": true
+				},
+				"@shikijs/themes": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				},
+				"react-dom": {
+					"optional": true
+				},
+				"shiki": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@playwright/test": {
 			"version": "1.62.1",
 			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
@@ -1551,6 +1619,119 @@
 			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
 			"integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@shikijs/core": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.4.3.tgz",
+			"integrity": "sha512-QCR4q2ZO/ILJEuwiBMel4wdcTDb1JGwfjKTxPDF6x8ixOaluPrVqIn06C99AcRPhmYlBR56d/Fb+GN58GzExpg==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/primitive": "4.4.3",
+				"@shikijs/types": "4.4.3",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.5",
+				"hast-util-to-html": "^9.0.5"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@shikijs/engine-javascript": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.4.3.tgz",
+			"integrity": "sha512-FbOjFJp9VLdo1Wevs10BBtVxiTWwNLqZh5Gkhjgda/ioL15YOgeSl9n+6XMa3qRlPQzfhFNe641SrynFHYG0nQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "4.4.3",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"oniguruma-to-es": "^4.3.6"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@shikijs/engine-oniguruma": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.4.3.tgz",
+			"integrity": "sha512-EcOQkxdxGQrc1Row/cC2c96/v1dbZqGnEVu1qTuT/MJmp6+cXCvQussowVmCv5Tqr3KuY3c7IbM6HTW3LJ1k9w==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "4.4.3",
+				"@shikijs/vscode-textmate": "^10.0.2"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@shikijs/langs": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.4.3.tgz",
+			"integrity": "sha512-ePic0yfAJGOF83D5wBHK/00EjK65oahBYxFk5epgq33WRv7X9UuxLEV8PtR0szC0z8dl7INIpIodB99JRFlR+A==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "4.4.3"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@shikijs/primitive": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.4.3.tgz",
+			"integrity": "sha512-m0wBeLDQDeIxRdUmrCPdQqfuUamDwRL5isCfYbguKD6NiaKpVbsv+3J81DyIKgNW5h4WAIIr8T4EkgQrBBxvaQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "4.4.3",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.5"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@shikijs/themes": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.4.3.tgz",
+			"integrity": "sha512-w8UHjeUnIR965KMWJHUPXOc2mNJUnK3vpVLYLvw5IYU2mnTTJ89E24OrJDBNiJDQ0qzb0tc4l7mrIXx5cFeIyw==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "4.4.3"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@shikijs/transformers": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-4.4.3.tgz",
+			"integrity": "sha512-oJSARV6NaWd+rnNJbtnpAdj3Zg0ZVyzsnMgb3vi3HA+35y8lBWUCpOnWsmyiXZIikY+x1BDqrQUgmxfzWh7Jvw==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/core": "4.4.3",
+				"@shikijs/types": "4.4.3"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@shikijs/types": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.4.3.tgz",
+			"integrity": "sha512-UEJxmRR++MAGR6hugn0vgVS2W/6lWAts84FFSrnlH9sP0LNol7E5+NQ792pH8liWUhyMyjhTgSUH3k7iD7tc5g==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.5"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/@shikijs/vscode-textmate": {
+			"version": "10.0.2",
+			"resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+			"integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
 			"license": "MIT"
 		},
 		"node_modules/@sindresorhus/tsconfig": {
@@ -4363,6 +4544,29 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/hast-util-to-html": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+			"integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/hast": "^3.0.0",
+				"@types/unist": "^3.0.0",
+				"ccount": "^2.0.0",
+				"comma-separated-tokens": "^2.0.0",
+				"hast-util-whitespace": "^3.0.0",
+				"html-void-elements": "^3.0.0",
+				"mdast-util-to-hast": "^13.0.0",
+				"property-information": "^7.0.0",
+				"space-separated-tokens": "^2.0.0",
+				"stringify-entities": "^4.0.0",
+				"zwitch": "^2.0.4"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/hast-util-to-jsx-runtime": {
 			"version": "2.3.6",
 			"resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -4444,6 +4648,16 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/html-void-elements": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+			"integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/http-errors": {
@@ -5618,6 +5832,12 @@
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lru_map": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.4.1.tgz",
+			"integrity": "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==",
 			"license": "MIT"
 		},
 		"node_modules/lru-cache": {
@@ -6900,6 +7120,23 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/oniguruma-parser": {
+			"version": "0.12.2",
+			"resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+			"integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+			"license": "MIT"
+		},
+		"node_modules/oniguruma-to-es": {
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+			"integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+			"license": "MIT",
+			"dependencies": {
+				"oniguruma-parser": "^0.12.2",
+				"regex": "^6.1.0",
+				"regex-recursion": "^6.0.2"
+			}
+		},
 		"node_modules/optionator": {
 			"version": "0.9.4",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -7436,6 +7673,30 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/regex": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+			"integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+			"license": "MIT",
+			"dependencies": {
+				"regex-utilities": "^2.3.0"
+			}
+		},
+		"node_modules/regex-recursion": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+			"integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+			"license": "MIT",
+			"dependencies": {
+				"regex-utilities": "^2.3.0"
+			}
+		},
+		"node_modules/regex-utilities": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+			"integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+			"license": "MIT"
+		},
 		"node_modules/regexp.prototype.flags": {
 			"version": "1.5.4",
 			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -7852,6 +8113,25 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/shiki": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/shiki/-/shiki-4.4.3.tgz",
+			"integrity": "sha512-Mb/GvXPHBAXdgGIcnfU5L3ldpn1XcxrGkPHwqgRx17/I2XRfqlFKk2vGkHWINn1kdXvzJZeuO3is6I9KLPFm0g==",
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/core": "4.4.3",
+				"@shikijs/engine-javascript": "4.4.3",
+				"@shikijs/engine-oniguruma": "4.4.3",
+				"@shikijs/langs": "4.4.3",
+				"@shikijs/themes": "4.4.3",
+				"@shikijs/types": "4.4.3",
+				"@shikijs/vscode-textmate": "^10.0.2",
+				"@types/hast": "^3.0.5"
+			},
+			"engines": {
+				"node": ">=20"
 			}
 		},
 		"node_modules/side-channel": {
@@ -9371,474 +9651,6 @@
 				}
 			}
 		},
-		"node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
-			"integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"aix"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/android-arm": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
-			"integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/android-arm64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
-			"integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/android-x64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
-			"integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
-			"integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/darwin-x64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
-			"integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
-			"integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
-			"integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/linux-arm": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
-			"integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/linux-arm64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
-			"integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/linux-ia32": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
-			"integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/linux-loong64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
-			"integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
-			"cpu": [
-				"loong64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
-			"integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
-			"cpu": [
-				"mips64el"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
-			"integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
-			"integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/linux-s390x": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
-			"integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/linux-x64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
-			"integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
-			"integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
-			"integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
-			"integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
-			"integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
-			"integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openharmony"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/sunos-x64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
-			"integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"sunos"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/win32-arm64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
-			"integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/win32-ia32": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
-			"integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vitest/node_modules/@esbuild/win32-x64": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
-			"integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/vitest/node_modules/@vitest/mocker": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
@@ -9864,50 +9676,6 @@
 				"vite": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/vitest/node_modules/esbuild": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
-			"integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"esbuild": "bin/esbuild"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.28.2",
-				"@esbuild/android-arm": "0.28.2",
-				"@esbuild/android-arm64": "0.28.2",
-				"@esbuild/android-x64": "0.28.2",
-				"@esbuild/darwin-arm64": "0.28.2",
-				"@esbuild/darwin-x64": "0.28.2",
-				"@esbuild/freebsd-arm64": "0.28.2",
-				"@esbuild/freebsd-x64": "0.28.2",
-				"@esbuild/linux-arm": "0.28.2",
-				"@esbuild/linux-arm64": "0.28.2",
-				"@esbuild/linux-ia32": "0.28.2",
-				"@esbuild/linux-loong64": "0.28.2",
-				"@esbuild/linux-mips64el": "0.28.2",
-				"@esbuild/linux-ppc64": "0.28.2",
-				"@esbuild/linux-riscv64": "0.28.2",
-				"@esbuild/linux-s390x": "0.28.2",
-				"@esbuild/linux-x64": "0.28.2",
-				"@esbuild/netbsd-arm64": "0.28.2",
-				"@esbuild/netbsd-x64": "0.28.2",
-				"@esbuild/openbsd-arm64": "0.28.2",
-				"@esbuild/openbsd-x64": "0.28.2",
-				"@esbuild/openharmony-arm64": "0.28.2",
-				"@esbuild/sunos-x64": "0.28.2",
-				"@esbuild/win32-arm64": "0.28.2",
-				"@esbuild/win32-ia32": "0.28.2",
-				"@esbuild/win32-x64": "0.28.2"
 			}
 		},
 		"node_modules/vitest/node_modules/vite": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9651,6 +9651,474 @@
 				}
 			}
 		},
+		"node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+			"integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/android-arm": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+			"integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/android-arm64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+			"integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/android-x64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+			"integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+			"integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+			"integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+			"integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+			"integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/linux-arm": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+			"integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+			"integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+			"integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+			"integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+			"integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+			"integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+			"integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+			"integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/linux-x64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+			"integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+			"integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+			"integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+			"integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+			"integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+			"integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+			"integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+			"integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+			"integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/win32-x64": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+			"integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/vitest/node_modules/@vitest/mocker": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
@@ -9676,6 +10144,50 @@
 				"vite": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/vitest/node_modules/esbuild": {
+			"version": "0.28.2",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+			"integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.28.2",
+				"@esbuild/android-arm": "0.28.2",
+				"@esbuild/android-arm64": "0.28.2",
+				"@esbuild/android-x64": "0.28.2",
+				"@esbuild/darwin-arm64": "0.28.2",
+				"@esbuild/darwin-x64": "0.28.2",
+				"@esbuild/freebsd-arm64": "0.28.2",
+				"@esbuild/freebsd-x64": "0.28.2",
+				"@esbuild/linux-arm": "0.28.2",
+				"@esbuild/linux-arm64": "0.28.2",
+				"@esbuild/linux-ia32": "0.28.2",
+				"@esbuild/linux-loong64": "0.28.2",
+				"@esbuild/linux-mips64el": "0.28.2",
+				"@esbuild/linux-ppc64": "0.28.2",
+				"@esbuild/linux-riscv64": "0.28.2",
+				"@esbuild/linux-s390x": "0.28.2",
+				"@esbuild/linux-x64": "0.28.2",
+				"@esbuild/netbsd-arm64": "0.28.2",
+				"@esbuild/netbsd-x64": "0.28.2",
+				"@esbuild/openbsd-arm64": "0.28.2",
+				"@esbuild/openbsd-x64": "0.28.2",
+				"@esbuild/openharmony-arm64": "0.28.2",
+				"@esbuild/sunos-x64": "0.28.2",
+				"@esbuild/win32-arm64": "0.28.2",
+				"@esbuild/win32-ia32": "0.28.2",
+				"@esbuild/win32-x64": "0.28.2"
 			}
 		},
 		"node_modules/vitest/node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
 	],
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "^1.29.0",
+		"@pierre/diffs": "^1.3.6",
 		"@xterm/headless": "^6.0.0",
 		"ink": "^6.8.0",
 		"meow": "^14.1.0",

--- a/source/gui/api/lib/websocket.model.ts
+++ b/source/gui/api/lib/websocket.model.ts
@@ -80,4 +80,5 @@ export type GuiMessage =
 			// No boardId: commits are repository-wide.
 			payload?: {start?: number; end?: number; requestId?: number};
 	  }
-	| {type: 'commit:inspect'; payload: {sha: string}};
+	| {type: 'commit:inspect'; payload: {sha: string}}
+	| {type: 'commit:diff:get'; payload: {sha: string}};

--- a/source/gui/api/lib/websocket.model.ts
+++ b/source/gui/api/lib/websocket.model.ts
@@ -81,4 +81,5 @@ export type GuiMessage =
 			payload?: {start?: number; end?: number; requestId?: number};
 	  }
 	| {type: 'commit:inspect'; payload: {sha: string}}
-	| {type: 'commit:diff:get'; payload: {sha: string}};
+	| {type: 'commit:diff:get'; payload: {sha: string}}
+	| {type: 'issue:commits:get'; payload: {issueId: string}};

--- a/source/gui/api/lib/websocket.ts
+++ b/source/gui/api/lib/websocket.ts
@@ -201,12 +201,21 @@ export const setupWebsocket = (
 				}
 
 				if (type === 'issue:commits:get') {
+					const {issueId} = message.payload;
+
+					// Wrapped with the issueId for the same reason commit:diff:result is:
+					// switching tickets while the Code tab stays open can leave an older
+					// ticket's request in flight, and the client needs to tell whose
+					// reply this is before applying it.
 					return sendSocket(socket, {
 						type: 'issue:commits:result',
-						payload: await getCommitsForRef({
-							repoRoot,
-							ref: nodeRef(message.payload.issueId),
-						}),
+						payload: {
+							issueId,
+							result: await getCommitsForRef({
+								repoRoot,
+								ref: nodeRef(issueId),
+							}),
+						},
 					});
 				}
 

--- a/source/gui/api/lib/websocket.ts
+++ b/source/gui/api/lib/websocket.ts
@@ -188,12 +188,15 @@ export const setupWebsocket = (
 				}
 
 				if (type === 'commit:diff:get') {
+					const {sha} = message.payload;
+
+					// Wrapped with the sha rather than sending the Result bare: two
+					// surfaces can each have a diff request in flight for a different
+					// commit (the scrubber's dot and the ticket tab's commit list), and
+					// a failed Result carries no sha of its own to tell them apart.
 					return sendSocket(socket, {
 						type: 'commit:diff:result',
-						payload: await getCommitDiff({
-							repoRoot,
-							sha: message.payload.sha,
-						}),
+						payload: {sha, result: await getCommitDiff({repoRoot, sha})},
 					});
 				}
 

--- a/source/gui/api/lib/websocket.ts
+++ b/source/gui/api/lib/websocket.ts
@@ -28,6 +28,7 @@ import {
 import {
 	checkoutStateAt,
 	getCommitDiff,
+	getCommitsForRef,
 	getCommitTimeline,
 	getEventTimeline,
 	getTimeTravelStatus,
@@ -37,6 +38,7 @@ import {
 } from '../../../mcp/epiq-time-travel.js';
 import {isFail, Result, succeeded} from '../../../lib/model/result-types.js';
 import {NO_PROJECT_MESSAGE} from '../../../lib/storage/paths.js';
+import {nodeRef} from '../../../lib/utils/node-ref.js';
 import {
 	broadcastGuiMessage,
 	registerGuiSocket,
@@ -191,6 +193,16 @@ export const setupWebsocket = (
 						payload: await getCommitDiff({
 							repoRoot,
 							sha: message.payload.sha,
+						}),
+					});
+				}
+
+				if (type === 'issue:commits:get') {
+					return sendSocket(socket, {
+						type: 'issue:commits:result',
+						payload: await getCommitsForRef({
+							repoRoot,
+							ref: nodeRef(message.payload.issueId),
 						}),
 					});
 				}

--- a/source/gui/api/lib/websocket.ts
+++ b/source/gui/api/lib/websocket.ts
@@ -27,6 +27,7 @@ import {
 } from '../../../mcp/epiq-api.js';
 import {
 	checkoutStateAt,
+	getCommitDiff,
 	getCommitTimeline,
 	getEventTimeline,
 	getTimeTravelStatus,
@@ -178,6 +179,16 @@ export const setupWebsocket = (
 					return sendSocket(socket, {
 						type: 'commit:inspect:result',
 						payload: await openCommitDiffInEditor({
+							repoRoot,
+							sha: message.payload.sha,
+						}),
+					});
+				}
+
+				if (type === 'commit:diff:get') {
+					return sendSocket(socket, {
+						type: 'commit:diff:result',
+						payload: await getCommitDiff({
 							repoRoot,
 							sha: message.payload.sha,
 						}),

--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -5,11 +5,12 @@ import {
 	useParams,
 	useSearchParams,
 } from 'react-router-dom';
-import {ASIDE_WIDTH} from './components/Aside';
+import {ASIDE_DIFF_WIDTH, ASIDE_WIDTH, Aside} from './components/Aside';
 import {Button} from './components/Button';
 import {CreateNodeModal} from './components/CreateNodeModal';
 import {AddSwimlaneColumn} from './components/AddSwimlaneColumn';
 import {ConfirmModal} from './components/ConfirmModal';
+import {DiffPanel} from './components/DiffPanel';
 import {InitProjectScreen} from './components/InitProjectScreen';
 import {Dropdown} from './components/Dropdown';
 import {Header} from './components/Header';
@@ -33,6 +34,8 @@ import {
 } from './lib/gui-state-helper';
 import {
 	GuiComment,
+	GuiCommitDiff,
+	GuiCommitDiffFile,
 	GuiIssue,
 	GuiIssueHistoryEntry,
 	GuiCommitEntry,
@@ -115,9 +118,12 @@ export const App = () => {
 		commits: GuiCommitEntry[];
 	}>({requestId: 0, timeline: null, commits: []});
 	const [historyBuffer] = useState(() => createHistoryBuffer(setHistory));
-	const [commitInspectError, setCommitInspectError] = useState<string | null>(
-		null,
-	);
+	const [commitDiff, setCommitDiff] = useState<{
+		sha: string;
+		loading: boolean;
+		error: string | null;
+		files: GuiCommitDiffFile[] | null;
+	} | null>(null);
 	const [removeError, setRemoveError] = useState<string | null>(null);
 	const [actionError, setActionError] = useState<string | null>(null);
 	const [dragOverSwimlaneId, setDragOverSwimlaneId] = useState<string | null>(
@@ -432,11 +438,23 @@ export const App = () => {
 				}
 			}
 
-			if (
-				message.type === 'commit:inspect:result' &&
-				message.payload?.status === 'fail'
-			) {
-				setCommitInspectError(message.payload.message);
+			if (message.type === 'commit:diff:result') {
+				if (message.payload?.status === 'fail') {
+					setCommitDiff(prev =>
+						prev ? {...prev, loading: false, error: message.payload.message} : prev,
+					);
+				} else {
+					const diff = getResultValue<GuiCommitDiff>(message.payload);
+					// Ignores a reply for a sha that is no longer the one showing —
+					// a fast second click can leave an earlier request in flight.
+					if (diff) {
+						setCommitDiff(prev =>
+							prev && prev.sha === diff.sha
+								? {...prev, loading: false, error: null, files: diff.files}
+								: prev,
+						);
+					}
+				}
 			}
 
 			if (
@@ -769,16 +787,12 @@ export const App = () => {
 		setPickedIssueIds([]);
 	}, [selectedBoardId]);
 
-	const inspectCommit = useCallback((sha: string) => {
-		sendSocketJson(socketRef.current, {type: 'commit:inspect', payload: {sha}});
+	const openCommitDiff = useCallback((sha: string) => {
+		setCommitDiff({sha, loading: true, error: null, files: null});
+		sendSocketJson(socketRef.current, {type: 'commit:diff:get', payload: {sha}});
 	}, []);
 
-	useEffect(() => {
-		if (!commitInspectError) return;
-
-		const timeout = setTimeout(() => setCommitInspectError(null), 8000);
-		return () => clearTimeout(timeout);
-	}, [commitInspectError]);
+	const closeCommitDiff = useCallback(() => setCommitDiff(null), []);
 
 	useEffect(() => {
 		if (!removeError) return;
@@ -1102,13 +1116,6 @@ export const App = () => {
 		>
 			<GlobalScrollbarStyles />
 
-			{commitInspectError && (
-				<ErrorToast
-					message={`Couldn't open commit diff: ${commitInspectError}`}
-					onDismiss={() => setCommitInspectError(null)}
-				/>
-			)}
-
 			{removeError && (
 				<ErrorToast
 					message={removeError}
@@ -1147,7 +1154,7 @@ export const App = () => {
 				connected={connected}
 				socketEpoch={socketEpoch}
 				onRequestHistory={requestBoardHistory}
-				onInspectCommit={inspectCommit}
+				onInspectCommit={openCommitDiff}
 				highlightEventId={hoveredLogEventId}
 				timeTravel={state?.timeTravel ?? {mode: 'live', asOfTime: null}}
 				onScrub={scrubToTime}
@@ -1283,7 +1290,7 @@ export const App = () => {
 							in clientWidth, keeping max scrollLeft identical across
 							open/closed so the board doesn't bounce back when scrolled
 							far right. */}
-						{!(selectedIssue && state?.user) && (
+						{!commitDiff && !(selectedIssue && state?.user) && (
 							<div style={{width: ASIDE_WIDTH, flexShrink: 0}} />
 						)}
 
@@ -1293,7 +1300,19 @@ export const App = () => {
 					</div>
 				</main>
 
-				{pickedIssues.length > 1 && (
+				{commitDiff && (
+					<Aside width={ASIDE_DIFF_WIDTH}>
+						<DiffPanel
+							title={`Commit ${commitDiff.sha.slice(0, 7)}`}
+							files={commitDiff.files}
+							loading={commitDiff.loading}
+							error={commitDiff.error}
+							onClose={closeCommitDiff}
+						/>
+					</Aside>
+				)}
+
+				{!commitDiff && pickedIssues.length > 1 && (
 					<BulkDetails
 						issues={pickedIssues}
 						knownTags={state?.tags ?? []}
@@ -1331,7 +1350,7 @@ export const App = () => {
 					/>
 				)}
 
-				{pickedIssues.length <= 1 && selectedIssue && state?.user && (
+				{!commitDiff && pickedIssues.length <= 1 && selectedIssue && state?.user && (
 					<IssueDetails
 						whoAmI={state.user}
 						issue={((): GuiIssue => {

--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -53,7 +53,7 @@ import {AttachmentUploadStatus} from './components/IssueAttachments';
 import {SyncStatus} from './lib/gui-sync-statusmodel';
 import {GUI_THEME} from './lib/gui-theme';
 
-type IssueDetailsTab = 'overview' | 'comments' | 'history';
+type IssueDetailsTab = 'overview' | 'comments' | 'history' | 'code';
 
 // Module scope so an absent state does not hand the memos below a new object
 // on every render.
@@ -124,6 +124,28 @@ export const App = () => {
 		error: string | null;
 		files: GuiCommitDiffFile[] | null;
 	} | null>(null);
+	// The ticket detail Code tab's commit list. Reset per selected issue, like
+	// issueDetail below — refetched fresh each time the tab opens rather than
+	// cached, since a full ref-prefix log scan is cheap next to the round trip.
+	const [issueCommits, setIssueCommits] = useState<{
+		issueId: string;
+		loading: boolean;
+		error: string | null;
+		commits: GuiCommitEntry[];
+	} | null>(null);
+	// Per-commit diffs for whichever commits are expanded in the Code tab.
+	// Keyed by sha rather than nested under issueCommits so an expanded commit
+	// survives a commits-list refetch (e.g. re-opening the tab).
+	const [issueCommitDiffs, setIssueCommitDiffs] = useState<
+		Record<
+			string,
+			{
+				loading: boolean;
+				error: string | null;
+				files: GuiCommitDiffFile[] | null;
+			}
+		>
+	>({});
 	const [removeError, setRemoveError] = useState<string | null>(null);
 	const [actionError, setActionError] = useState<string | null>(null);
 	const [dragOverSwimlaneId, setDragOverSwimlaneId] = useState<string | null>(
@@ -178,7 +200,9 @@ export const App = () => {
 
 	const tabParam = searchParams.get('tab');
 	const selectedTab: IssueDetailsTab =
-		tabParam === 'comments' || tabParam === 'history' ? tabParam : 'overview';
+		tabParam === 'comments' || tabParam === 'history' || tabParam === 'code'
+			? tabParam
+			: 'overview';
 	const navigate = useNavigate();
 
 	// Route params carry shorthand refs (full ids in old links still resolve).
@@ -293,6 +317,40 @@ export const App = () => {
 			payload: {issueId: selectedIssue.id},
 		});
 	}, [selectedIssue?.id, state]);
+
+	// Fetched lazily on entering the Code tab rather than alongside issue:get
+	// above: a full ref-prefix log scan on every ticket selection would be
+	// wasted on the common case where nobody opens the tab.
+	useEffect(() => {
+		setIssueCommitDiffs({});
+
+		if (!selectedIssue || selectedTab !== 'code') {
+			setIssueCommits(null);
+			return;
+		}
+
+		setIssueCommits({
+			issueId: selectedIssue.id,
+			loading: true,
+			error: null,
+			commits: [],
+		});
+		sendSocketJson(socketRef.current, {
+			type: 'issue:commits:get',
+			payload: {issueId: selectedIssue.id},
+		});
+	}, [selectedIssue?.id, selectedTab]);
+
+	const loadIssueCommitDiff = useCallback((sha: string) => {
+		setIssueCommitDiffs(prev => ({
+			...prev,
+			[sha]: {loading: true, error: null, files: null},
+		}));
+		sendSocketJson(socketRef.current, {
+			type: 'commit:diff:get',
+			payload: {sha},
+		});
+	}, []);
 
 	const requestState = () => {
 		sendSocketJson(socketRef.current, {type: 'state:get'});
@@ -439,19 +497,67 @@ export const App = () => {
 			}
 
 			if (message.type === 'commit:diff:result') {
-				if (message.payload?.status === 'fail') {
+				// Wrapped with the sha it was requested for: the scrubber's dot and
+				// the ticket tab's commit list can each have a different commit's
+				// diff in flight at once, and a failed Result alone carries no sha
+				// to attribute the failure to.
+				const {sha, result} = message.payload as {
+					sha: string;
+					result: {status: string; message: string; value?: GuiCommitDiff};
+				};
+
+				if (result?.status === 'fail') {
+					// Ignores a reply for a sha no longer showing — a fast second click
+					// can leave an earlier request in flight.
 					setCommitDiff(prev =>
-						prev ? {...prev, loading: false, error: message.payload.message} : prev,
+						prev && prev.sha === sha
+							? {...prev, loading: false, error: result.message}
+							: prev,
+					);
+					setIssueCommitDiffs(prev =>
+						prev[sha]
+							? {
+									...prev,
+									[sha]: {loading: false, error: result.message, files: null},
+							  }
+							: prev,
 					);
 				} else {
-					const diff = getResultValue<GuiCommitDiff>(message.payload);
-					// Ignores a reply for a sha that is no longer the one showing —
-					// a fast second click can leave an earlier request in flight.
+					const diff = getResultValue<GuiCommitDiff>(result);
 					if (diff) {
 						setCommitDiff(prev =>
 							prev && prev.sha === diff.sha
 								? {...prev, loading: false, error: null, files: diff.files}
 								: prev,
+						);
+						setIssueCommitDiffs(prev =>
+							prev[diff.sha]
+								? {
+										...prev,
+										[diff.sha]: {
+											loading: false,
+											error: null,
+											files: diff.files,
+										},
+								  }
+								: prev,
+						);
+					}
+				}
+			}
+
+			if (message.type === 'issue:commits:result') {
+				if (message.payload?.status === 'fail') {
+					setIssueCommits(prev =>
+						prev
+							? {...prev, loading: false, error: message.payload.message}
+							: prev,
+					);
+				} else {
+					const commits = getResultValue<GuiCommitEntry[]>(message.payload);
+					if (commits) {
+						setIssueCommits(prev =>
+							prev ? {...prev, loading: false, error: null, commits} : prev,
 						);
 					}
 				}
@@ -789,7 +895,10 @@ export const App = () => {
 
 	const openCommitDiff = useCallback((sha: string) => {
 		setCommitDiff({sha, loading: true, error: null, files: null});
-		sendSocketJson(socketRef.current, {type: 'commit:diff:get', payload: {sha}});
+		sendSocketJson(socketRef.current, {
+			type: 'commit:diff:get',
+			payload: {sha},
+		});
 	}, []);
 
 	const closeCommitDiff = useCallback(() => setCommitDiff(null), []);
@@ -1350,52 +1459,72 @@ export const App = () => {
 					/>
 				)}
 
-				{!commitDiff && pickedIssues.length <= 1 && selectedIssue && state?.user && (
-					<IssueDetails
-						whoAmI={state.user}
-						issue={((): GuiIssue => {
-							const base =
-								issueDetail?.issueId === selectedIssue.id
-									? {...selectedIssue, description: issueDetail.description}
-									: selectedIssue;
+				{!commitDiff &&
+					pickedIssues.length <= 1 &&
+					selectedIssue &&
+					state?.user && (
+						<IssueDetails
+							whoAmI={state.user}
+							issue={((): GuiIssue => {
+								const base =
+									issueDetail?.issueId === selectedIssue.id
+										? {...selectedIssue, description: issueDetail.description}
+										: selectedIssue;
 
-							return offline ? {...base, readonly: true} : base;
-						})()}
-						activeTab={selectedTab}
-						comments={
-							issueDetail?.issueId === selectedIssue.id
-								? issueDetail.comments
-								: []
-						}
-						history={
-							issueDetail?.issueId === selectedIssue.id
-								? issueDetail.history
-								: []
-						}
-						onHoverHistoryEvent={setHoveredLogEventId}
-						onChangeTab={changeIssueDetailsTab}
-						onClose={closeIssueDetails}
-						onEditTitle={editIssueTitle}
-						onEditDescription={editIssueDescription}
-						onAddTag={addIssueTag}
-						onRemoveTag={removeIssueTag}
-						onAddAssignee={addIssueAssignee}
-						onAddExternalAssignee={addExternalIssueAssignee}
-						onRemoveContributor={removeContributor}
-						onRemoveAssignee={removeIssueAssignee}
-						onAddComment={addIssueComment}
-						onDeleteComment={deleteIssueComment}
-						attachments={attachmentsByIssueId[selectedIssue.id] ?? []}
-						attachmentUploadStatus={attachmentUploadStatus}
-						onUploadAttachments={uploadIssueAttachments}
-						onDeleteAttachment={deleteIssueAttachment}
-						onReopenIssue={reopenIssue}
-						onCloseIssue={closeIssue}
-						knownTags={state.tags ?? []}
-						knownAssignees={contributors}
-						onOpenAssigneePicker={requestContributors}
-					/>
-				)}
+								return offline ? {...base, readonly: true} : base;
+							})()}
+							activeTab={selectedTab}
+							comments={
+								issueDetail?.issueId === selectedIssue.id
+									? issueDetail.comments
+									: []
+							}
+							history={
+								issueDetail?.issueId === selectedIssue.id
+									? issueDetail.history
+									: []
+							}
+							onHoverHistoryEvent={setHoveredLogEventId}
+							onChangeTab={changeIssueDetailsTab}
+							onClose={closeIssueDetails}
+							onEditTitle={editIssueTitle}
+							onEditDescription={editIssueDescription}
+							onAddTag={addIssueTag}
+							onRemoveTag={removeIssueTag}
+							onAddAssignee={addIssueAssignee}
+							onAddExternalAssignee={addExternalIssueAssignee}
+							onRemoveContributor={removeContributor}
+							onRemoveAssignee={removeIssueAssignee}
+							onAddComment={addIssueComment}
+							onDeleteComment={deleteIssueComment}
+							attachments={attachmentsByIssueId[selectedIssue.id] ?? []}
+							attachmentUploadStatus={attachmentUploadStatus}
+							onUploadAttachments={uploadIssueAttachments}
+							onDeleteAttachment={deleteIssueAttachment}
+							commits={
+								issueCommits?.issueId === selectedIssue.id
+									? issueCommits.commits
+									: []
+							}
+							commitsLoading={
+								issueCommits?.issueId === selectedIssue.id
+									? issueCommits.loading
+									: false
+							}
+							commitsError={
+								issueCommits?.issueId === selectedIssue.id
+									? issueCommits.error
+									: null
+							}
+							commitDiffsBySha={issueCommitDiffs}
+							onLoadCommitDiff={loadIssueCommitDiff}
+							onReopenIssue={reopenIssue}
+							onCloseIssue={closeIssue}
+							knownTags={state.tags ?? []}
+							knownAssignees={contributors}
+							onOpenAssigneePicker={requestContributors}
+						/>
+					)}
 			</div>
 
 			{createIssueModal && (

--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -318,12 +318,16 @@ export const App = () => {
 		});
 	}, [selectedIssue?.id, state]);
 
+	// Keyed on the issue alone, not the tab: switching to Code and back must not
+	// discard diffs already loaded there, only a genuinely different ticket should.
+	useEffect(() => {
+		setIssueCommitDiffs({});
+	}, [selectedIssue?.id]);
+
 	// Fetched lazily on entering the Code tab rather than alongside issue:get
 	// above: a full ref-prefix log scan on every ticket selection would be
 	// wasted on the common case where nobody opens the tab.
 	useEffect(() => {
-		setIssueCommitDiffs({});
-
 		if (!selectedIssue || selectedTab !== 'code') {
 			setIssueCommits(null);
 			return;
@@ -547,17 +551,27 @@ export const App = () => {
 			}
 
 			if (message.type === 'issue:commits:result') {
-				if (message.payload?.status === 'fail') {
+				// Wrapped with the issueId it was requested for: switching tickets
+				// while the Code tab stays open can leave an older ticket's request
+				// in flight, and a failed Result alone carries no issueId to check.
+				const {issueId, result} = message.payload as {
+					issueId: string;
+					result: {status: string; message: string; value?: GuiCommitEntry[]};
+				};
+
+				if (result?.status === 'fail') {
 					setIssueCommits(prev =>
-						prev
-							? {...prev, loading: false, error: message.payload.message}
+						prev && prev.issueId === issueId
+							? {...prev, loading: false, error: result.message}
 							: prev,
 					);
 				} else {
-					const commits = getResultValue<GuiCommitEntry[]>(message.payload);
+					const commits = getResultValue<GuiCommitEntry[]>(result);
 					if (commits) {
 						setIssueCommits(prev =>
-							prev ? {...prev, loading: false, error: null, commits} : prev,
+							prev && prev.issueId === issueId
+								? {...prev, loading: false, error: null, commits}
+								: prev,
 						);
 					}
 				}
@@ -1398,9 +1412,17 @@ export const App = () => {
 						{/* Grows scrollWidth by exactly what closing the panel gave back
 							in clientWidth, keeping max scrollLeft identical across
 							open/closed so the board doesn't bounce back when scrolled
-							far right. */}
+							far right. Width must match whichever panel would be showing —
+							the commit-diff panel and a ticket's Code tab are both
+							ASIDE_DIFF_WIDTH wide, not the default ASIDE_WIDTH. */}
 						{!commitDiff && !(selectedIssue && state?.user) && (
-							<div style={{width: ASIDE_WIDTH, flexShrink: 0}} />
+							<div
+								style={{
+									width:
+										selectedTab === 'code' ? ASIDE_DIFF_WIDTH : ASIDE_WIDTH,
+									flexShrink: 0,
+								}}
+							/>
 						)}
 
 						{/* The page's right margin, scrolling with the columns. Constant,

--- a/source/gui/client/components/Aside.tsx
+++ b/source/gui/client/components/Aside.tsx
@@ -3,24 +3,29 @@ import {GUI_THEME} from '../lib/gui-theme';
 
 export const ASIDE_WIDTH = 440;
 
-export const Aside = forwardRef<HTMLElement, {children: React.ReactNode}>(
-	({children}, ref) => (
-		<aside
-			ref={ref}
-			style={{
-				boxSizing: 'border-box',
-				width: ASIDE_WIDTH,
-				minWidth: ASIDE_WIDTH,
-				borderLeft: `1px solid ${GUI_THEME.line}`,
-				background: GUI_THEME.panel,
-				padding: 20,
-				fontSize: 12,
-				overflow: 'auto',
-			}}
-		>
-			{children}
-		</aside>
-	),
-);
+// Diff mode's split (before/after) layout needs roughly double the room a
+// single-column panel does.
+export const ASIDE_DIFF_WIDTH = ASIDE_WIDTH * 2;
+
+export const Aside = forwardRef<
+	HTMLElement,
+	{children: React.ReactNode; width?: number}
+>(({children, width = ASIDE_WIDTH}, ref) => (
+	<aside
+		ref={ref}
+		style={{
+			boxSizing: 'border-box',
+			width,
+			minWidth: width,
+			borderLeft: `1px solid ${GUI_THEME.line}`,
+			background: GUI_THEME.panel,
+			padding: 20,
+			fontSize: 12,
+			overflow: 'auto',
+		}}
+	>
+		{children}
+	</aside>
+));
 
 Aside.displayName = 'Aside';

--- a/source/gui/client/components/DiffPanel.tsx
+++ b/source/gui/client/components/DiffPanel.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import {DiffFileInput, FileContents, MultiFileDiff} from '@pierre/diffs/react';
+import {GUI_THEME} from '../lib/gui-theme';
+import {GuiCommitDiffFile} from '../lib/gui-state.model';
+import {Button} from './Button';
+import {Empty} from './FormPrimitives';
+import {FormHeader} from './FormHeader';
+
+// A single dark theme: the app has no light mode to match (GUI_THEME is a
+// fixed dark palette), so there is no pair to switch between.
+const PIERRE_THEME = 'github-dark';
+
+// Independently-nullable before/after strings don't structurally match
+// DiffFileInput's three-branch union (it forbids "both null"), so this picks
+// the one branch that fits rather than letting TypeScript infer a wider type.
+const toDiffFileInput = (file: GuiCommitDiffFile): DiffFileInput => {
+	const oldFile: FileContents = {name: file.path, contents: file.before};
+	const newFile: FileContents = {name: file.path, contents: file.after};
+
+	// Empty means "did not exist at this revision", same convention the server
+	// side already uses (a missing git blob reads as ''). A genuinely empty
+	// file on one side, that also exists, is indistinguishable from this and
+	// renders as added/deleted rather than an empty-content change.
+	if (file.before === '' && file.after !== '') return {oldFile: null, newFile};
+	if (file.after === '' && file.before !== '') return {oldFile, newFile: null};
+
+	return {oldFile, newFile};
+};
+
+export const FileDiffView = ({file}: {file: GuiCommitDiffFile}) => (
+	<div
+		style={{
+			marginBottom: 16,
+			border: `1px solid ${GUI_THEME.line}`,
+			borderRadius: 8,
+			overflow: 'hidden',
+		}}
+	>
+		<MultiFileDiff
+			{...toDiffFileInput(file)}
+			options={{diffStyle: 'split', theme: PIERRE_THEME}}
+		/>
+	</div>
+);
+
+export const DiffPanel = ({
+	title,
+	files,
+	loading,
+	error,
+	onClose,
+}: {
+	title: string;
+	files: GuiCommitDiffFile[] | null;
+	loading: boolean;
+	error: string | null;
+	onClose: () => void;
+}) => (
+	<>
+		<FormHeader>
+			<span
+				style={{
+					color: GUI_THEME.secondary,
+					fontSize: 10,
+					textTransform: 'uppercase',
+					letterSpacing: '0.08em',
+				}}
+			>
+				{title}
+			</span>
+
+			<Button variant="ghost" onClick={onClose}>
+				×
+			</Button>
+		</FormHeader>
+
+		{loading && <Empty>Loading diff…</Empty>}
+		{!loading && error && <Empty>{error}</Empty>}
+		{!loading && !error && files?.length === 0 && <Empty>No changes.</Empty>}
+
+		{!loading &&
+			!error &&
+			files?.map(file => <FileDiffView key={file.path} file={file} />)}
+	</>
+);

--- a/source/gui/client/components/IssueCommits.tsx
+++ b/source/gui/client/components/IssueCommits.tsx
@@ -1,0 +1,221 @@
+import React, {useState} from 'react';
+import {GuiCommitDiffFile, GuiCommitEntry} from '../lib/gui-state.model';
+import {GUI_THEME} from '../lib/gui-theme';
+import {Empty} from './FormPrimitives';
+import {FileDiffView} from './DiffPanel';
+import {IconChevronDown} from './IconChevronDown';
+import {IconChevronRight} from './IconChevronRight';
+
+export type CommitDiffState = {
+	loading: boolean;
+	error: string | null;
+	files: GuiCommitDiffFile[] | null;
+};
+
+const disclosureStyle: React.CSSProperties = {
+	display: 'flex',
+	alignItems: 'center',
+	gap: 8,
+	width: '100%',
+	textAlign: 'left',
+	background: 'transparent',
+	border: 'none',
+	cursor: 'pointer',
+	color: GUI_THEME.primary,
+	font: 'inherit',
+	fontSize: 12,
+};
+
+const FileRow = ({
+	file,
+	expanded,
+	onToggle,
+}: {
+	file: GuiCommitDiffFile;
+	expanded: boolean;
+	onToggle: () => void;
+}) => (
+	<div style={{marginTop: 8}}>
+		<button
+			onClick={onToggle}
+			aria-expanded={expanded}
+			style={{...disclosureStyle, color: GUI_THEME.secondary, padding: '4px 0'}}
+		>
+			{expanded ? (
+				<IconChevronDown size={12} />
+			) : (
+				<IconChevronRight size={12} />
+			)}
+			<span
+				style={{
+					fontFamily: 'ui-monospace, monospace',
+					overflow: 'hidden',
+					textOverflow: 'ellipsis',
+					whiteSpace: 'nowrap',
+				}}
+			>
+				{file.path}
+			</span>
+		</button>
+
+		{expanded && <FileDiffView file={file} />}
+	</div>
+);
+
+const CommitRow = ({
+	commit,
+	diff,
+	expanded,
+	onToggle,
+	expandedFiles,
+	onToggleFile,
+}: {
+	commit: GuiCommitEntry;
+	diff: CommitDiffState | undefined;
+	expanded: boolean;
+	onToggle: () => void;
+	expandedFiles: Set<string>;
+	onToggleFile: (path: string) => void;
+}) => (
+	<div
+		style={{
+			marginBottom: 10,
+			border: `1px solid ${GUI_THEME.line}`,
+			borderRadius: 8,
+			overflow: 'hidden',
+		}}
+	>
+		<button
+			onClick={onToggle}
+			aria-expanded={expanded}
+			style={{...disclosureStyle, padding: '8px 10px'}}
+		>
+			{expanded ? (
+				<IconChevronDown size={12} />
+			) : (
+				<IconChevronRight size={12} />
+			)}
+			<span
+				style={{color: GUI_THEME.dim, fontFamily: 'ui-monospace, monospace'}}
+			>
+				{commit.sha.slice(0, 7)}
+			</span>
+			<span
+				style={{
+					flex: 1,
+					overflow: 'hidden',
+					textOverflow: 'ellipsis',
+					whiteSpace: 'nowrap',
+				}}
+			>
+				{commit.subject}
+			</span>
+		</button>
+
+		{expanded && (
+			<div
+				style={{
+					padding: '0 10px 10px',
+					borderTop: `1px solid ${GUI_THEME.line}`,
+				}}
+			>
+				{diff?.loading && <Empty>Loading files…</Empty>}
+				{!diff?.loading && diff?.error && <Empty>{diff.error}</Empty>}
+
+				{diff?.files?.map(file => (
+					<FileRow
+						key={file.path}
+						file={file}
+						expanded={expandedFiles.has(file.path)}
+						onToggle={() => onToggleFile(file.path)}
+					/>
+				))}
+			</div>
+		)}
+	</div>
+);
+
+// The tree this renders:
+//
+// Issue
+//  ├── Commit A
+//  │     ├── server.ts
+//  │     └── auth.ts
+//  └── Commit B
+//        └── ui.tsx
+//
+// Deliberately per-commit rather than a flattened file list across the whole
+// ticket — a file touched in two commits shows twice, once per commit, same
+// as GitHub's "Commits" tab vs. its squashed "Files changed" tab.
+export const IssueCommits = ({
+	commits,
+	loading,
+	error,
+	diffsBySha,
+	onLoadDiff,
+}: {
+	commits: GuiCommitEntry[];
+	loading: boolean;
+	error: string | null;
+	diffsBySha: Record<string, CommitDiffState>;
+	onLoadDiff: (sha: string) => void;
+}) => {
+	const [expandedShas, setExpandedShas] = useState<Set<string>>(new Set());
+	const [expandedFilesBySha, setExpandedFilesBySha] = useState<
+		Record<string, Set<string>>
+	>({});
+
+	const toggleCommit = (sha: string) => {
+		const alreadyExpanded = expandedShas.has(sha);
+
+		setExpandedShas(prev => {
+			const next = new Set(prev);
+			if (alreadyExpanded) {
+				next.delete(sha);
+			} else {
+				next.add(sha);
+			}
+			return next;
+		});
+
+		if (!alreadyExpanded && !diffsBySha[sha]) onLoadDiff(sha);
+	};
+
+	const toggleFile = (sha: string, path: string) => {
+		setExpandedFilesBySha(prev => {
+			const current = new Set(prev[sha] ?? []);
+			if (current.has(path)) {
+				current.delete(path);
+			} else {
+				current.add(path);
+			}
+			return {...prev, [sha]: current};
+		});
+	};
+
+	if (loading) return <Empty>Loading commits…</Empty>;
+	if (error) return <Empty>{error}</Empty>;
+	if (commits.length === 0) {
+		return <Empty>No commits reference this ticket yet.</Empty>;
+	}
+
+	// Oldest first, reading top-to-bottom as the story unfolded — the log
+	// itself comes back newest-first.
+	const ordered = [...commits].sort((a, b) => a.time - b.time);
+
+	return (
+		<div>
+			{ordered.map(commit => (
+				<CommitRow
+					key={commit.sha}
+					commit={commit}
+					diff={diffsBySha[commit.sha]}
+					expanded={expandedShas.has(commit.sha)}
+					onToggle={() => toggleCommit(commit.sha)}
+					expandedFiles={expandedFilesBySha[commit.sha] ?? new Set()}
+					onToggleFile={path => toggleFile(commit.sha, path)}
+				/>
+			))}
+		</div>
+	);
+};

--- a/source/gui/client/components/IssueCommits.tsx
+++ b/source/gui/client/components/IssueCommits.tsx
@@ -178,7 +178,12 @@ export const IssueCommits = ({
 			return next;
 		});
 
-		if (!alreadyExpanded && !diffsBySha[sha]) onLoadDiff(sha);
+		// Also retries on a prior failure — a truthy-but-errored entry would
+		// otherwise stay stuck showing that error forever, since collapsing and
+		// re-expanding is the only other trigger and it hits this same guard.
+		if (!alreadyExpanded && (!diffsBySha[sha] || diffsBySha[sha].error)) {
+			onLoadDiff(sha);
+		}
 	};
 
 	const toggleFile = (sha: string, path: string) => {

--- a/source/gui/client/components/IssueDetails.tsx
+++ b/source/gui/client/components/IssueDetails.tsx
@@ -7,9 +7,10 @@ import {
 	GuiTag,
 	GuiComment,
 	GuiAttachment,
+	GuiCommitEntry,
 	GuiIssueHistoryEntry,
 } from '../lib/gui-state.model';
-import {Aside} from './Aside';
+import {ASIDE_DIFF_WIDTH, Aside} from './Aside';
 import {Button} from './Button';
 import {ManageContributorsModal} from './ManageContributorsModal';
 import {CopyRef} from './CopyRef';
@@ -24,13 +25,14 @@ import {
 } from './FormPrimitives';
 import {AttachmentUploadStatus, IssueAttachments} from './IssueAttachments';
 import {IssueComments} from './IssueComments';
+import {CommitDiffState, IssueCommits} from './IssueCommits';
 import {MarkdownContent} from './MarkdownContent';
 import {Section} from './Section';
 import {Tabs, TabItem} from './Tabs';
 import {IssueHistory} from './IssueHistory';
 import {formatAbsolute, timeAgo} from '../lib/gui-format.helper';
 
-type IssueDetailsTab = 'overview' | 'comments' | 'history';
+type IssueDetailsTab = 'overview' | 'comments' | 'history' | 'code';
 
 export const IssueDetails = ({
 	whoAmI,
@@ -57,6 +59,11 @@ export const IssueDetails = ({
 	attachmentUploadStatus,
 	onUploadAttachments,
 	onDeleteAttachment,
+	commits,
+	commitsLoading,
+	commitsError,
+	commitDiffsBySha,
+	onLoadCommitDiff,
 	knownTags: tags,
 	knownAssignees: assignees,
 	onOpenAssigneePicker,
@@ -85,6 +92,11 @@ export const IssueDetails = ({
 	attachmentUploadStatus: AttachmentUploadStatus;
 	onUploadAttachments?: (issueId: string, files: File[]) => void;
 	onDeleteAttachment?: (issueId: string, attachmentId: string) => void;
+	commits: GuiCommitEntry[];
+	commitsLoading: boolean;
+	commitsError: string | null;
+	commitDiffsBySha: Record<string, CommitDiffState>;
+	onLoadCommitDiff: (sha: string) => void;
 	knownTags: GuiTag[];
 	knownAssignees: GuiContributor[];
 	// Fired when the picker opens, so the caller can fetch the list only then.
@@ -130,6 +142,9 @@ export const IssueDetails = ({
 		{id: 'overview', label: 'Overview'},
 		{id: 'comments', label: 'Comments', count: comments.length},
 		{id: 'history', label: 'Log', count: history.length},
+		// No count before the first load: commits are fetched lazily on opening
+		// this tab, so showing 0 until then would misread as "no commits yet".
+		{id: 'code', label: 'Code', count: commits.length || undefined},
 	];
 
 	const saveTitle = () => {
@@ -208,7 +223,10 @@ export const IssueDetails = ({
 		);
 
 	return (
-		<Aside ref={panelRef}>
+		<Aside
+			ref={panelRef}
+			width={activeTab === 'code' ? ASIDE_DIFF_WIDTH : undefined}
+		>
 			{issue ? (
 				<>
 					<FormHeader>
@@ -601,6 +619,16 @@ export const IssueDetails = ({
 						<IssueHistory
 							entries={history}
 							onHoverEvent={onHoverHistoryEvent}
+						/>
+					)}
+
+					{activeTab === 'code' && (
+						<IssueCommits
+							commits={commits}
+							loading={commitsLoading}
+							error={commitsError}
+							diffsBySha={commitDiffsBySha}
+							onLoadDiff={onLoadCommitDiff}
 						/>
 					)}
 				</>

--- a/source/gui/client/lib/gui-state.model.ts
+++ b/source/gui/client/lib/gui-state.model.ts
@@ -118,3 +118,14 @@ export type GuiCommitEntry = {
 	subject: string;
 	linesChanged: number;
 };
+
+export type GuiCommitDiffFile = {
+	path: string;
+	before: string;
+	after: string;
+};
+
+export type GuiCommitDiff = {
+	sha: string;
+	files: GuiCommitDiffFile[];
+};

--- a/source/mcp/epiq-time-travel.ts
+++ b/source/mcp/epiq-time-travel.ts
@@ -447,11 +447,16 @@ export const getCommitsForRef = async (
 	const timelineResult = await getCommitTimeline({repoRoot: input.repoRoot});
 	if (isFail(timelineResult)) return failed(timelineResult.message);
 
-	const prefix = `${ref} `;
+	// Case-insensitive, matching nodeRefMatches' convention (source/lib/utils/node-ref.ts)
+	// rather than a strict-case prefix: a hand-typed or manually-copied ref
+	// should still match, not just one pasted verbatim from the MCP response.
+	const prefix = `${ref.toUpperCase()} `;
 
 	return succeeded(
 		'Matched commits by ref',
-		timelineResult.value.filter(commit => commit.subject.startsWith(prefix)),
+		timelineResult.value.filter(commit =>
+			commit.subject.toUpperCase().startsWith(prefix),
+		),
 	);
 };
 
@@ -501,14 +506,18 @@ const readFileAtRevision = async (
 	return isFail(result) ? '' : result.value.stdout;
 };
 
-// Shared by the editor path below and by getCommitDiff's data path.
+// Shared by the editor path below and by getCommitDiff's data path. A plain
+// two-tree diff against the first parent (matching readFileAtRevision's own
+// `sha~1` convention) rather than `diff-tree -r <sha>`: diff-tree's single-
+// commit mode reports no files at all for a merge commit unless told
+// otherwise, which read as "no changes" instead of the merge's real diff.
 const getChangedFilePaths = async (
 	repoRoot: string,
 	sha: string,
 ): Promise<Result<string[]>> => {
 	const filesResult = await execGit({
 		cwd: repoRoot,
-		args: ['diff-tree', '--no-commit-id', '--name-only', '-r', sha],
+		args: ['diff', '--name-only', `${sha}~1`, sha],
 	});
 	if (isFail(filesResult)) return failed(filesResult.message);
 
@@ -647,6 +656,38 @@ export type CommitDiff = {
 // exists for — a rendered accordion tolerates far more files than open windows do.
 const MAX_DIFF_FILES_FOR_DATA = 200;
 
+// Caps concurrent git subprocesses: an unbatched Promise.all over a near-
+// MAX_DIFF_FILES_FOR_DATA commit would fire hundreds of `git show` processes
+// (two per file) at once.
+const DIFF_READ_CONCURRENCY = 8;
+
+const readFileDiffsInBatches = async (
+	repoRoot: string,
+	sha: string,
+	filePaths: string[],
+): Promise<CommitDiffFile[]> => {
+	const files: CommitDiffFile[] = [];
+
+	for (let i = 0; i < filePaths.length; i += DIFF_READ_CONCURRENCY) {
+		const batch = filePaths.slice(i, i + DIFF_READ_CONCURRENCY);
+
+		const batchFiles = await Promise.all(
+			batch.map(async (filePath): Promise<CommitDiffFile> => {
+				const [before, after] = await Promise.all([
+					readFileAtRevision(repoRoot, `${sha}~1`, filePath),
+					readFileAtRevision(repoRoot, sha, filePath),
+				]);
+
+				return {path: filePath, before, after};
+			}),
+		);
+
+		files.push(...batchFiles);
+	}
+
+	return files;
+};
+
 // The GUI diff panel's data source: same git calls as the editor path above,
 // returned as content instead of written to temp files. Never touches the
 // materialized state singleton, so it is independent of any time-travel checkout.
@@ -670,16 +711,7 @@ export const getCommitDiff = async (
 		);
 	}
 
-	const files = await Promise.all(
-		filePaths.map(async (filePath): Promise<CommitDiffFile> => {
-			const [before, after] = await Promise.all([
-				readFileAtRevision(repoRoot, `${input.sha}~1`, filePath),
-				readFileAtRevision(repoRoot, input.sha, filePath),
-			]);
-
-			return {path: filePath, before, after};
-		}),
-	);
+	const files = await readFileDiffsInBatches(repoRoot, input.sha, filePaths);
 
 	return succeeded('Loaded commit diff', {sha: input.sha, files});
 };

--- a/source/mcp/epiq-time-travel.ts
+++ b/source/mcp/epiq-time-travel.ts
@@ -479,12 +479,11 @@ const readFileAtRevision = async (
 	return isFail(result) ? '' : result.value.stdout;
 };
 
-// Each side keeps its real filename so the editor detects the language.
-const openCommitAsSideBySideDiffs = async (
+// Shared by the editor path below and by getCommitDiff's data path.
+const getChangedFilePaths = async (
 	repoRoot: string,
 	sha: string,
-	editor: string,
-): Promise<Result<true>> => {
+): Promise<Result<string[]>> => {
 	const filesResult = await execGit({
 		cwd: repoRoot,
 		args: ['diff-tree', '--no-commit-id', '--name-only', '-r', sha],
@@ -499,6 +498,20 @@ const openCommitAsSideBySideDiffs = async (
 	if (filePaths.length === 0) {
 		return failed('No changed files found for this commit');
 	}
+
+	return succeeded('Listed changed files', filePaths);
+};
+
+// Each side keeps its real filename so the editor detects the language.
+const openCommitAsSideBySideDiffs = async (
+	repoRoot: string,
+	sha: string,
+	editor: string,
+): Promise<Result<true>> => {
+	const filesResult = await getChangedFilePaths(repoRoot, sha);
+	if (isFail(filesResult)) return failed(filesResult.message);
+
+	const filePaths = filesResult.value;
 
 	if (filePaths.length > MAX_DIFF_FILES_FOR_SIDE_BY_SIDE) {
 		return failed(
@@ -594,6 +607,59 @@ export const openCommitDiffInEditor = async (
 	}
 
 	return openCommitAsUnifiedDiff(repoRoot, input.sha);
+};
+
+export type CommitDiffFile = {
+	path: string;
+	before: string;
+	after: string;
+};
+
+export type CommitDiff = {
+	sha: string;
+	files: CommitDiffFile[];
+};
+
+// Bounds payload size for a pathological commit (a vendored dep, a lockfile
+// rewrite) rather than the editor-tab-count concern MAX_DIFF_FILES_FOR_SIDE_BY_SIDE
+// exists for — a rendered accordion tolerates far more files than open windows do.
+const MAX_DIFF_FILES_FOR_DATA = 200;
+
+// The GUI diff panel's data source: same git calls as the editor path above,
+// returned as content instead of written to temp files. Never touches the
+// materialized state singleton, so it is independent of any time-travel checkout.
+export const getCommitDiff = async (
+	input: ToolInput & {sha: string},
+): Promise<Result<CommitDiff>> => {
+	if (!isPlausibleSha(input.sha)) return failed('Invalid commit sha');
+
+	const repoRootResult = resolveRepoRoot(input.repoRoot);
+	if (isFail(repoRootResult)) return failed(repoRootResult.message);
+	const repoRoot = repoRootResult.value;
+
+	const filesResult = await getChangedFilePaths(repoRoot, input.sha);
+	if (isFail(filesResult)) return failed(filesResult.message);
+
+	const filePaths = filesResult.value;
+
+	if (filePaths.length > MAX_DIFF_FILES_FOR_DATA) {
+		return failed(
+			`Commit touches ${filePaths.length} files — too many to show as a diff`,
+		);
+	}
+
+	const files = await Promise.all(
+		filePaths.map(async (filePath): Promise<CommitDiffFile> => {
+			const [before, after] = await Promise.all([
+				readFileAtRevision(repoRoot, `${input.sha}~1`, filePath),
+				readFileAtRevision(repoRoot, input.sha, filePath),
+			]);
+
+			return {path: filePath, before, after};
+		}),
+	);
+
+	return succeeded('Loaded commit diff', {sha: input.sha, files});
 };
 
 // Takes NO lock: its callers already run inside `runExclusive`, which is not

--- a/source/mcp/epiq-time-travel.ts
+++ b/source/mcp/epiq-time-travel.ts
@@ -433,6 +433,28 @@ export const getCommitTimeline = async (
 	return succeeded('Computed commit timeline', commits);
 };
 
+// Matches the convention documented in the epiq skill: a commit's subject is
+// prefixed with the issue's ref, e.g. "5S52AC8 message". Reuses
+// getCommitTimeline's full-history read rather than a second git invocation —
+// same repo, same state-branch exclusion, and this repo's whole history is a
+// few thousand commits at most.
+export const getCommitsForRef = async (
+	input: ToolInput & {ref: string},
+): Promise<Result<CommitEntry[]>> => {
+	const ref = input.ref.trim();
+	if (!ref) return failed('ref must not be empty');
+
+	const timelineResult = await getCommitTimeline({repoRoot: input.repoRoot});
+	if (isFail(timelineResult)) return failed(timelineResult.message);
+
+	const prefix = `${ref} `;
+
+	return succeeded(
+		'Matched commits by ref',
+		timelineResult.value.filter(commit => commit.subject.startsWith(prefix)),
+	);
+};
+
 // `sha` reaches a `git show <sha>` argv slot, where a leading `-` would be read
 // as a flag. Argument injection, not shell injection.
 const isPlausibleSha = (sha: string): boolean => /^[0-9a-f]{7,40}$/i.test(sha);

--- a/source/scripts/build-gui.mjs
+++ b/source/scripts/build-gui.mjs
@@ -24,14 +24,22 @@ copyFileSync(
 	resolve(root, 'dist/gui/favicon.ico'),
 );
 
+// Splitting rather than a single --outfile: @pierre/diffs pulls in Shiki's
+// full bundled-language and theme set, which a single-file bundle inlines
+// wholesale (~12mb) regardless of which languages actually render. Splitting
+// lets each language/theme load lazily as its own chunk, only when a diff
+// actually needs it. serveStatic (api-server.ts) already serves any path
+// under dist/gui, and build-sea.mjs embeds the directory's full contents —
+// both already account for a chunked output, not just main.js.
 execFileSync(
 	esbuild,
 	[
 		'source/gui/client/main.tsx',
 		'--bundle',
+		'--splitting',
 		'--format=esm',
 		'--target=es2020',
-		'--outfile=dist/gui/main.js',
+		'--outdir=dist/gui',
 	],
 	{cwd: root, stdio: 'inherit', shell: platform === 'win32'},
 );

--- a/source/scripts/build-sea.mjs
+++ b/source/scripts/build-sea.mjs
@@ -11,7 +11,13 @@
 //   statically. We stub it so the bundle is fully self-contained.
 
 import {execSync, execFileSync} from 'node:child_process';
-import {readFileSync, writeFileSync, copyFileSync, chmodSync} from 'node:fs';
+import {
+	readFileSync,
+	writeFileSync,
+	copyFileSync,
+	chmodSync,
+	readdirSync,
+} from 'node:fs';
 import {mkdirSync} from 'node:fs';
 import {platform} from 'node:process';
 import {fileURLToPath} from 'node:url';
@@ -105,11 +111,14 @@ run('npm run build:gui');
 const seaConfig = JSON.parse(
 	readFileSync(resolve(root, 'source/config/sea-config.json'), 'utf8'),
 );
-seaConfig.assets = {
-	'gui/index.html': resolve(root, 'dist/gui/index.html'),
-	'gui/main.js': resolve(root, 'dist/gui/main.js'),
-	'gui/favicon.ico': resolve(root, 'dist/gui/favicon.ico'),
-};
+// Embeds every file the GUI build produced, not a fixed list: esbuild code-
+// splitting (build-gui.mjs) writes one chunk per lazily-loaded language/theme
+// alongside main.js, and serveStatic (api-server.ts) resolves any of them by
+// path — a fixed list would silently 404 on whichever chunk a diff needs.
+const guiDir = resolve(root, 'dist/gui');
+seaConfig.assets = Object.fromEntries(
+	readdirSync(guiDir).map(name => [`gui/${name}`, resolve(guiDir, name)]),
+);
 // Absolute paths for main/output too, so this generated config's location
 // (dist/) doesn't change how they're resolved.
 seaConfig.main = resolve(root, seaConfig.main);

--- a/source/test/epiq-time-travel.test.ts
+++ b/source/test/epiq-time-travel.test.ts
@@ -714,7 +714,7 @@ describe('epiq-time-travel', () => {
 				contentByPath: Record<string, string> = {},
 			) => {
 				vi.mocked(execGit).mockImplementation(async ({args}) => {
-					if (args[0] === 'diff-tree') {
+					if (args[0] === 'diff') {
 						return succeeded('changed files', {
 							stdout: files.join('\n'),
 							stderr: '',
@@ -903,7 +903,7 @@ describe('epiq-time-travel', () => {
 			contentByPath: Record<string, string> = {},
 		) => {
 			vi.mocked(execGit).mockImplementation(async ({args}) => {
-				if (args[0] === 'diff-tree') {
+				if (args[0] === 'diff') {
 					return succeeded('changed files', {
 						stdout: files.join('\n'),
 						stderr: '',
@@ -993,12 +993,36 @@ describe('epiq-time-travel', () => {
 			expect(isSuccess(result)).toBe(false);
 		});
 
-		it('propagates a diff-tree failure', async () => {
+		it('propagates a diff failure', async () => {
 			vi.mocked(execGit).mockResolvedValue(failed('bad object'));
 
 			const result = await getCommitDiff({sha: validSha});
 
 			expect(isSuccess(result)).toBe(false);
+		});
+
+		// diff-tree's single-commit mode reports no files for a merge commit
+		// unless told otherwise — diffing against the first parent explicitly
+		// (`sha~1`) works for both merge and non-merge commits alike.
+		it('lists a merge commit as a diff against its first parent, not as having no changes', async () => {
+			mockGitForFiles(['source/a.ts'], {
+				[`${validSha}~1:source/a.ts`]: 'before',
+				[`${validSha}:source/a.ts`]: 'after',
+			});
+
+			const result = await getCommitDiff({sha: validSha});
+
+			expect(execGit).toHaveBeenCalledWith(
+				expect.objectContaining({
+					args: ['diff', '--name-only', `${validSha}~1`, validSha],
+				}),
+			);
+			expect(isSuccess(result)).toBe(true);
+			if (isSuccess(result)) {
+				expect(result.value.files).toEqual([
+					{path: 'source/a.ts', before: 'before', after: 'after'},
+				]);
+			}
 		});
 	});
 

--- a/source/test/epiq-time-travel.test.ts
+++ b/source/test/epiq-time-travel.test.ts
@@ -92,6 +92,7 @@ import {
 import {
 	checkoutStateAt,
 	getCommitDiff,
+	getCommitsForRef,
 	getCommitTimeline,
 	getEventTimeline,
 	getTimeTravelStatus,
@@ -567,6 +568,60 @@ describe('epiq-time-travel', () => {
 			vi.mocked(execGit).mockResolvedValue(failed('git not found'));
 
 			const result = await getCommitTimeline();
+
+			expect(isSuccess(result)).toBe(false);
+		});
+	});
+
+	describe('getCommitsForRef', () => {
+		const SEP = '\x1f';
+		const REC = '\x1e';
+
+		it('matches commits whose subject starts with "<ref> "', async () => {
+			vi.mocked(execGit).mockResolvedValue(
+				succeeded('git log', {
+					stdout:
+						`${REC}aaa111${SEP}1700000000${SEP}Ada${SEP}5S52AC8 add the tool\n` +
+						`${REC}bbb222${SEP}1700000100${SEP}Grace${SEP}unrelated commit\n`,
+					stderr: '',
+					exitCode: 0,
+				}),
+			);
+
+			const result = await getCommitsForRef({ref: '5S52AC8'});
+
+			expect(isSuccess(result)).toBe(true);
+			if (isFail(result)) return;
+			expect(result.value.map(commit => commit.sha)).toEqual(['aaa111']);
+		});
+
+		it('requires a space after the ref, not just a text prefix', async () => {
+			vi.mocked(execGit).mockResolvedValue(
+				succeeded('git log', {
+					stdout: `${REC}aaa111${SEP}1700000000${SEP}Ada${SEP}5S52AC89 similar but longer ref\n`,
+					stderr: '',
+					exitCode: 0,
+				}),
+			);
+
+			const result = await getCommitsForRef({ref: '5S52AC8'});
+
+			expect(isSuccess(result)).toBe(true);
+			if (isFail(result)) return;
+			expect(result.value).toEqual([]);
+		});
+
+		it('fails for an empty ref', async () => {
+			const result = await getCommitsForRef({ref: '   '});
+
+			expect(isSuccess(result)).toBe(false);
+			expect(execGit).not.toHaveBeenCalled();
+		});
+
+		it('propagates a git log failure', async () => {
+			vi.mocked(execGit).mockResolvedValue(failed('git not found'));
+
+			const result = await getCommitsForRef({ref: '5S52AC8'});
 
 			expect(isSuccess(result)).toBe(false);
 		});

--- a/source/test/epiq-time-travel.test.ts
+++ b/source/test/epiq-time-travel.test.ts
@@ -91,6 +91,7 @@ import {
 } from '../lib/model/result-types.js';
 import {
 	checkoutStateAt,
+	getCommitDiff,
 	getCommitTimeline,
 	getEventTimeline,
 	getTimeTravelStatus,
@@ -836,6 +837,113 @@ describe('epiq-time-travel', () => {
 				expect(openEditorOnFileNonBlocking).toHaveBeenCalled();
 				expect(isSuccess(result)).toBe(true);
 			});
+		});
+	});
+
+	describe('getCommitDiff', () => {
+		const validSha = 'b42a0bf111e4b6213abf6c1bfe65088b5c9764f8';
+
+		const mockGitForFiles = (
+			files: string[],
+			contentByPath: Record<string, string> = {},
+		) => {
+			vi.mocked(execGit).mockImplementation(async ({args}) => {
+				if (args[0] === 'diff-tree') {
+					return succeeded('changed files', {
+						stdout: files.join('\n'),
+						stderr: '',
+						exitCode: 0,
+					});
+				}
+
+				if (args[0] === 'show') {
+					const spec = args[1] ?? '';
+					const content = contentByPath[spec];
+
+					// Omit a spec to simulate a blob missing on that side.
+					return content === undefined
+						? failed('bad object (missing blob)')
+						: succeeded('blob', {stdout: content, stderr: '', exitCode: 0});
+				}
+
+				return failed(`unexpected git args: ${args.join(' ')}`);
+			});
+		};
+
+		it('rejects a sha shaped like a git flag, without ever shelling out', async () => {
+			const result = await getCommitDiff({sha: '--upload-pack=/bin/sh'});
+
+			expect(isSuccess(result)).toBe(false);
+			expect(execGit).not.toHaveBeenCalled();
+		});
+
+		it('returns before/after content for each changed file', async () => {
+			mockGitForFiles(['source/a.ts', 'source/b.ts'], {
+				[`${validSha}~1:source/a.ts`]: 'a before',
+				[`${validSha}:source/a.ts`]: 'a after',
+				[`${validSha}~1:source/b.ts`]: 'b before',
+				[`${validSha}:source/b.ts`]: 'b after',
+			});
+
+			const result = await getCommitDiff({sha: validSha});
+
+			expect(isSuccess(result)).toBe(true);
+			if (isSuccess(result)) {
+				expect(result.value).toEqual({
+					sha: validSha,
+					files: [
+						{path: 'source/a.ts', before: 'a before', after: 'a after'},
+						{path: 'source/b.ts', before: 'b before', after: 'b after'},
+					],
+				});
+			}
+		});
+
+		it('treats a missing blob (file added or deleted here) as empty content, not a failure', async () => {
+			mockGitForFiles(['source/new-file.ts'], {
+				[`${validSha}:source/new-file.ts`]: 'brand new content',
+			});
+
+			const result = await getCommitDiff({sha: validSha});
+
+			expect(isSuccess(result)).toBe(true);
+			if (isSuccess(result)) {
+				expect(result.value.files).toEqual([
+					{
+						path: 'source/new-file.ts',
+						before: '',
+						after: 'brand new content',
+					},
+				]);
+			}
+		});
+
+		it('fails when the commit has no changed files', async () => {
+			mockGitForFiles([]);
+
+			const result = await getCommitDiff({sha: validSha});
+
+			expect(isSuccess(result)).toBe(false);
+		});
+
+		it('fails when the commit touches too many files to render', async () => {
+			const manyFiles = Array.from(
+				{length: 201},
+				(_, i) => `source/file-${i}.ts`,
+			);
+			mockGitForFiles(manyFiles);
+
+			const result = await getCommitDiff({sha: validSha});
+
+			expect(isSuccess(result)).toBe(false);
+		});
+
+		it('propagates a diff-tree failure', async () => {
+			vi.mocked(execGit).mockResolvedValue(failed('bad object'));
+
+			const result = await getCommitDiff({sha: validSha});
+
+			expect(isSuccess(result)).toBe(false);
 		});
 	});
 


### PR DESCRIPTION
## Summary
- Click a commit dot on the scrubber to see its diff inline, instead of opening it in an external editor.
- A ticket's new **Code** tab lists every commit whose message is prefixed with its ref, each as a commit/file accordion tree — expand a file to see its diff.
- Uses `@pierre/diffs` (Shiki-based) for syntax-highlighted split diffs.

## What's in
- `EC1P9JP` — `getCommitDiff`: a commit's diff as structured data (server), plus a `commit:diff:get` websocket message.
- `BJF4BP0` — `getCommitsForRef`: list commits linked to a ticket by ref prefix.
- `12G0CG9` — `DiffPanel`/`Aside` width for the two-column diff layout; also fixes a real build issue found along the way — `@pierre/diffs` was pulling Shiki's entire bundled language/theme set into a single-file esbuild bundle (~12.5mb). Switched to code-splitting (main.js → 2.6mb, languages/themes load lazily) and updated the SEA packaging script to embed the full chunked output instead of a fixed file list. Verified against a real packaged SEA binary, not just the dev build.
- `F7CKBVM` — wires the scrubber's commit-dot click to the inline diff panel.
- `QG9544B` — the ticket's Code tab.

## Review
Ran `/code-review` against this diff and fixed what it found:
- A cross-ticket race where switching tickets quickly while the Code tab is open could show the wrong ticket's commits (now correlated by issueId, same fix pattern as the commit-diff request).
- Merge commits showed as "no changes" (`git diff-tree` reports nothing for a merge without `-m`; switched to a plain two-tree diff against the first parent).
- Ref matching was case-sensitive, unlike the rest of the codebase's ref-matching convention.
- A failed per-commit diff load in the Code tab got stuck showing the error forever (no retry path).
- The board's horizontal-scroll-position spacer still assumed the old fixed panel width, which could now be wider.
- Unbounded concurrent `git show` subprocesses for large commits — now batched.

## Left out deliberately
A ticket for an MCP tool to create ref-prefixed commits (`5S52AC8`) is **not** in this PR. It commits into the user's own repo, and a test (`git-safety.test.ts`) enforces that only `init.cmd.ts` may ever do that — a guard that exists because of a real past incident. Left for a separate decision rather than widening that allowlist myself.

## Test plan
- [x] `npm run build` (typecheck)
- [x] `npm test` (605 tests, prettier)
- [x] `npm run test:e2e` (Docker, includes the reboot/replay suite)
- [x] `npm run test:collab` (Docker)
- [x] `npm run test:gui` (43 Playwright tests)
- [x] Manually verified both entry points live in a browser against this repo's own real board/git history
- [x] Verified the packaged SEA binary serves the code-split GUI bundle correctly