### PR TITLE
Render diff-comment snippets as real highlighted code

### DIFF
--- a/source/gui/client/components/CodeSnippet.tsx
+++ b/source/gui/client/components/CodeSnippet.tsx
@@ -1,0 +1,37 @@
+import {File} from '@pierre/diffs/react';
+import {GUI_THEME} from '../lib/gui-theme';
+
+// The same highlighter and theme the diff view itself renders with, so a
+// snippet quoted into a comment looks like the code it was taken from rather
+// than like markdown text. `name` is what infers the language, which is why
+// the quoting side keeps the real file path around.
+const PIERRE_THEME = 'github-dark';
+
+export const CodeSnippet = ({
+	filePath,
+	snippet,
+}: {
+	filePath: string;
+	snippet: string;
+}) => (
+	<div
+		style={{
+			marginTop: 8,
+			border: `1px solid ${GUI_THEME.line}`,
+			borderRadius: 8,
+			overflow: 'hidden',
+		}}
+	>
+		<File
+			file={{name: filePath, contents: snippet}}
+			options={{
+				theme: PIERRE_THEME,
+				// The caption above already names the file and its line range, and
+				// the snippet's own numbers would start at 1 rather than at the
+				// lines it was taken from — actively misleading.
+				disableFileHeader: true,
+				disableLineNumbers: true,
+			}}
+		/>
+	</div>
+);

--- a/source/gui/client/components/IssueComments.tsx
+++ b/source/gui/client/components/IssueComments.tsx
@@ -1,12 +1,42 @@
 import {useState} from 'react';
 import {CONTENT_FONT, GUI_THEME} from '../lib/gui-theme';
 import {Button} from './Button';
+import {CodeSnippet} from './CodeSnippet';
 import {ActionRow, Empty, Textarea} from './FormPrimitives';
 import {GuiComment, GuiUser} from '../lib/gui-state.model';
 import {timeAgo} from '../lib/gui-format.helper';
-import {stripDiffCommentMarker} from './IssueCommits';
+import {
+	extractCommentSnippet,
+	parseDiffCommentMeta,
+	stripCommentSnippet,
+	stripDiffCommentMarker,
+} from './IssueCommits';
 import {MarkdownContent} from './MarkdownContent';
 import {MAX_COMMENT_LENGTH} from '../../../lib/utils/comment.limits.js';
+
+// A diff-selection comment's quoted code is rendered through the same
+// highlighter the diff view uses, rather than as a markdown fence — the whole
+// point of quoting it is that it reads as code. Everything else in the body
+// (the note, the file/line caption) stays plain markdown.
+const CommentBody = ({body}: {body: string}) => {
+	const meta = parseDiffCommentMeta(body);
+	const withoutMarker = stripDiffCommentMarker(body);
+	const snippet = meta && extractCommentSnippet(withoutMarker);
+
+	if (!meta || !snippet) {
+		return <MarkdownContent content={withoutMarker} softBreaks />;
+	}
+
+	return (
+		<>
+			<MarkdownContent
+				content={stripCommentSnippet(withoutMarker)}
+				softBreaks
+			/>
+			<CodeSnippet filePath={meta.filePath} snippet={snippet} />
+		</>
+	);
+};
 
 type Props = {
 	issueId: string;
@@ -95,10 +125,7 @@ export const IssueComments = ({
 									)}
 							</div>
 
-							<MarkdownContent
-								content={stripDiffCommentMarker(comment.body)}
-								softBreaks
-							/>
+							<CommentBody body={comment.body} />
 						</div>
 					))}
 				</div>

--- a/source/gui/client/components/IssueCommits.test.ts
+++ b/source/gui/client/components/IssueCommits.test.ts
@@ -3,10 +3,12 @@ import {SelectedLineRange} from '@pierre/diffs/react';
 import {
 	dedent,
 	encodeDiffCommentMarker,
+	extractCommentSnippet,
 	extractSnippet,
 	findDiffCommentsForFile,
 	formatSelectionLabel,
 	parseDiffCommentMeta,
+	stripCommentSnippet,
 	stripDiffCommentMarker,
 } from './IssueCommits';
 import {GuiComment, GuiCommitDiffFile} from '../lib/gui-state.model';
@@ -150,6 +152,38 @@ describe('encodeDiffCommentMarker / parseDiffCommentMeta', () => {
 // comment on its own (it renders as literal text without rehype-raw) — the
 // marker leaking into a rendered comment was caught live and is exactly what
 // this strips before the body ever reaches the markdown renderer.
+describe('extractCommentSnippet / stripCommentSnippet', () => {
+	const body = [
+		'a note',
+		'',
+		'`source/a.ts` lines 2-3 (added)',
+		'```',
+		'const a = 1;',
+		'const b = 2;',
+		'```',
+	].join('\n');
+
+	it('pulls the fenced snippet back out verbatim', () => {
+		expect(extractCommentSnippet(body)).toBe('const a = 1;\nconst b = 2;');
+	});
+
+	it('leaves the note and caption behind when the snippet is removed', () => {
+		expect(stripCommentSnippet(body)).toBe(
+			'a note\n\n`source/a.ts` lines 2-3 (added)',
+		);
+	});
+
+	it('preserves blank lines inside the snippet', () => {
+		const withBlank = ['```', 'first', '', 'third', '```'].join('\n');
+
+		expect(extractCommentSnippet(withBlank)).toBe('first\n\nthird');
+	});
+
+	it('returns null for a comment with no fenced block', () => {
+		expect(extractCommentSnippet('just a regular comment')).toBeNull();
+	});
+});
+
 describe('stripDiffCommentMarker', () => {
 	it('removes the marker and its trailing newline', () => {
 		const meta = {

--- a/source/gui/client/components/IssueCommits.tsx
+++ b/source/gui/client/components/IssueCommits.tsx
@@ -164,6 +164,20 @@ export const findDiffCommentsForFile = (
 		return meta && meta.filePath === filePath ? [{comment, meta}] : [];
 	});
 
+// The fenced block a diff-selection comment's body ends with. Pulled back out
+// so the snippet can be rendered as real highlighted code instead of markdown
+// text — the body keeps carrying it verbatim so the comment still reads
+// correctly anywhere that only knows how to render markdown.
+const SNIPPET_FENCE = /```\n([\s\S]*?)\n?```\s*$/;
+
+export const extractCommentSnippet = (body: string): string | null =>
+	SNIPPET_FENCE.exec(body)?.[1] ?? null;
+
+// Everything before the fenced snippet: the author's note plus the
+// `path` lines X-Y (added) caption, still plain markdown.
+export const stripCommentSnippet = (body: string): string =>
+	body.replace(SNIPPET_FENCE, '').trimEnd();
+
 // What a "File ticket" submission carries up to the caller that owns the
 // actual issues:create call and the origin-ticket back-comment — everything
 // needed to build both without the caller re-deriving any of it.

--- a/source/gui/client/components/MarkdownContent.tsx
+++ b/source/gui/client/components/MarkdownContent.tsx
@@ -1,8 +1,18 @@
-import React from 'react';
+import React, {createContext, useContext} from 'react';
 import ReactMarkdown, {type Components} from 'react-markdown';
 import remarkBreaks from 'remark-breaks';
 import remarkGfm from 'remark-gfm';
 import {CONTENT_FONT, GUI_THEME} from '../lib/gui-theme';
+
+// react-markdown wraps a fenced block in <pre><code>, and only sets a
+// className on the <code> when the fence names a language — so keying
+// block-vs-inline off className alone renders a bare ``` fence as inline,
+// wrapping it into one ragged background box per line. Being inside a <pre>
+// is the thing that actually distinguishes the two.
+const InPre = createContext(false);
+
+const CODE_FONT =
+	'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace';
 
 const components: Components = {
 	p: ({children}) => <p style={{margin: '0 0 14px'}}>{children}</p>,
@@ -44,27 +54,46 @@ const components: Components = {
 			{children}
 		</blockquote>
 	),
-	code: ({children, className}) => {
-		const isBlock = Boolean(className);
+	code: ({children}) => {
+		const isBlock = useContext(InPre);
+
+		// A block's own chrome (background, padding, scrolling) belongs to the
+		// <pre> below, so that one contiguous box wraps every line rather than
+		// each line carrying its own.
 		return (
 			<code
-				style={{
-					fontFamily:
-						'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
-					fontSize: isBlock ? 12 : '0.9em',
-					background: GUI_THEME.bg,
-					borderRadius: 4,
-					padding: isBlock ? '10px 12px' : '1px 5px',
-					display: isBlock ? 'block' : 'inline',
-					overflowX: isBlock ? 'auto' : undefined,
-					whiteSpace: isBlock ? 'pre' : undefined,
-				}}
+				style={
+					isBlock
+						? {fontFamily: CODE_FONT, fontSize: 12}
+						: {
+								fontFamily: CODE_FONT,
+								fontSize: '0.9em',
+								background: GUI_THEME.bg,
+								borderRadius: 4,
+								padding: '1px 5px',
+						  }
+				}
 			>
 				{children}
 			</code>
 		);
 	},
-	pre: ({children}) => <pre style={{margin: '0 0 14px'}}>{children}</pre>,
+	pre: ({children}) => (
+		<InPre.Provider value={true}>
+			<pre
+				style={{
+					margin: '0 0 14px',
+					padding: '10px 12px',
+					background: GUI_THEME.bg,
+					borderRadius: 6,
+					overflowX: 'auto',
+					whiteSpace: 'pre',
+				}}
+			>
+				{children}
+			</pre>
+		</InPre.Provider>
+	),
 	hr: () => (
 		<hr
 			style={{


### PR DESCRIPTION
## Summary
A diff-selection comment's quoted code rendered as plain markdown text — the one thing it should not look like.

Two fixes:

**Render the snippet as code (`GDWVECE`).** It now goes through `@pierre/diffs`' `File` component — the same shiki highlighter and `github-dark` theme the diff view itself uses — with the language inferred from the file path the comment's marker already carries. The body still stores the snippet as an ordinary fenced block, so a comment stays readable anywhere that only knows how to render markdown; the fence is just pulled back out at render time.

**Fix language-less fenced blocks generally (`AD8KVTN`).** `MarkdownContent` decided block-vs-inline from `Boolean(className)`, but react-markdown only sets a className when the fence names a language. A bare ``` fence therefore rendered `display: inline`, wrapping into one ragged background box per line instead of a contiguous block — visible in the screenshot that prompted this. Block-ness now comes from actually being inside the `<pre>` react-markdown wraps fenced blocks in, with the block chrome moved onto that `<pre>`. This affects every markdown surface, ticket descriptions included.

## Test plan
- [x] Full unit suite (647 tests) passing, incl. 4 new tests for snippet extraction/stripping
- [x] Full Playwright GUI e2e suite (44 tests) passing
- [x] Verified live: a diff-selection comment's snippet renders with correct TypeScript tokenization (keywords, strings, template-literal interpolations) matching the diff view; ordinary comments with inline code, links and paragraphs still render unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)