### PR TITLE
Diff line selection: comment or file a linked ticket

### DIFF
--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -19,6 +19,10 @@ import {InitProjectScreen} from './components/InitProjectScreen';
 import {Dropdown} from './components/Dropdown';
 import {Header} from './components/Header';
 import {IssueDetails} from './components/IssueDetails';
+import {
+	FileTicketParams,
+	formatSelectionLabel,
+} from './components/IssueCommits';
 import {BulkDetails} from './components/BulkDetails';
 import {SwimlaneColumn} from './components/SwimlaneColumn';
 import {GlobalScrollbarStyles} from './components/GlobalScrollbarStyles';
@@ -194,6 +198,15 @@ export const App = () => {
 
 	const boardMenuRef = useRef<HTMLDivElement | null>(null);
 	const socketRef = useRef<WebSocket | null>(null);
+	// Set right before an issues:create request that came from "File ticket"
+	// on a diff selection, consumed by that request's own issues:create:result
+	// reply (not the issue:created broadcast, which fires for every creation
+	// on the board) — that's how the origin ticket's back-comment knows which
+	// creation to react to.
+	const pendingFileTicketOrigin = useRef<{
+		originIssueId: string;
+		originRef: string;
+	} | null>(null);
 	const [reconnectTick, setReconnectTick] = useState(0);
 	// True once the automatic attempts are spent; the topbar then offers the
 	// button rather than retrying behind the reader's back forever.
@@ -464,6 +477,29 @@ export const App = () => {
 					void navigateRef.current(
 						`/board/${boardId}/issue/${nodeRef(created.id)}?tab=overview`,
 					);
+				}
+			}
+
+			// Keyed off this request's own reply rather than the issue:created
+			// broadcast above: that one fires for every creation on the board,
+			// including other people's, and would attach the back-comment to
+			// whichever creation happened to land next.
+			if (message.type === 'issues:create:result') {
+				const origin = pendingFileTicketOrigin.current;
+				pendingFileTicketOrigin.current = null;
+
+				const created = getResultValue<{id: string}>(message.payload);
+
+				if (origin && created) {
+					sendSocketJson(socket, {
+						type: 'issue:comment:add',
+						payload: {
+							issueId: origin.originIssueId,
+							body: `Filed \`${nodeRef(
+								created.id,
+							)}\` from a code selection on this ticket.`,
+						},
+					});
 				}
 			}
 
@@ -1136,6 +1172,37 @@ export const App = () => {
 		send('issue:comment:add', {issueId, body});
 	};
 
+	const fileTicketFromSelection = (
+		originIssueId: string,
+		originRef: string,
+		params: FileTicketParams,
+	) => {
+		// The leftmost swimlane, by the board's own left-to-right "not started →
+		// done" convention — a ticket filed off a code review is new work, so it
+		// belongs there rather than beside the ticket being reviewed.
+		const targetSwimlaneId = selectedBoard?.swimlanes[0]?.id;
+		if (!targetSwimlaneId) return;
+
+		const description = [
+			...(params.note ? [params.note, ''] : []),
+			`Filed from a code selection on \`${originRef}\`.`,
+			'',
+			`\`${params.filePath}\` ${formatSelectionLabel(params.range)}`,
+			'```',
+			params.snippet,
+			'```',
+		].join('\n');
+
+		pendingFileTicketOrigin.current = {originIssueId, originRef};
+
+		send('issues:create', {
+			title: params.title,
+			parentId: targetSwimlaneId,
+			description,
+			tagNames: ['from-code-comment'],
+		});
+	};
+
 	const uploadIssueAttachments = async (issueId: string, files: File[]) => {
 		for (const file of files) {
 			setAttachmentUploadStatus({state: 'uploading', name: file.name});
@@ -1546,6 +1613,7 @@ export const App = () => {
 							onRemoveAssignee={removeIssueAssignee}
 							onAddComment={addIssueComment}
 							onDeleteComment={deleteIssueComment}
+							onFileTicket={fileTicketFromSelection}
 							attachments={attachmentsByIssueId[selectedIssue.id] ?? []}
 							attachmentUploadStatus={attachmentUploadStatus}
 							onUploadAttachments={uploadIssueAttachments}

--- a/source/gui/client/components/DiffPanel.tsx
+++ b/source/gui/client/components/DiffPanel.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import {DiffFileInput, FileContents, MultiFileDiff} from '@pierre/diffs/react';
+import {
+	DiffFileInput,
+	FileContents,
+	MultiFileDiff,
+	SelectedLineRange,
+} from '@pierre/diffs/react';
 import {GUI_THEME} from '../lib/gui-theme';
 import {GuiCommitDiffFile} from '../lib/gui-state.model';
 import {Button} from './Button';
@@ -32,9 +37,16 @@ const toDiffFileInput = (file: GuiCommitDiffFile): DiffFileInput => {
 export const FileDiffView = ({
 	file,
 	diffStyle,
+	selectedLines,
+	onSelectionEnd,
 }: {
 	file: GuiCommitDiffFile;
 	diffStyle: 'split' | 'unified';
+	// Undefined (the DiffPanel scrubber-dot flow's default) leaves selection
+	// off entirely — enabling it costs nothing there, but there's no ticket
+	// for a selection to attach to in that flow, so it stays opt-in.
+	selectedLines?: SelectedLineRange | null;
+	onSelectionEnd?: (range: SelectedLineRange | null) => void;
 }) => (
 	<div
 		style={{
@@ -46,7 +58,14 @@ export const FileDiffView = ({
 	>
 		<MultiFileDiff
 			{...toDiffFileInput(file)}
-			options={{diffStyle, theme: PIERRE_THEME}}
+			options={{
+				diffStyle,
+				theme: PIERRE_THEME,
+				enableLineSelection: onSelectionEnd !== undefined,
+				controlledSelection: onSelectionEnd !== undefined,
+				onLineSelectionEnd: onSelectionEnd,
+			}}
+			selectedLines={selectedLines}
 		/>
 	</div>
 );

--- a/source/gui/client/components/DiffPanel.tsx
+++ b/source/gui/client/components/DiffPanel.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {
 	DiffFileInput,
+	DiffLineAnnotation,
 	FileContents,
 	MultiFileDiff,
 	SelectedLineRange,
@@ -34,11 +35,13 @@ const toDiffFileInput = (file: GuiCommitDiffFile): DiffFileInput => {
 	return {oldFile, newFile};
 };
 
-export const FileDiffView = ({
+export const FileDiffView = <LAnnotation = undefined,>({
 	file,
 	diffStyle,
 	selectedLines,
 	onSelectionEnd,
+	lineAnnotations,
+	renderAnnotation,
 }: {
 	file: GuiCommitDiffFile;
 	diffStyle: 'split' | 'unified';
@@ -47,6 +50,10 @@ export const FileDiffView = ({
 	// for a selection to attach to in that flow, so it stays opt-in.
 	selectedLines?: SelectedLineRange | null;
 	onSelectionEnd?: (range: SelectedLineRange | null) => void;
+	lineAnnotations?: DiffLineAnnotation<LAnnotation>[];
+	renderAnnotation?: (
+		annotation: DiffLineAnnotation<LAnnotation>,
+	) => React.ReactNode;
 }) => (
 	<div
 		style={{
@@ -64,8 +71,14 @@ export const FileDiffView = ({
 				enableLineSelection: onSelectionEnd !== undefined,
 				controlledSelection: onSelectionEnd !== undefined,
 				onLineSelectionEnd: onSelectionEnd,
+				// Signals a line is selectable before the user has tried dragging —
+				// otherwise the whole selection/comment feature is invisible until
+				// discovered by accident.
+				lineHoverHighlight: onSelectionEnd !== undefined ? 'both' : 'disabled',
 			}}
 			selectedLines={selectedLines}
+			lineAnnotations={lineAnnotations}
+			renderAnnotation={renderAnnotation}
 		/>
 	</div>
 );

--- a/source/gui/client/components/FileTicketModal.tsx
+++ b/source/gui/client/components/FileTicketModal.tsx
@@ -1,0 +1,156 @@
+import {useState} from 'react';
+import {GUI_THEME} from '../lib/gui-theme';
+import {Button} from './Button';
+import {Textarea} from './FormPrimitives';
+
+// Same overlay/panel language as CreateNodeModal, but with the extra fields
+// (note, read-only snippet) that a bare title-only modal doesn't have room for.
+export const FileTicketModal = ({
+	defaultTitle,
+	snippetLabel,
+	snippet,
+	onCreate,
+	onClose,
+}: {
+	defaultTitle: string;
+	snippetLabel: string;
+	snippet: string;
+	onCreate: (params: {title: string; note: string}) => void;
+	onClose: () => void;
+}) => {
+	const [title, setTitle] = useState(defaultTitle);
+	const [note, setNote] = useState('');
+
+	const submit = () => {
+		const trimmedTitle = title.trim();
+		if (!trimmedTitle) return;
+
+		onCreate({title: trimmedTitle, note: note.trim()});
+	};
+
+	return (
+		<div
+			style={{
+				position: 'fixed',
+				inset: 0,
+				background: 'rgba(0, 0, 0, 0.25)',
+				backdropFilter: 'blur(.5px)',
+				display: 'flex',
+				alignItems: 'center',
+				justifyContent: 'center',
+				zIndex: 1000,
+			}}
+			onMouseDown={onClose}
+		>
+			<form
+				onSubmit={event => {
+					event.preventDefault();
+					submit();
+				}}
+				onMouseDown={event => event.stopPropagation()}
+				style={{
+					marginTop: '-120px',
+					width: 460,
+					maxHeight: '70vh',
+					display: 'flex',
+					flexDirection: 'column',
+					background: GUI_THEME.panel,
+					border: `1px solid ${GUI_THEME.line}`,
+					borderRadius: 12,
+					padding: 20,
+				}}
+			>
+				<div
+					style={{
+						color: GUI_THEME.accent,
+						fontSize: 10,
+						marginBottom: 8,
+						letterSpacing: 1,
+						textTransform: 'uppercase',
+					}}
+				>
+					File a ticket
+				</div>
+
+				<input
+					autoFocus
+					value={title}
+					placeholder="Ticket title"
+					onChange={event => setTitle(event.target.value)}
+					onKeyDown={event => {
+						if (event.key === 'Escape') onClose();
+					}}
+					style={{
+						width: '100%',
+						boxSizing: 'border-box',
+						background: GUI_THEME.bg,
+						color: GUI_THEME.primary,
+						border: `1px solid ${GUI_THEME.line}`,
+						borderRadius: 8,
+						padding: '10px',
+						font: 'inherit',
+						fontSize: 12,
+						outline: 'none',
+						boxShadow: `inset 0 0 0 1px ${GUI_THEME.accent}22`,
+					}}
+				/>
+
+				<Textarea
+					maxLength={Number.MAX_SAFE_INTEGER}
+					value={note}
+					placeholder="Add a note (optional)"
+					onChange={event => setNote(event.target.value)}
+					style={{
+						marginTop: 10,
+						minHeight: 45,
+						font: 'inherit',
+						fontSize: 12,
+					}}
+				/>
+
+				<div
+					style={{
+						marginTop: 10,
+						color: GUI_THEME.secondary,
+						fontSize: 11,
+					}}
+				>
+					{snippetLabel}
+				</div>
+				<pre
+					style={{
+						margin: '4px 0 0',
+						padding: '10px 12px',
+						background: GUI_THEME.bg,
+						border: `1px solid ${GUI_THEME.line}`,
+						borderRadius: 8,
+						overflow: 'auto',
+						fontFamily:
+							'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+						fontSize: 12,
+						color: GUI_THEME.primary,
+					}}
+				>
+					{snippet}
+				</pre>
+
+				<div
+					style={{
+						display: 'flex',
+						justifyContent: 'flex-end',
+						gap: 10,
+						marginTop: 16,
+					}}
+				>
+					<Button type="button" variant="ghost" onClick={onClose}>
+						cancel
+					</Button>
+
+					<Button type="submit" variant="primary" disabled={!title.trim()}>
+						file ticket
+					</Button>
+				</div>
+			</form>
+		</div>
+	);
+};

--- a/source/gui/client/components/IssueComments.tsx
+++ b/source/gui/client/components/IssueComments.tsx
@@ -4,6 +4,7 @@ import {Button} from './Button';
 import {ActionRow, Empty, Textarea} from './FormPrimitives';
 import {GuiComment, GuiUser} from '../lib/gui-state.model';
 import {timeAgo} from '../lib/gui-format.helper';
+import {stripDiffCommentMarker} from './IssueCommits';
 import {MarkdownContent} from './MarkdownContent';
 import {MAX_COMMENT_LENGTH} from '../../../lib/utils/comment.limits.js';
 
@@ -38,13 +39,19 @@ export const IssueComments = ({
 		setBody('');
 	};
 
+	// Newest first: the most recent activity is what a reader coming back to
+	// a ticket wants to see without scrolling.
+	const ordered = [...comments].sort(
+		(a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0),
+	);
+
 	return (
 		<div>
 			{comments.length === 0 ? (
 				<Empty>No comments</Empty>
 			) : (
 				<div style={{display: 'flex', flexDirection: 'column', gap: 12}}>
-					{comments.map(comment => (
+					{ordered.map(comment => (
 						<div
 							key={comment.id}
 							style={{
@@ -88,7 +95,10 @@ export const IssueComments = ({
 									)}
 							</div>
 
-							<MarkdownContent content={comment.body} softBreaks />
+							<MarkdownContent
+								content={stripDiffCommentMarker(comment.body)}
+								softBreaks
+							/>
 						</div>
 					))}
 				</div>

--- a/source/gui/client/components/IssueCommits.test.ts
+++ b/source/gui/client/components/IssueCommits.test.ts
@@ -1,0 +1,74 @@
+import {describe, expect, it} from 'vitest';
+import {SelectedLineRange} from '@pierre/diffs/react';
+import {extractSnippet, formatSelectionLabel} from './IssueCommits';
+import {GuiCommitDiffFile} from '../lib/gui-state.model';
+
+const file: GuiCommitDiffFile = {
+	path: 'source/a.ts',
+	before: 'before one\nbefore two\nbefore three\nbefore four',
+	after: 'after one\nafter two\nafter three\nafter four',
+};
+
+describe('extractSnippet', () => {
+	it('slices the added side when side and endSide are both additions', () => {
+		const range: SelectedLineRange = {start: 2, end: 3, side: 'additions'};
+
+		expect(extractSnippet(file, range)).toBe('after two\nafter three');
+	});
+
+	it('slices the removed side when side is deletions', () => {
+		const range: SelectedLineRange = {start: 1, end: 2, side: 'deletions'};
+
+		expect(extractSnippet(file, range)).toBe('before one\nbefore two');
+	});
+
+	it('defaults endSide to side when endSide is omitted', () => {
+		const range: SelectedLineRange = {start: 4, end: 4, side: 'additions'};
+
+		expect(extractSnippet(file, range)).toBe('after four');
+	});
+
+	it('quotes both halves when a selection spans deletions into additions', () => {
+		const range: SelectedLineRange = {
+			start: 3,
+			side: 'deletions',
+			end: 2,
+			endSide: 'additions',
+		};
+
+		expect(extractSnippet(file, range)).toBe(
+			'before three\nbefore four\nafter one\nafter two',
+		);
+	});
+});
+
+describe('formatSelectionLabel', () => {
+	it('labels a single selected line as singular', () => {
+		expect(formatSelectionLabel({start: 5, end: 5, side: 'additions'})).toBe(
+			'line 5 (added)',
+		);
+	});
+
+	it('labels a multi-line selection as a range', () => {
+		expect(formatSelectionLabel({start: 5, end: 8, side: 'additions'})).toBe(
+			'lines 5-8 (added)',
+		);
+	});
+
+	it('labels a deletions-side selection as removed', () => {
+		expect(formatSelectionLabel({start: 1, end: 2, side: 'deletions'})).toBe(
+			'lines 1-2 (removed)',
+		);
+	});
+
+	it('labels a mixed-side selection by its end side', () => {
+		const range: SelectedLineRange = {
+			start: 1,
+			side: 'deletions',
+			end: 2,
+			endSide: 'additions',
+		};
+
+		expect(formatSelectionLabel(range)).toBe('lines 1-2 (added)');
+	});
+});

--- a/source/gui/client/components/IssueCommits.test.ts
+++ b/source/gui/client/components/IssueCommits.test.ts
@@ -118,6 +118,25 @@ describe('encodeDiffCommentMarker / parseDiffCommentMeta', () => {
 		).toBeNull();
 	});
 
+	// Regression guard: `-->` inside a note used to terminate the HTML-comment
+	// marker early, truncating the JSON (annotation silently lost) and leaving
+	// the remainder rendered as visible garbage in the comment.
+	it('round-trips a note containing an HTML comment terminator', () => {
+		const meta = {
+			filePath: 'source/a.ts',
+			start: 1,
+			side: 'additions' as const,
+			end: 2,
+			endSide: 'additions' as const,
+			note: 'this --> that',
+		};
+
+		const body = `this --> that\n\n${encodeDiffCommentMarker(meta)}\nrest`;
+
+		expect(parseDiffCommentMeta(body)).toEqual(meta);
+		expect(stripDiffCommentMarker(body)).toBe('this --> that\n\nrest');
+	});
+
 	it('returns null when a required field is missing', () => {
 		const incomplete = JSON.stringify({filePath: 'a.ts', start: 1});
 

--- a/source/gui/client/components/IssueCommits.test.ts
+++ b/source/gui/client/components/IssueCommits.test.ts
@@ -1,7 +1,15 @@
 import {describe, expect, it} from 'vitest';
 import {SelectedLineRange} from '@pierre/diffs/react';
-import {extractSnippet, formatSelectionLabel} from './IssueCommits';
-import {GuiCommitDiffFile} from '../lib/gui-state.model';
+import {
+	dedent,
+	encodeDiffCommentMarker,
+	extractSnippet,
+	findDiffCommentsForFile,
+	formatSelectionLabel,
+	parseDiffCommentMeta,
+	stripDiffCommentMarker,
+} from './IssueCommits';
+import {GuiComment, GuiCommitDiffFile} from '../lib/gui-state.model';
 
 const file: GuiCommitDiffFile = {
 	path: 'source/a.ts',
@@ -39,6 +47,142 @@ describe('extractSnippet', () => {
 		expect(extractSnippet(file, range)).toBe(
 			'before three\nbefore four\nafter one\nafter two',
 		);
+	});
+});
+
+describe('dedent', () => {
+	it('strips the common leading whitespace shared by every non-blank line', () => {
+		const snippet = '\t\t\tfirst\n\t\t\tsecond\n\t\t\t\tindented further';
+
+		expect(dedent(snippet)).toBe('first\nsecond\n\tindented further');
+	});
+
+	it('ignores blank lines when computing the common indent', () => {
+		const snippet = '\t\tfirst\n\n\t\tsecond';
+
+		expect(dedent(snippet)).toBe('first\n\nsecond');
+	});
+
+	it('leaves an already-flush snippet unchanged', () => {
+		expect(dedent('first\nsecond')).toBe('first\nsecond');
+	});
+
+	it('leaves a snippet of only blank lines unchanged', () => {
+		expect(dedent('\n\n')).toBe('\n\n');
+	});
+});
+
+const guiComment = (
+	body: string,
+	overrides: Partial<GuiComment> = {},
+): GuiComment => ({
+	id: 'c1',
+	issueId: 'issue1',
+	body,
+	author: {id: 'u1', name: 'Ada', color: '#fff'},
+	createdAt: 1_700_000_000_000,
+	...overrides,
+});
+
+describe('encodeDiffCommentMarker / parseDiffCommentMeta', () => {
+	it('round-trips through a full comment body', () => {
+		const meta = {
+			filePath: 'source/a.ts',
+			start: 2,
+			side: 'additions' as const,
+			end: 4,
+			endSide: 'additions' as const,
+			note: 'worth a look',
+		};
+
+		const body = [
+			'worth a look',
+			'',
+			encodeDiffCommentMarker(meta),
+			'`source/a.ts` lines 2-4 (added)',
+			'```',
+			'snippet',
+			'```',
+		].join('\n');
+
+		expect(parseDiffCommentMeta(body)).toEqual(meta);
+	});
+
+	it('returns null for a plain comment with no marker', () => {
+		expect(parseDiffCommentMeta('just a regular comment')).toBeNull();
+	});
+
+	it('returns null for malformed JSON inside the marker', () => {
+		expect(
+			parseDiffCommentMeta('<!-- epiq-diff-comment:{not json} -->'),
+		).toBeNull();
+	});
+
+	it('returns null when a required field is missing', () => {
+		const incomplete = JSON.stringify({filePath: 'a.ts', start: 1});
+
+		expect(
+			parseDiffCommentMeta(`<!-- epiq-diff-comment:${incomplete} -->`),
+		).toBeNull();
+	});
+});
+
+// Regression guard: react-markdown does not drop a raw `<!-- ... -->` HTML
+// comment on its own (it renders as literal text without rehype-raw) — the
+// marker leaking into a rendered comment was caught live and is exactly what
+// this strips before the body ever reaches the markdown renderer.
+describe('stripDiffCommentMarker', () => {
+	it('removes the marker and its trailing newline', () => {
+		const meta = {
+			filePath: 'a.ts',
+			start: 1,
+			side: 'additions' as const,
+			end: 1,
+			endSide: 'additions' as const,
+			note: 'note',
+		};
+		const body = `note\n\n${encodeDiffCommentMarker(
+			meta,
+		)}\nrest of the comment`;
+
+		expect(stripDiffCommentMarker(body)).toBe('note\n\nrest of the comment');
+	});
+
+	it('leaves a plain comment with no marker unchanged', () => {
+		expect(stripDiffCommentMarker('just a regular comment')).toBe(
+			'just a regular comment',
+		);
+	});
+});
+
+describe('findDiffCommentsForFile', () => {
+	const meta = {
+		filePath: 'source/a.ts',
+		start: 1,
+		side: 'additions' as const,
+		end: 1,
+		endSide: 'additions' as const,
+		note: '',
+	};
+
+	it('matches comments whose marker targets the given file', () => {
+		const comment = guiComment(`${encodeDiffCommentMarker(meta)}\ntext`);
+
+		expect(findDiffCommentsForFile([comment], 'source/a.ts')).toEqual([
+			{comment, meta},
+		]);
+	});
+
+	it('excludes comments targeting a different file', () => {
+		const comment = guiComment(encodeDiffCommentMarker(meta));
+
+		expect(findDiffCommentsForFile([comment], 'source/other.ts')).toEqual([]);
+	});
+
+	it('excludes plain (non-diff) comments', () => {
+		const comment = guiComment('just a regular comment');
+
+		expect(findDiffCommentsForFile([comment], 'source/a.ts')).toEqual([]);
 	});
 });
 

--- a/source/gui/client/components/IssueCommits.tsx
+++ b/source/gui/client/components/IssueCommits.tsx
@@ -113,8 +113,15 @@ const DIFF_COMMENT_MARKER = /<!--\s*epiq-diff-comment:(.+?)-->\n?/;
 export const stripDiffCommentMarker = (body: string): string =>
 	body.replace(DIFF_COMMENT_MARKER, '');
 
+// `>` is escaped so a note containing `-->` cannot terminate the marker early
+// — that truncated the JSON (losing the annotation) and left the remainder
+// visible as garbage in the rendered comment. JSON.parse decodes > back
+// to `>`, so the round trip is exact.
 export const encodeDiffCommentMarker = (meta: DiffCommentMeta): string =>
-	`<!-- epiq-diff-comment:${JSON.stringify(meta)} -->`;
+	`<!-- epiq-diff-comment:${JSON.stringify(meta).replaceAll(
+		'>',
+		'\\u003e',
+	)} -->`;
 
 const isSelectionSide = (value: unknown): value is SelectedLineRange['side'] =>
 	value === 'additions' || value === 'deletions';

--- a/source/gui/client/components/IssueCommits.tsx
+++ b/source/gui/client/components/IssueCommits.tsx
@@ -1,7 +1,16 @@
 import React, {useState} from 'react';
-import {SelectedLineRange} from '@pierre/diffs/react';
-import {GuiCommitDiffFile, GuiRefCommitEntry} from '../lib/gui-state.model';
+import {
+	DiffLineAnnotation,
+	SelectedLineRange,
+	SelectionSide,
+} from '@pierre/diffs/react';
+import {
+	GuiComment,
+	GuiCommitDiffFile,
+	GuiRefCommitEntry,
+} from '../lib/gui-state.model';
 import {GUI_THEME} from '../lib/gui-theme';
+import {timeAgo} from '../lib/gui-format.helper';
 import {ActionRow, Textarea} from './FormPrimitives';
 import {Button} from './Button';
 import {CopyRef} from './CopyRef';
@@ -10,6 +19,7 @@ import {Empty} from './FormPrimitives';
 import {FileDiffView} from './DiffPanel';
 import {IconChevronDown} from './IconChevronDown';
 import {IconChevronRight} from './IconChevronRight';
+import {IconComment} from './IconComment';
 
 export type CommitDiffState = {
 	loading: boolean;
@@ -61,6 +71,90 @@ export const formatSelectionLabel = (range: SelectedLineRange): string => {
 		? `line ${range.start} (${sideLabel})`
 		: `lines ${range.start}-${range.end} (${sideLabel})`;
 };
+
+// Quoted lines keep their real source indentation (often several tabs deep
+// inside nested JSX) — fine in the wide diff, unreadable in a narrow comment
+// box. Strips the whitespace every non-blank line shares, same as most
+// editors' own "copy" behavior.
+export const dedent = (snippet: string): string => {
+	const lines = snippet.split('\n');
+
+	const commonIndent = lines
+		.filter(line => line.trim() !== '')
+		.reduce<number | null>((min, line) => {
+			const indent = /^[ \t]*/.exec(line)?.[0].length ?? 0;
+			return min === null ? indent : Math.min(min, indent);
+		}, null);
+
+	if (!commonIndent) return snippet;
+
+	return lines.map(line => line.slice(commonIndent)).join('\n');
+};
+
+// Metadata for a diff-selection comment, carried as an HTML-comment-shaped
+// marker in the posted body — round-trips through storage intact with no
+// separate field needed on GuiComment. react-markdown does *not* silently
+// drop `<!-- ... -->` without rehype-raw as might be assumed — it renders
+// the literal text — so every render path showing a comment body must strip
+// it via stripDiffCommentMarker below rather than relying on the markdown
+// renderer to hide it.
+type DiffCommentMeta = {
+	filePath: string;
+	start: number;
+	side: SelectionSide;
+	end: number;
+	endSide: SelectionSide;
+	note: string;
+};
+
+const DIFF_COMMENT_MARKER = /<!--\s*epiq-diff-comment:(.+?)-->\n?/;
+
+export const stripDiffCommentMarker = (body: string): string =>
+	body.replace(DIFF_COMMENT_MARKER, '');
+
+export const encodeDiffCommentMarker = (meta: DiffCommentMeta): string =>
+	`<!-- epiq-diff-comment:${JSON.stringify(meta)} -->`;
+
+const isSelectionSide = (value: unknown): value is SelectedLineRange['side'] =>
+	value === 'additions' || value === 'deletions';
+
+export const parseDiffCommentMeta = (body: string): DiffCommentMeta | null => {
+	const match = DIFF_COMMENT_MARKER.exec(body);
+	if (!match?.[1]) return null;
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(match[1]);
+	} catch {
+		return null;
+	}
+
+	const meta = parsed as Partial<DiffCommentMeta> | null;
+
+	if (
+		typeof meta?.filePath !== 'string' ||
+		typeof meta.start !== 'number' ||
+		typeof meta.end !== 'number' ||
+		typeof meta.note !== 'string' ||
+		!isSelectionSide(meta.side) ||
+		!isSelectionSide(meta.endSide)
+	) {
+		return null;
+	}
+
+	return meta as DiffCommentMeta;
+};
+
+export type DiffComment = {comment: GuiComment; meta: DiffCommentMeta};
+
+export const findDiffCommentsForFile = (
+	comments: GuiComment[],
+	filePath: string,
+): DiffComment[] =>
+	comments.flatMap(comment => {
+		const meta = parseDiffCommentMeta(comment.body);
+		return meta && meta.filePath === filePath ? [{comment, meta}] : [];
+	});
 
 // The timeline rail: a dot per commit, in the scrubber's own commit-series
 // color, connected to the next by a line. RAIL_DOT_OFFSET lines the dot up
@@ -154,11 +248,25 @@ const SelectionToolbar = ({
 	const [note, setNote] = useState('');
 
 	const submit = () => {
-		const snippet = extractSnippet(file, selection);
+		const snippet = dedent(extractSnippet(file, selection));
 		const trimmedNote = note.trim();
+		// Matches extractSnippet's own default: a range without a reported side
+		// is expected to be a modern-git edge case at worst, not a real gap.
+		const side = selection.side ?? 'additions';
+		const endSide = selection.endSide ?? side;
+
+		const marker = encodeDiffCommentMarker({
+			filePath: file.path,
+			start: selection.start,
+			side,
+			end: selection.end,
+			endSide,
+			note: trimmedNote,
+		});
 
 		const body = [
 			...(trimmedNote ? [trimmedNote, ''] : []),
+			marker,
 			`\`${file.path}\` ${formatSelectionLabel(selection)}`,
 			'```',
 			snippet,
@@ -174,9 +282,10 @@ const SelectionToolbar = ({
 			style={{
 				marginTop: 8,
 				padding: 10,
-				border: `1px solid ${GUI_THEME.line}`,
+				border: `1px solid ${GUI_THEME.accent}`,
 				borderRadius: 8,
-				background: GUI_THEME.panel,
+				background: GUI_THEME.tertiary,
+				boxShadow: `0 0 0 1px ${GUI_THEME.accent}33`,
 			}}
 		>
 			<div
@@ -195,13 +304,13 @@ const SelectionToolbar = ({
 				{!composing && (
 					<>
 						{onAddComment && (
-							<Button variant="ghost" onClick={() => setComposing(true)}>
+							<Button variant="primary" onClick={() => setComposing(true)}>
 								Comment
 							</Button>
 						)}
 						{/* File-ticket filing lands in a follow-up — the button previews
 						    the intended shape rather than being omitted outright. */}
-						<Button variant="ghost" disabled title="Coming soon">
+						<Button variant="default" disabled title="Coming soon">
 							File ticket
 						</Button>
 						<Button variant="ghost" onClick={onClear}>
@@ -238,20 +347,79 @@ const SelectionToolbar = ({
 	);
 };
 
+// Rendered by MultiFileDiff at the line a diff-selection comment is anchored
+// to. Just the author and note — the full body (including the requoted
+// snippet, redundant here since the diff itself is right above it) lives in
+// the Comments tab.
+const DiffCommentAnnotation = ({
+	annotation,
+}: {
+	annotation: DiffLineAnnotation<DiffComment>;
+}) => {
+	const {comment, meta} = annotation.metadata;
+
+	return (
+		<div
+			style={{
+				margin: '4px 0',
+				padding: '8px 10px',
+				border: `1px solid ${GUI_THEME.line}`,
+				borderLeft: `2px solid ${GUI_THEME.accent}`,
+				borderRadius: 6,
+				background: GUI_THEME.tertiary,
+				fontSize: 12,
+				display: 'flex',
+				alignItems: 'flex-start',
+				gap: 8,
+			}}
+		>
+			<span style={{color: GUI_THEME.accent, flexShrink: 0, marginTop: 1}}>
+				<IconComment size={12} />
+			</span>
+			<div style={{flex: 1, minWidth: 0}}>
+				<div style={{color: GUI_THEME.secondary, fontSize: 11}}>
+					{comment.author.name ?? 'unknown'}
+					{comment.createdAt && (
+						<span style={{color: GUI_THEME.dim2}}>
+							{' '}
+							· {timeAgo(comment.createdAt)}
+						</span>
+					)}
+				</div>
+				<div style={{marginTop: 2}}>
+					{meta.note || <em style={{color: GUI_THEME.dim}}>commented</em>}
+				</div>
+			</div>
+		</div>
+	);
+};
+
 const FileRow = ({
 	file,
 	expanded,
 	onToggle,
 	diffStyle,
 	onAddComment,
+	comments,
 }: {
 	file: GuiCommitDiffFile;
 	expanded: boolean;
 	onToggle: () => void;
 	diffStyle: 'split' | 'unified';
 	onAddComment?: (body: string) => void;
+	comments: GuiComment[];
 }) => {
 	const [selection, setSelection] = useState<SelectedLineRange | null>(null);
+
+	const fileComments = findDiffCommentsForFile(comments, file.path);
+
+	const lineAnnotations: DiffLineAnnotation<DiffComment>[] = fileComments.map(
+		entry => ({
+			side: entry.meta.endSide,
+			lineNumber: entry.meta.end,
+			metadata: entry,
+		}),
+	);
 
 	return (
 		<div style={{marginTop: 8}}>
@@ -279,6 +447,26 @@ const FileRow = ({
 				>
 					{file.path}
 				</span>
+				{/* Findable when collapsed — otherwise a comment left on a file with
+				    several others is easy to lose track of. */}
+				{fileComments.length > 0 && (
+					<span
+						title={`${fileComments.length} comment${
+							fileComments.length === 1 ? '' : 's'
+						}`}
+						style={{
+							display: 'inline-flex',
+							alignItems: 'center',
+							gap: 3,
+							flexShrink: 0,
+							color: GUI_THEME.accent,
+							fontSize: 10,
+						}}
+					>
+						<IconComment size={10} />
+						{fileComments.length}
+					</span>
+				)}
 			</button>
 
 			{expanded && (
@@ -288,6 +476,10 @@ const FileRow = ({
 						diffStyle={diffStyle}
 						selectedLines={selection}
 						onSelectionEnd={setSelection}
+						lineAnnotations={lineAnnotations}
+						renderAnnotation={annotation => (
+							<DiffCommentAnnotation annotation={annotation} />
+						)}
 					/>
 					{selection && (
 						<SelectionToolbar
@@ -310,8 +502,10 @@ const CommitRow = ({
 	onToggle,
 	expandedFiles,
 	onToggleFile,
+	onSetAllFilesExpanded,
 	diffStyle,
 	onAddComment,
+	comments,
 }: {
 	commit: GuiRefCommitEntry;
 	diff: CommitDiffState | undefined;
@@ -319,8 +513,10 @@ const CommitRow = ({
 	onToggle: () => void;
 	expandedFiles: Set<string>;
 	onToggleFile: (path: string) => void;
+	onSetAllFilesExpanded: (filePaths: string[], expand: boolean) => void;
 	diffStyle: 'split' | 'unified';
 	onAddComment?: (body: string) => void;
+	comments: GuiComment[];
 }) => {
 	const [hovered, setHovered] = useState(false);
 	// Also tracks focus (not just mouse hover): the copy button is a real
@@ -410,6 +606,25 @@ const CommitRow = ({
 					{diff?.loading && <Empty>Loading files…</Empty>}
 					{!diff?.loading && diff?.error && <Empty>{diff.error}</Empty>}
 
+					{diff?.files && diff.files.length > 1 && (
+						<div style={{display: 'flex', justifyContent: 'flex-end'}}>
+							<Button
+								variant="ghost"
+								onClick={() => {
+									const filePaths = diff.files!.map(file => file.path);
+									const allExpanded = filePaths.every(path =>
+										expandedFiles.has(path),
+									);
+									onSetAllFilesExpanded(filePaths, !allExpanded);
+								}}
+							>
+								{diff.files.every(file => expandedFiles.has(file.path))
+									? 'Collapse all'
+									: 'Expand all'}
+							</Button>
+						</div>
+					)}
+
 					{diff?.files?.map(file => (
 						<FileRow
 							key={file.path}
@@ -418,6 +633,7 @@ const CommitRow = ({
 							onToggle={() => onToggleFile(file.path)}
 							diffStyle={diffStyle}
 							onAddComment={onAddComment}
+							comments={comments}
 						/>
 					))}
 				</div>
@@ -447,6 +663,7 @@ export const IssueCommits = ({
 	onLoadDiff,
 	diffStyle,
 	onAddComment,
+	comments,
 }: {
 	issueRef: string;
 	commits: GuiRefCommitEntry[];
@@ -456,6 +673,7 @@ export const IssueCommits = ({
 	onLoadDiff: (sha: string) => void;
 	diffStyle: 'split' | 'unified';
 	onAddComment?: (body: string) => void;
+	comments: GuiComment[];
 }) => {
 	const [expandedShas, setExpandedShas] = useState<Set<string>>(new Set());
 	const [expandedFilesBySha, setExpandedFilesBySha] = useState<
@@ -493,6 +711,17 @@ export const IssueCommits = ({
 			}
 			return {...prev, [sha]: current};
 		});
+	};
+
+	const setAllFilesExpanded = (
+		sha: string,
+		filePaths: string[],
+		expand: boolean,
+	) => {
+		setExpandedFilesBySha(prev => ({
+			...prev,
+			[sha]: expand ? new Set(filePaths) : new Set(),
+		}));
 	};
 
 	if (loading) return <Empty>Loading commits…</Empty>;
@@ -588,8 +817,12 @@ export const IssueCommits = ({
 							onToggle={() => toggleCommit(commit.sha)}
 							expandedFiles={expandedFilesBySha[commit.sha] ?? new Set()}
 							onToggleFile={path => toggleFile(commit.sha, path)}
+							onSetAllFilesExpanded={(paths, expand) =>
+								setAllFilesExpanded(commit.sha, paths, expand)
+							}
 							diffStyle={diffStyle}
 							onAddComment={onAddComment}
+							comments={comments}
 						/>
 					</div>
 				</div>

--- a/source/gui/client/components/IssueCommits.tsx
+++ b/source/gui/client/components/IssueCommits.tsx
@@ -17,6 +17,7 @@ import {CopyRef} from './CopyRef';
 import {CopyShaButton} from './CopyShaButton';
 import {Empty} from './FormPrimitives';
 import {FileDiffView} from './DiffPanel';
+import {FileTicketModal} from './FileTicketModal';
 import {IconChevronDown} from './IconChevronDown';
 import {IconChevronRight} from './IconChevronRight';
 import {IconComment} from './IconComment';
@@ -156,6 +157,17 @@ export const findDiffCommentsForFile = (
 		return meta && meta.filePath === filePath ? [{comment, meta}] : [];
 	});
 
+// What a "File ticket" submission carries up to the caller that owns the
+// actual issues:create call and the origin-ticket back-comment — everything
+// needed to build both without the caller re-deriving any of it.
+export type FileTicketParams = {
+	filePath: string;
+	range: SelectedLineRange;
+	snippet: string;
+	title: string;
+	note: string;
+};
+
 // The timeline rail: a dot per commit, in the scrubber's own commit-series
 // color, connected to the next by a line. RAIL_DOT_OFFSET lines the dot up
 // with the header's text (padding-top plus half its line height), not the
@@ -237,18 +249,23 @@ const SelectionToolbar = ({
 	file,
 	selection,
 	onAddComment,
+	onFileTicket,
 	onClear,
 }: {
 	file: GuiCommitDiffFile;
 	selection: SelectedLineRange;
 	onAddComment?: (body: string) => void;
+	onFileTicket?: (params: FileTicketParams) => void;
 	onClear: () => void;
 }) => {
 	const [composing, setComposing] = useState(false);
+	const [filing, setFiling] = useState(false);
 	const [note, setNote] = useState('');
 
+	const snippet = dedent(extractSnippet(file, selection));
+	const selectionLabel = `${file.path} ${formatSelectionLabel(selection)}`;
+
 	const submit = () => {
-		const snippet = dedent(extractSnippet(file, selection));
 		const trimmedNote = note.trim();
 		// Matches extractSnippet's own default: a range without a reported side
 		// is expected to be a modern-git edge case at worst, not a real gap.
@@ -276,6 +293,27 @@ const SelectionToolbar = ({
 		onAddComment?.(body);
 		onClear();
 	};
+
+	if (filing) {
+		return (
+			<FileTicketModal
+				defaultTitle={selectionLabel}
+				snippetLabel={selectionLabel}
+				snippet={snippet}
+				onCreate={({title, note: filingNote}) => {
+					onFileTicket?.({
+						filePath: file.path,
+						range: selection,
+						snippet,
+						title,
+						note: filingNote,
+					});
+					onClear();
+				}}
+				onClose={onClear}
+			/>
+		);
+	}
 
 	return (
 		<div
@@ -308,11 +346,11 @@ const SelectionToolbar = ({
 								Comment
 							</Button>
 						)}
-						{/* File-ticket filing lands in a follow-up — the button previews
-						    the intended shape rather than being omitted outright. */}
-						<Button variant="default" disabled title="Coming soon">
-							File ticket
-						</Button>
+						{onFileTicket && (
+							<Button variant="default" onClick={() => setFiling(true)}>
+								File ticket
+							</Button>
+						)}
 						<Button variant="ghost" onClick={onClear}>
 							×
 						</Button>
@@ -400,6 +438,7 @@ const FileRow = ({
 	onToggle,
 	diffStyle,
 	onAddComment,
+	onFileTicket,
 	comments,
 }: {
 	file: GuiCommitDiffFile;
@@ -407,6 +446,7 @@ const FileRow = ({
 	onToggle: () => void;
 	diffStyle: 'split' | 'unified';
 	onAddComment?: (body: string) => void;
+	onFileTicket?: (params: FileTicketParams) => void;
 	comments: GuiComment[];
 }) => {
 	const [selection, setSelection] = useState<SelectedLineRange | null>(null);
@@ -486,6 +526,7 @@ const FileRow = ({
 							file={file}
 							selection={selection}
 							onAddComment={onAddComment}
+							onFileTicket={onFileTicket}
 							onClear={() => setSelection(null)}
 						/>
 					)}
@@ -505,6 +546,7 @@ const CommitRow = ({
 	onSetAllFilesExpanded,
 	diffStyle,
 	onAddComment,
+	onFileTicket,
 	comments,
 }: {
 	commit: GuiRefCommitEntry;
@@ -516,6 +558,7 @@ const CommitRow = ({
 	onSetAllFilesExpanded: (filePaths: string[], expand: boolean) => void;
 	diffStyle: 'split' | 'unified';
 	onAddComment?: (body: string) => void;
+	onFileTicket?: (params: FileTicketParams) => void;
 	comments: GuiComment[];
 }) => {
 	const [hovered, setHovered] = useState(false);
@@ -633,6 +676,7 @@ const CommitRow = ({
 							onToggle={() => onToggleFile(file.path)}
 							diffStyle={diffStyle}
 							onAddComment={onAddComment}
+							onFileTicket={onFileTicket}
 							comments={comments}
 						/>
 					))}
@@ -663,6 +707,7 @@ export const IssueCommits = ({
 	onLoadDiff,
 	diffStyle,
 	onAddComment,
+	onFileTicket,
 	comments,
 }: {
 	issueRef: string;
@@ -673,6 +718,7 @@ export const IssueCommits = ({
 	onLoadDiff: (sha: string) => void;
 	diffStyle: 'split' | 'unified';
 	onAddComment?: (body: string) => void;
+	onFileTicket?: (params: FileTicketParams) => void;
 	comments: GuiComment[];
 }) => {
 	const [expandedShas, setExpandedShas] = useState<Set<string>>(new Set());
@@ -822,6 +868,7 @@ export const IssueCommits = ({
 							}
 							diffStyle={diffStyle}
 							onAddComment={onAddComment}
+							onFileTicket={onFileTicket}
 							comments={comments}
 						/>
 					</div>

--- a/source/gui/client/components/IssueCommits.tsx
+++ b/source/gui/client/components/IssueCommits.tsx
@@ -1,6 +1,9 @@
 import React, {useState} from 'react';
+import {SelectedLineRange} from '@pierre/diffs/react';
 import {GuiCommitDiffFile, GuiRefCommitEntry} from '../lib/gui-state.model';
 import {GUI_THEME} from '../lib/gui-theme';
+import {ActionRow, Textarea} from './FormPrimitives';
+import {Button} from './Button';
 import {CopyRef} from './CopyRef';
 import {CopyShaButton} from './CopyShaButton';
 import {Empty} from './FormPrimitives';
@@ -23,6 +26,40 @@ const stripRefPrefix = (subject: string, ref: string): string => {
 	return subject.toUpperCase().startsWith(prefix.toUpperCase())
 		? subject.slice(prefix.length)
 		: subject;
+};
+
+// A selection's start/end are the real (gutter-displayed) line numbers within
+// whichever side they belong to — 'deletions' means the old file, 'additions'
+// the new one. A range can span both sides (dragged from a removed line into
+// an added one in split view): quote both halves rather than picking one.
+export const extractSnippet = (
+	file: GuiCommitDiffFile,
+	range: SelectedLineRange,
+): string => {
+	const linesFor = (side: SelectedLineRange['side']) =>
+		(side === 'deletions' ? file.before : file.after).split('\n');
+
+	const endSide = range.endSide ?? range.side;
+
+	if (endSide === range.side) {
+		return linesFor(range.side)
+			.slice(range.start - 1, range.end)
+			.join('\n');
+	}
+
+	const startHalf = linesFor(range.side).slice(range.start - 1);
+	const endHalf = linesFor(endSide).slice(0, range.end);
+
+	return [...startHalf, ...endHalf].join('\n');
+};
+
+export const formatSelectionLabel = (range: SelectedLineRange): string => {
+	const endSide = range.endSide ?? range.side;
+	const sideLabel = endSide === 'deletions' ? 'removed' : 'added';
+
+	return range.start === range.end
+		? `line ${range.start} (${sideLabel})`
+		: `lines ${range.start}-${range.end} (${sideLabel})`;
 };
 
 // The timeline rail: a dot per commit, in the scrubber's own commit-series
@@ -98,43 +135,173 @@ const DiffStat = ({
 	);
 };
 
+// The bar that appears under a diff once a line range is selected — a plain
+// two-step flow (pick an action, then write the optional note) rather than
+// trying to float it exactly over the selection, which the diff library
+// doesn't hand back pixel coordinates for.
+const SelectionToolbar = ({
+	file,
+	selection,
+	onAddComment,
+	onClear,
+}: {
+	file: GuiCommitDiffFile;
+	selection: SelectedLineRange;
+	onAddComment?: (body: string) => void;
+	onClear: () => void;
+}) => {
+	const [composing, setComposing] = useState(false);
+	const [note, setNote] = useState('');
+
+	const submit = () => {
+		const snippet = extractSnippet(file, selection);
+		const trimmedNote = note.trim();
+
+		const body = [
+			...(trimmedNote ? [trimmedNote, ''] : []),
+			`\`${file.path}\` ${formatSelectionLabel(selection)}`,
+			'```',
+			snippet,
+			'```',
+		].join('\n');
+
+		onAddComment?.(body);
+		onClear();
+	};
+
+	return (
+		<div
+			style={{
+				marginTop: 8,
+				padding: 10,
+				border: `1px solid ${GUI_THEME.line}`,
+				borderRadius: 8,
+				background: GUI_THEME.panel,
+			}}
+		>
+			<div
+				style={{
+					display: 'flex',
+					alignItems: 'center',
+					gap: 8,
+					fontSize: 11,
+					color: GUI_THEME.secondary,
+				}}
+			>
+				<span style={{flex: 1}}>
+					{file.path} {formatSelectionLabel(selection)}
+				</span>
+
+				{!composing && (
+					<>
+						{onAddComment && (
+							<Button variant="ghost" onClick={() => setComposing(true)}>
+								Comment
+							</Button>
+						)}
+						{/* File-ticket filing lands in a follow-up — the button previews
+						    the intended shape rather than being omitted outright. */}
+						<Button variant="ghost" disabled title="Coming soon">
+							File ticket
+						</Button>
+						<Button variant="ghost" onClick={onClear}>
+							×
+						</Button>
+					</>
+				)}
+			</div>
+
+			{composing && (
+				<div style={{marginTop: 8}}>
+					<Textarea
+						autoFocus
+						maxLength={Number.MAX_SAFE_INTEGER}
+						value={note}
+						placeholder="Add a note (optional)"
+						onChange={event => setNote(event.target.value)}
+						onKeyDown={event => {
+							if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+								submit();
+							}
+						}}
+						style={{minHeight: 45, font: 'inherit', fontSize: 12}}
+					/>
+					<ActionRow>
+						<Button variant="ghost" onClick={onClear}>
+							Cancel
+						</Button>
+						<Button onClick={submit}>Post comment</Button>
+					</ActionRow>
+				</div>
+			)}
+		</div>
+	);
+};
+
 const FileRow = ({
 	file,
 	expanded,
 	onToggle,
 	diffStyle,
+	onAddComment,
 }: {
 	file: GuiCommitDiffFile;
 	expanded: boolean;
 	onToggle: () => void;
 	diffStyle: 'split' | 'unified';
-}) => (
-	<div style={{marginTop: 8}}>
-		<button
-			onClick={onToggle}
-			aria-expanded={expanded}
-			style={{...disclosureStyle, color: GUI_THEME.secondary, padding: '4px 0'}}
-		>
-			{expanded ? (
-				<IconChevronDown size={12} />
-			) : (
-				<IconChevronRight size={12} />
-			)}
-			<span
+	onAddComment?: (body: string) => void;
+}) => {
+	const [selection, setSelection] = useState<SelectedLineRange | null>(null);
+
+	return (
+		<div style={{marginTop: 8}}>
+			<button
+				onClick={onToggle}
+				aria-expanded={expanded}
 				style={{
-					fontFamily: 'ui-monospace, monospace',
-					overflow: 'hidden',
-					textOverflow: 'ellipsis',
-					whiteSpace: 'nowrap',
+					...disclosureStyle,
+					color: GUI_THEME.secondary,
+					padding: '4px 0',
 				}}
 			>
-				{file.path}
-			</span>
-		</button>
+				{expanded ? (
+					<IconChevronDown size={12} />
+				) : (
+					<IconChevronRight size={12} />
+				)}
+				<span
+					style={{
+						fontFamily: 'ui-monospace, monospace',
+						overflow: 'hidden',
+						textOverflow: 'ellipsis',
+						whiteSpace: 'nowrap',
+					}}
+				>
+					{file.path}
+				</span>
+			</button>
 
-		{expanded && <FileDiffView file={file} diffStyle={diffStyle} />}
-	</div>
-);
+			{expanded && (
+				<>
+					<FileDiffView
+						file={file}
+						diffStyle={diffStyle}
+						selectedLines={selection}
+						onSelectionEnd={setSelection}
+					/>
+					{selection && (
+						<SelectionToolbar
+							file={file}
+							selection={selection}
+							onAddComment={onAddComment}
+							onClear={() => setSelection(null)}
+						/>
+					)}
+				</>
+			)}
+		</div>
+	);
+};
 
 const CommitRow = ({
 	commit,
@@ -144,6 +311,7 @@ const CommitRow = ({
 	expandedFiles,
 	onToggleFile,
 	diffStyle,
+	onAddComment,
 }: {
 	commit: GuiRefCommitEntry;
 	diff: CommitDiffState | undefined;
@@ -152,6 +320,7 @@ const CommitRow = ({
 	expandedFiles: Set<string>;
 	onToggleFile: (path: string) => void;
 	diffStyle: 'split' | 'unified';
+	onAddComment?: (body: string) => void;
 }) => {
 	const [hovered, setHovered] = useState(false);
 	// Also tracks focus (not just mouse hover): the copy button is a real
@@ -248,6 +417,7 @@ const CommitRow = ({
 							expanded={expandedFiles.has(file.path)}
 							onToggle={() => onToggleFile(file.path)}
 							diffStyle={diffStyle}
+							onAddComment={onAddComment}
 						/>
 					))}
 				</div>
@@ -276,6 +446,7 @@ export const IssueCommits = ({
 	diffsBySha,
 	onLoadDiff,
 	diffStyle,
+	onAddComment,
 }: {
 	issueRef: string;
 	commits: GuiRefCommitEntry[];
@@ -284,6 +455,7 @@ export const IssueCommits = ({
 	diffsBySha: Record<string, CommitDiffState>;
 	onLoadDiff: (sha: string) => void;
 	diffStyle: 'split' | 'unified';
+	onAddComment?: (body: string) => void;
 }) => {
 	const [expandedShas, setExpandedShas] = useState<Set<string>>(new Set());
 	const [expandedFilesBySha, setExpandedFilesBySha] = useState<
@@ -417,6 +589,7 @@ export const IssueCommits = ({
 							expandedFiles={expandedFilesBySha[commit.sha] ?? new Set()}
 							onToggleFile={path => toggleFile(commit.sha, path)}
 							diffStyle={diffStyle}
+							onAddComment={onAddComment}
 						/>
 					</div>
 				</div>

--- a/source/gui/client/components/IssueDetails.tsx
+++ b/source/gui/client/components/IssueDetails.tsx
@@ -653,6 +653,7 @@ export const IssueDetails = ({
 									diffStyle={
 										panelWidth >= STACKED_DIFF_WIDTH ? 'split' : 'unified'
 									}
+									comments={comments}
 									onAddComment={
 										disabled
 											? undefined

--- a/source/gui/client/components/IssueDetails.tsx
+++ b/source/gui/client/components/IssueDetails.tsx
@@ -26,7 +26,7 @@ import {
 } from './FormPrimitives';
 import {AttachmentUploadStatus, IssueAttachments} from './IssueAttachments';
 import {IssueComments} from './IssueComments';
-import {CommitDiffState, IssueCommits} from './IssueCommits';
+import {CommitDiffState, FileTicketParams, IssueCommits} from './IssueCommits';
 import {MarkdownContent} from './MarkdownContent';
 import {Section} from './Section';
 import {Tabs, TabItem} from './Tabs';
@@ -56,6 +56,7 @@ export const IssueDetails = ({
 	onReopenIssue,
 	onAddComment,
 	onDeleteComment,
+	onFileTicket,
 	attachments,
 	attachmentUploadStatus,
 	onUploadAttachments,
@@ -89,6 +90,11 @@ export const IssueDetails = ({
 	onReopenIssue: (issueId: string) => void;
 	onAddComment?: (issueId: string, body: string) => void;
 	onDeleteComment?: (issueId: string, commentId: string) => void;
+	onFileTicket?: (
+		originIssueId: string,
+		originRef: string,
+		params: FileTicketParams,
+	) => void;
 	attachments: GuiAttachment[];
 	attachmentUploadStatus: AttachmentUploadStatus;
 	onUploadAttachments?: (issueId: string, files: File[]) => void;
@@ -658,6 +664,11 @@ export const IssueDetails = ({
 										disabled
 											? undefined
 											: body => onAddComment?.(issue.id, body)
+									}
+									onFileTicket={
+										disabled
+											? undefined
+											: params => onFileTicket?.(issue.id, issue.ref, params)
 									}
 								/>
 							)}

--- a/source/gui/client/components/IssueDetails.tsx
+++ b/source/gui/client/components/IssueDetails.tsx
@@ -653,6 +653,11 @@ export const IssueDetails = ({
 									diffStyle={
 										panelWidth >= STACKED_DIFF_WIDTH ? 'split' : 'unified'
 									}
+									onAddComment={
+										disabled
+											? undefined
+											: body => onAddComment?.(issue.id, body)
+									}
 								/>
 							)}
 						</>


### PR DESCRIPTION
## Summary
Select lines in a commit's diff by click-and-drag, then either comment on the current ticket or file a new linked ticket — both quoting the selected code.

Built on `@pierre/diffs`' native line-selection support (`enableLineSelection` / `onLineSelectionEnd` / `controlledSelection`), not a custom overlay. Scoped to the Commits tab's expanded-commit diff, where "current ticket" is unambiguous — not the scrubber-dot `DiffPanel`, which isn't opened from any one ticket.

### Comment
Posts to the current ticket via the existing `issue:comment:add`, quoting file path, line range and snippet. The selection's metadata rides along as a hidden `<!-- epiq-diff-comment:{...} -->` marker in the body, so the comment can be re-anchored to its lines later — no schema change, no new field on `GuiComment`.

### File ticket
Opens a modal (matching `CreateNodeModal`'s language) prefilled with the selection, plus a note field and the snippet read-only. Creates the ticket via the existing `issues:create` — tagged `from-code-comment`, landing in the board's leftmost swimlane. Both directions are linked by plain ref mention: the new ticket references the origin, and the origin gets an automatic comment naming the new ticket.

### Inline annotations & polish (from live-testing feedback)
- Posted comments render **inline in the diff**, anchored to their line range; collapsed file rows show a comment-count badge so they're findable again
- Snippets are **dedented** before quoting — raw source indentation was unreadable in a narrow comment box
- Comments tab orders **newest first**
- **Expand/collapse all** files in a commit
- `lineHoverHighlight` plus accent-colored toolbar chrome, so the feature is discoverable rather than found by accident

## Notes
Two bugs found and fixed during verification, both with regression tests:
- react-markdown does **not** silently drop raw `<!-- ... -->` without rehype-raw — it renders the literal text. Every render path now strips the marker explicitly rather than relying on the renderer.
- A note containing `-->` terminated the marker early, losing the annotation and leaking garbage into the rendered comment. `>` is now escaped as `>`.

## Test plan
- [x] Full unit suite (642 tests) passing, incl. 22 new tests covering snippet extraction, dedent, marker encode/parse/strip, and file matching
- [x] Full Playwright GUI e2e suite (44 tests) passing
- [x] Manually verified end-to-end: drag-select → comment (with and without a note) → inline annotation appears at the right line, badge shows on the collapsed row; drag-select → file ticket → new ticket created with snippet + tag + back-reference, origin ticket receives its back-comment. Test artifacts cleaned up afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)