### PR TITLE
Link a diff comment's file/line reference back into the diff

### DIFF
--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -22,6 +22,10 @@ import {IssueDetails} from './components/IssueDetails';
 import {
 	FileTicketParams,
 	formatSelectionLabel,
+	clearDiffLocationParams,
+	DiffLocation,
+	readDiffLocationParams,
+	writeDiffLocationParams,
 } from './components/IssueCommits';
 import {BulkDetails} from './components/BulkDetails';
 import {SwimlaneColumn} from './components/SwimlaneColumn';
@@ -226,6 +230,9 @@ export const App = () => {
 		tabParam === 'comments' || tabParam === 'history' || tabParam === 'code'
 			? tabParam
 			: 'overview';
+	// Where a followed comment permalink points, if any. Read straight off the
+	// URL so the deep link survives a reload rather than living in state.
+	const diffFocus = readDiffLocationParams(searchParams);
 	const navigate = useNavigate();
 
 	// Route params carry shorthand refs (full ids in old links still resolve).
@@ -352,8 +359,22 @@ export const App = () => {
 
 	// Keyed on the issue alone, not the tab: switching to Code and back must not
 	// discard diffs already loaded there, only a genuinely different ticket should.
+	//
+	// The first ticket to appear is not a *change*, and clearing then is not
+	// harmless: children mount before this parent effect runs, so a Commits tab
+	// that requested a diff on mount (following a permalink) would have that
+	// request's state wiped straight back out, leaving the file expanded and
+	// permanently blank.
+	const previousIssueId = useRef<string | undefined>(undefined);
+
 	useEffect(() => {
-		setIssueCommitDiffs({});
+		const changed =
+			previousIssueId.current !== undefined &&
+			previousIssueId.current !== selectedIssue?.id;
+
+		previousIssueId.current = selectedIssue?.id;
+
+		if (changed) setIssueCommitDiffs({});
 	}, [selectedIssue?.id]);
 
 	// Fetched lazily on entering the Code tab rather than alongside issue:get
@@ -755,10 +776,27 @@ export const App = () => {
 			prev => {
 				const next = new URLSearchParams(prev);
 				next.set('tab', nextTab);
+				// A deep link belongs to the Commits tab it points into; leaving it
+				// on the URL after a deliberate tab change would drag the reader
+				// back to it the moment they returned.
+				clearDiffLocationParams(next);
 				return next;
 			},
 			{replace: true},
 		);
+	};
+
+	// Following a comment's file/line reference: the location goes in the URL
+	// rather than into state, so the resulting view survives a reload and can
+	// be handed to someone else. Pushed, not replaced — this is a navigation
+	// the reader should be able to come back from.
+	const openDiffLocation = (location: DiffLocation) => {
+		setSearchParams(prev => {
+			const next = new URLSearchParams(prev);
+			next.set('tab', 'code');
+			writeDiffLocationParams(next, location);
+			return next;
+		});
 	};
 
 	const editIssueTitle = (issueId: string, title: string) => {
@@ -1614,6 +1652,8 @@ export const App = () => {
 							onAddComment={addIssueComment}
 							onDeleteComment={deleteIssueComment}
 							onFileTicket={fileTicketFromSelection}
+							onOpenDiffLocation={openDiffLocation}
+							diffFocus={diffFocus}
 							attachments={attachmentsByIssueId[selectedIssue.id] ?? []}
 							attachmentUploadStatus={attachmentUploadStatus}
 							onUploadAttachments={uploadIssueAttachments}

--- a/source/gui/client/components/IssueComments.tsx
+++ b/source/gui/client/components/IssueComments.tsx
@@ -6,9 +6,11 @@ import {ActionRow, Empty, Textarea} from './FormPrimitives';
 import {GuiComment, GuiUser} from '../lib/gui-state.model';
 import {timeAgo} from '../lib/gui-format.helper';
 import {
+	DiffLocation,
+	diffLocationFromMeta,
 	extractCommentSnippet,
+	formatSelectionLabel,
 	parseDiffCommentMeta,
-	stripCommentSnippet,
 	stripDiffCommentMarker,
 } from './IssueCommits';
 import {MarkdownContent} from './MarkdownContent';
@@ -16,9 +18,16 @@ import {MAX_COMMENT_LENGTH} from '../../../lib/utils/comment.limits.js';
 
 // A diff-selection comment's quoted code is rendered through the same
 // highlighter the diff view uses, rather than as a markdown fence — the whole
-// point of quoting it is that it reads as code. Everything else in the body
-// (the note, the file/line caption) stays plain markdown.
-const CommentBody = ({body}: {body: string}) => {
+// point of quoting it is that it reads as code. The note and the file/line
+// caption are rebuilt from the marker's own metadata rather than sliced back
+// out of the body, so the caption can be a real control rather than text.
+const CommentBody = ({
+	body,
+	onOpenDiffLocation,
+}: {
+	body: string;
+	onOpenDiffLocation?: (location: DiffLocation) => void;
+}) => {
 	const meta = parseDiffCommentMeta(body);
 	const withoutMarker = stripDiffCommentMarker(body);
 	const snippet = meta && extractCommentSnippet(withoutMarker);
@@ -27,12 +36,54 @@ const CommentBody = ({body}: {body: string}) => {
 		return <MarkdownContent content={withoutMarker} softBreaks />;
 	}
 
+	const location = diffLocationFromMeta(meta);
+	const caption = `${meta.filePath} ${formatSelectionLabel(meta)}`;
+
 	return (
 		<>
-			<MarkdownContent
-				content={stripCommentSnippet(withoutMarker)}
-				softBreaks
-			/>
+			{meta.note && <MarkdownContent content={meta.note} softBreaks />}
+
+			{/* Only clickable when the marker recorded which commit the selection
+			    came from — a file can appear in several of a ticket's commits, so
+			    without it there is no unambiguous place to open. Comments written
+			    before the sha was recorded stay readable, just inert. */}
+			{location && onOpenDiffLocation ? (
+				<button
+					type="button"
+					onClick={() => onOpenDiffLocation(location)}
+					title="Open this in the diff"
+					style={{
+						display: 'block',
+						width: '100%',
+						textAlign: 'left',
+						margin: '8px 0 0',
+						padding: 0,
+						background: 'transparent',
+						border: 'none',
+						cursor: 'pointer',
+						font: 'inherit',
+						fontFamily: 'ui-monospace, monospace',
+						fontSize: 11,
+						color: GUI_THEME.accent,
+						textDecoration: 'underline',
+						textUnderlineOffset: 2,
+					}}
+				>
+					{caption}
+				</button>
+			) : (
+				<div
+					style={{
+						margin: '8px 0 0',
+						fontFamily: 'ui-monospace, monospace',
+						fontSize: 11,
+						color: GUI_THEME.secondary,
+					}}
+				>
+					{caption}
+				</div>
+			)}
+
 			<CodeSnippet filePath={meta.filePath} snippet={snippet} />
 		</>
 	);
@@ -45,6 +96,7 @@ type Props = {
 	whoAmI: GuiUser;
 	onAddComment?: (issueId: string, body: string) => void;
 	onDeleteComment?: (issueId: string, commentId: string) => void;
+	onOpenDiffLocation?: (location: DiffLocation) => void;
 };
 
 export const IssueComments = ({
@@ -54,6 +106,7 @@ export const IssueComments = ({
 	comments = [],
 	onAddComment,
 	onDeleteComment,
+	onOpenDiffLocation,
 }: Props) => {
 	const [body, setBody] = useState('');
 
@@ -125,7 +178,10 @@ export const IssueComments = ({
 									)}
 							</div>
 
-							<CommentBody body={comment.body} />
+							<CommentBody
+								body={comment.body}
+								onOpenDiffLocation={onOpenDiffLocation}
+							/>
 						</div>
 					))}
 				</div>

--- a/source/gui/client/components/IssueCommits.test.ts
+++ b/source/gui/client/components/IssueCommits.test.ts
@@ -8,8 +8,9 @@ import {
 	findDiffCommentsForFile,
 	formatSelectionLabel,
 	parseDiffCommentMeta,
-	stripCommentSnippet,
+	readDiffLocationParams,
 	stripDiffCommentMarker,
+	writeDiffLocationParams,
 } from './IssueCommits';
 import {GuiComment, GuiCommitDiffFile} from '../lib/gui-state.model';
 
@@ -148,11 +149,66 @@ describe('encodeDiffCommentMarker / parseDiffCommentMeta', () => {
 	});
 });
 
-// Regression guard: react-markdown does not drop a raw `<!-- ... -->` HTML
-// comment on its own (it renders as literal text without rehype-raw) — the
-// marker leaking into a rendered comment was caught live and is exactly what
-// this strips before the body ever reaches the markdown renderer.
-describe('extractCommentSnippet / stripCommentSnippet', () => {
+// A comment's file/line reference links back into the diff, so the location
+// has to survive a round trip through the URL — that is what makes the link
+// reloadable and shareable rather than a transient bit of state.
+describe('writeDiffLocationParams / readDiffLocationParams', () => {
+	const location = {
+		sha: 'abc123',
+		filePath: 'source/gui/client/App.tsx',
+		start: 12,
+		end: 18,
+		side: 'deletions' as const,
+		endSide: 'additions' as const,
+	};
+
+	it('round-trips a location through URL params', () => {
+		const params = new URLSearchParams();
+		writeDiffLocationParams(params, location);
+
+		expect(readDiffLocationParams(params)).toEqual(location);
+	});
+
+	it('survives being serialized into a query string', () => {
+		const params = new URLSearchParams();
+		writeDiffLocationParams(params, location);
+
+		expect(
+			readDiffLocationParams(new URLSearchParams(params.toString())),
+		).toEqual(location);
+	});
+
+	it('keeps unrelated params untouched', () => {
+		const params = new URLSearchParams({tab: 'code'});
+		writeDiffLocationParams(params, location);
+
+		expect(params.get('tab')).toBe('code');
+	});
+
+	it('reads null when no location is present', () => {
+		expect(
+			readDiffLocationParams(new URLSearchParams({tab: 'code'})),
+		).toBeNull();
+	});
+
+	it('reads null when the range is not numeric', () => {
+		const params = new URLSearchParams();
+		writeDiffLocationParams(params, location);
+		params.set('from', 'not-a-number');
+
+		expect(readDiffLocationParams(params)).toBeNull();
+	});
+
+	it('reads null when a side is not a known selection side', () => {
+		const params = new URLSearchParams();
+		writeDiffLocationParams(params, location);
+		params.set('side', 'sideways');
+
+		expect(readDiffLocationParams(params)).toBeNull();
+	});
+});
+
+describe('extractCommentSnippet', () => {
 	const body = [
 		'a note',
 		'',
@@ -167,12 +223,6 @@ describe('extractCommentSnippet / stripCommentSnippet', () => {
 		expect(extractCommentSnippet(body)).toBe('const a = 1;\nconst b = 2;');
 	});
 
-	it('leaves the note and caption behind when the snippet is removed', () => {
-		expect(stripCommentSnippet(body)).toBe(
-			'a note\n\n`source/a.ts` lines 2-3 (added)',
-		);
-	});
-
 	it('preserves blank lines inside the snippet', () => {
 		const withBlank = ['```', 'first', '', 'third', '```'].join('\n');
 
@@ -184,6 +234,10 @@ describe('extractCommentSnippet / stripCommentSnippet', () => {
 	});
 });
 
+// Regression guard: react-markdown does not drop a raw `<!-- ... -->` HTML
+// comment on its own (it renders as literal text without rehype-raw) — the
+// marker leaking into a rendered comment was caught live and is exactly what
+// this strips before the body ever reaches the markdown renderer.
 describe('stripDiffCommentMarker', () => {
 	it('removes the marker and its trailing newline', () => {
 		const meta = {

--- a/source/gui/client/components/IssueCommits.tsx
+++ b/source/gui/client/components/IssueCommits.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import {
 	DiffLineAnnotation,
 	SelectedLineRange,
@@ -99,13 +99,18 @@ export const dedent = (snippet: string): string => {
 // the literal text — so every render path showing a comment body must strip
 // it via stripDiffCommentMarker below rather than relying on the markdown
 // renderer to hide it.
-type DiffCommentMeta = {
+export type DiffCommentMeta = {
 	filePath: string;
 	start: number;
 	side: SelectionSide;
 	end: number;
 	endSide: SelectionSide;
 	note: string;
+	// Which commit's diff the selection was made in — a file can appear in
+	// several of a ticket's commits, so linking back needs it. Optional
+	// because comments written before it was recorded should still render
+	// their inline annotation; they just aren't clickable.
+	sha?: string;
 };
 
 const DIFF_COMMENT_MARKER = /<!--\s*epiq-diff-comment:(.+?)-->\n?/;
@@ -123,7 +128,7 @@ export const encodeDiffCommentMarker = (meta: DiffCommentMeta): string =>
 		'\\u003e',
 	)} -->`;
 
-const isSelectionSide = (value: unknown): value is SelectedLineRange['side'] =>
+const isSelectionSide = (value: unknown): value is SelectionSide =>
 	value === 'additions' || value === 'deletions';
 
 export const parseDiffCommentMeta = (body: string): DiffCommentMeta | null => {
@@ -145,7 +150,8 @@ export const parseDiffCommentMeta = (body: string): DiffCommentMeta | null => {
 		typeof meta.end !== 'number' ||
 		typeof meta.note !== 'string' ||
 		!isSelectionSide(meta.side) ||
-		!isSelectionSide(meta.endSide)
+		!isSelectionSide(meta.endSide) ||
+		(meta.sha !== undefined && typeof meta.sha !== 'string')
 	) {
 		return null;
 	}
@@ -173,11 +179,6 @@ const SNIPPET_FENCE = /```\n([\s\S]*?)\n?```\s*$/;
 export const extractCommentSnippet = (body: string): string | null =>
 	SNIPPET_FENCE.exec(body)?.[1] ?? null;
 
-// Everything before the fenced snippet: the author's note plus the
-// `path` lines X-Y (added) caption, still plain markdown.
-export const stripCommentSnippet = (body: string): string =>
-	body.replace(SNIPPET_FENCE, '').trimEnd();
-
 // What a "File ticket" submission carries up to the caller that owns the
 // actual issues:create call and the origin-ticket back-comment — everything
 // needed to build both without the caller re-deriving any of it.
@@ -187,6 +188,81 @@ export type FileTicketParams = {
 	snippet: string;
 	title: string;
 	note: string;
+};
+
+// A spot in a ticket's Commits tab, deep-linkable from a comment. Lives in the
+// URL rather than in transient state so the link survives a reload and can be
+// handed to someone else.
+export type DiffLocation = {
+	sha: string;
+	filePath: string;
+	start: number;
+	end: number;
+	side: SelectionSide;
+	endSide: SelectionSide;
+};
+
+export const diffLocationFromMeta = (
+	meta: DiffCommentMeta,
+): DiffLocation | null =>
+	meta.sha
+		? {
+				sha: meta.sha,
+				filePath: meta.filePath,
+				start: meta.start,
+				end: meta.end,
+				side: meta.side,
+				endSide: meta.endSide,
+		  }
+		: null;
+
+const DIFF_LOCATION_PARAMS = [
+	'commit',
+	'file',
+	'from',
+	'to',
+	'side',
+	'endSide',
+] as const;
+
+export const writeDiffLocationParams = (
+	params: URLSearchParams,
+	location: DiffLocation,
+): void => {
+	params.set('commit', location.sha);
+	params.set('file', location.filePath);
+	params.set('from', String(location.start));
+	params.set('to', String(location.end));
+	params.set('side', location.side);
+	params.set('endSide', location.endSide);
+};
+
+export const clearDiffLocationParams = (params: URLSearchParams): void => {
+	for (const key of DIFF_LOCATION_PARAMS) params.delete(key);
+};
+
+export const readDiffLocationParams = (
+	params: URLSearchParams,
+): DiffLocation | null => {
+	const sha = params.get('commit');
+	const filePath = params.get('file');
+	const start = Number(params.get('from'));
+	const end = Number(params.get('to'));
+	const side = params.get('side');
+	const endSide = params.get('endSide');
+
+	if (
+		!sha ||
+		!filePath ||
+		!Number.isFinite(start) ||
+		!Number.isFinite(end) ||
+		!isSelectionSide(side) ||
+		!isSelectionSide(endSide)
+	) {
+		return null;
+	}
+
+	return {sha, filePath, start, end, side, endSide};
 };
 
 // The timeline rail: a dot per commit, in the scrubber's own commit-series
@@ -267,12 +343,14 @@ const DiffStat = ({
 // trying to float it exactly over the selection, which the diff library
 // doesn't hand back pixel coordinates for.
 const SelectionToolbar = ({
+	sha,
 	file,
 	selection,
 	onAddComment,
 	onFileTicket,
 	onClear,
 }: {
+	sha: string;
 	file: GuiCommitDiffFile;
 	selection: SelectedLineRange;
 	onAddComment?: (body: string) => void;
@@ -300,6 +378,7 @@ const SelectionToolbar = ({
 			end: selection.end,
 			endSide,
 			note: trimmedNote,
+			sha,
 		});
 
 		const body = [
@@ -454,6 +533,7 @@ const DiffCommentAnnotation = ({
 };
 
 const FileRow = ({
+	sha,
 	file,
 	expanded,
 	onToggle,
@@ -461,7 +541,9 @@ const FileRow = ({
 	onAddComment,
 	onFileTicket,
 	comments,
+	focusRange,
 }: {
+	sha: string;
 	file: GuiCommitDiffFile;
 	expanded: boolean;
 	onToggle: () => void;
@@ -469,8 +551,26 @@ const FileRow = ({
 	onAddComment?: (body: string) => void;
 	onFileTicket?: (params: FileTicketParams) => void;
 	comments: GuiComment[];
+	// Set when a comment permalink points at this file: seeds the highlight
+	// and scrolls the diff into view.
+	focusRange?: SelectedLineRange | null;
 }) => {
 	const [selection, setSelection] = useState<SelectedLineRange | null>(null);
+	const rowRef = useRef<HTMLDivElement | null>(null);
+
+	// Keyed on the range's own values, not object identity — the parent
+	// rebuilds it from URL params on every render, and depending on identity
+	// would re-scroll (and re-select) forever.
+	const focusKey = focusRange
+		? `${focusRange.start}-${focusRange.end}-${focusRange.side}-${focusRange.endSide}`
+		: null;
+
+	useEffect(() => {
+		if (!focusRange || !expanded) return;
+
+		setSelection(focusRange);
+		rowRef.current?.scrollIntoView({block: 'center', behavior: 'smooth'});
+	}, [focusKey, expanded]);
 
 	const fileComments = findDiffCommentsForFile(comments, file.path);
 
@@ -483,7 +583,7 @@ const FileRow = ({
 	);
 
 	return (
-		<div style={{marginTop: 8}}>
+		<div ref={rowRef} style={{marginTop: 8}}>
 			<button
 				onClick={onToggle}
 				aria-expanded={expanded}
@@ -544,6 +644,7 @@ const FileRow = ({
 					/>
 					{selection && (
 						<SelectionToolbar
+							sha={sha}
 							file={file}
 							selection={selection}
 							onAddComment={onAddComment}
@@ -569,6 +670,7 @@ const CommitRow = ({
 	onAddComment,
 	onFileTicket,
 	comments,
+	focus,
 }: {
 	commit: GuiRefCommitEntry;
 	diff: CommitDiffState | undefined;
@@ -581,6 +683,8 @@ const CommitRow = ({
 	onAddComment?: (body: string) => void;
 	onFileTicket?: (params: FileTicketParams) => void;
 	comments: GuiComment[];
+	// Non-null only on the commit a permalink points at.
+	focus?: DiffLocation | null;
 }) => {
 	const [hovered, setHovered] = useState(false);
 	// Also tracks focus (not just mouse hover): the copy button is a real
@@ -692,6 +796,7 @@ const CommitRow = ({
 					{diff?.files?.map(file => (
 						<FileRow
 							key={file.path}
+							sha={commit.sha}
 							file={file}
 							expanded={expandedFiles.has(file.path)}
 							onToggle={() => onToggleFile(file.path)}
@@ -699,6 +804,16 @@ const CommitRow = ({
 							onAddComment={onAddComment}
 							onFileTicket={onFileTicket}
 							comments={comments}
+							focusRange={
+								focus?.filePath === file.path
+									? {
+											start: focus.start,
+											end: focus.end,
+											side: focus.side,
+											endSide: focus.endSide,
+									  }
+									: null
+							}
 						/>
 					))}
 				</div>
@@ -730,6 +845,7 @@ export const IssueCommits = ({
 	onAddComment,
 	onFileTicket,
 	comments,
+	focus,
 }: {
 	issueRef: string;
 	commits: GuiRefCommitEntry[];
@@ -741,11 +857,46 @@ export const IssueCommits = ({
 	onAddComment?: (body: string) => void;
 	onFileTicket?: (params: FileTicketParams) => void;
 	comments: GuiComment[];
+	// Where a comment permalink points, read from the URL by the caller.
+	focus?: DiffLocation | null;
 }) => {
 	const [expandedShas, setExpandedShas] = useState<Set<string>>(new Set());
 	const [expandedFilesBySha, setExpandedFilesBySha] = useState<
 		Record<string, Set<string>>
 	>({});
+
+	// Opens the commit and file a permalink names. Deliberately additive — it
+	// never collapses anything the reader already had open, so following a
+	// link into a tab you were already using doesn't throw your place away.
+	// Keyed on the location's own values rather than object identity, which
+	// the caller rebuilds from URL params on every render.
+	const focusKey = focus ? `${focus.sha}:${focus.filePath}` : null;
+
+	useEffect(() => {
+		if (!focus) return;
+
+		setExpandedShas(prev =>
+			prev.has(focus.sha) ? prev : new Set(prev).add(focus.sha),
+		);
+
+		setExpandedFilesBySha(prev =>
+			prev[focus.sha]?.has(focus.filePath)
+				? prev
+				: {
+						...prev,
+						[focus.sha]: new Set(prev[focus.sha] ?? []).add(focus.filePath),
+				  },
+		);
+	}, [focusKey]);
+
+	// Separate from the expand effect above: the diff has to be fetched too,
+	// and only when it isn't already loading or loaded.
+	useEffect(() => {
+		if (!focus) return;
+
+		const existing = diffsBySha[focus.sha];
+		if (!existing || existing.error) onLoadDiff(focus.sha);
+	}, [focusKey]);
 
 	const toggleCommit = (sha: string) => {
 		const alreadyExpanded = expandedShas.has(sha);
@@ -891,6 +1042,7 @@ export const IssueCommits = ({
 							onAddComment={onAddComment}
 							onFileTicket={onFileTicket}
 							comments={comments}
+							focus={focus?.sha === commit.sha ? focus : null}
 						/>
 					</div>
 				</div>

--- a/source/gui/client/components/IssueDetails.tsx
+++ b/source/gui/client/components/IssueDetails.tsx
@@ -26,7 +26,12 @@ import {
 } from './FormPrimitives';
 import {AttachmentUploadStatus, IssueAttachments} from './IssueAttachments';
 import {IssueComments} from './IssueComments';
-import {CommitDiffState, FileTicketParams, IssueCommits} from './IssueCommits';
+import {
+	CommitDiffState,
+	DiffLocation,
+	FileTicketParams,
+	IssueCommits,
+} from './IssueCommits';
 import {MarkdownContent} from './MarkdownContent';
 import {Section} from './Section';
 import {Tabs, TabItem} from './Tabs';
@@ -57,6 +62,8 @@ export const IssueDetails = ({
 	onAddComment,
 	onDeleteComment,
 	onFileTicket,
+	onOpenDiffLocation,
+	diffFocus,
 	attachments,
 	attachmentUploadStatus,
 	onUploadAttachments,
@@ -95,6 +102,10 @@ export const IssueDetails = ({
 		originRef: string,
 		params: FileTicketParams,
 	) => void;
+	// Following a comment's permalink: the caller puts it in the URL, and
+	// hands back where it currently points so the Commits tab can open there.
+	onOpenDiffLocation?: (location: DiffLocation) => void;
+	diffFocus?: DiffLocation | null;
 	attachments: GuiAttachment[];
 	attachmentUploadStatus: AttachmentUploadStatus;
 	onUploadAttachments?: (issueId: string, files: File[]) => void;
@@ -638,6 +649,7 @@ export const IssueDetails = ({
 									comments={comments}
 									onAddComment={onAddComment}
 									onDeleteComment={onDeleteComment}
+									onOpenDiffLocation={onOpenDiffLocation}
 								/>
 							)}
 
@@ -670,6 +682,7 @@ export const IssueDetails = ({
 											? undefined
 											: params => onFileTicket?.(issue.id, issue.ref, params)
 									}
+									focus={diffFocus}
 								/>
 							)}
 						</>


### PR DESCRIPTION
## Summary
A diff-selection comment named its file and line range, but the caption was inert. It's now a link that opens the Commits tab with that commit and file expanded, and the commented lines highlighted and scrolled into view.

**Router.** The location lives in the URL — `?tab=code&commit=<sha>&file=<path>&from=<n>&to=<n>&side=<side>&endSide=<side>` — rather than in transient state, so following the link survives a reload and the URL can be handed to someone else. A deliberate tab change clears those params, so returning to the tab later doesn't drag you back to the linked spot.

**Marker.** The comment marker now records the commit sha as well. A file can appear in several of a ticket's commits, so without it there's no unambiguous place to open. Parsing keeps it optional, so comments written before this change still render their inline annotation — they just aren't clickable.

## Bug found and fixed along the way
Following a permalink into a *freshly loaded* page left the file expanded but permanently blank. `App` cleared the loaded diffs whenever the selected ticket "changed", including on the first ticket to appear — and children mount before that parent effect runs, so the Commits tab's mount-time diff request had its state wiped straight back out. It now only clears on a genuine change from one ticket to another.

Worth noting my first attempt at this didn't work: I tried making the child effect re-request when its entry went missing, but React batches both updates so the dependency never actually changed value. Fixing the ordering at the source was the right call.

## Test plan
- [x] Full unit suite (652 tests) passing, incl. 6 new tests for the URL-param round trip (serialization, unrelated params preserved, malformed input rejected)
- [x] Full Playwright GUI e2e suite (44 tests) passing
- [x] Verified live: clicking the caption switches tab, expands the right commit and file, highlights lines 3-5 and scrolls to them; **and that the same URL reproduces all of that from a cold reload**

🤖 Generated with [Claude Code](https://claude.com/claude-code)