### PR TITLE
Adversarial audit: event log, sync, and client transports

### DIFF
--- a/source/git/git.ts
+++ b/source/git/git.ts
@@ -4,6 +4,7 @@ import {failed, isFail, Result, succeeded} from '../lib/model/result-types.js';
 import {logger} from '../logger.js';
 import {git} from './git-commands.js';
 import {ORIGIN, getStateBranch} from './git-constants.js';
+import {assertLogOnlyGrew} from './log-integrity.js';
 import {
 	EMPTY_TREE_SHA,
 	ensureDir,
@@ -511,6 +512,15 @@ export const stageStateBranchOwnEventFile = async ({
 	if (!fs.existsSync(eventAbsolutePath)) {
 		return succeeded('No event file to stage', null);
 	}
+
+	// Before anything is staged, not after: a damaged working copy must not
+	// reach the index, let alone a commit that autosync would push.
+	const integrity = await assertLogOnlyGrew({
+		stateBranchRoot,
+		relativePath: eventPath,
+		workingContent: fs.readFileSync(eventAbsolutePath, 'utf8'),
+	});
+	if (isFail(integrity)) return failed(integrity.message);
 
 	const stageResult = await git.stage({
 		cwd: stateBranchRoot,

--- a/source/git/log-integrity.ts
+++ b/source/git/log-integrity.ts
@@ -1,0 +1,92 @@
+import {execGitAllowFail} from './git-utils.js';
+import {failed, Result, succeeded} from '../lib/model/result-types.js';
+
+/**
+ * The event log is append-only. That is not a style preference — it is what
+ * makes `*.jsonl merge=union` safe, what lets an id mean one byte sequence
+ * forever, and what every replica's convergence rests on.
+ *
+ * Nothing enforced it. `createStateBranchSyncCommit` committed the log exactly
+ * as it sat on disk, so any process that emptied or replaced the working copy
+ * had its damage committed and pushed on the next autosync, and every clone
+ * that pulled lost the same history. It has happened: a 2158-line log went to
+ * one line, and twice before that a handful of lines went missing unnoticed.
+ *
+ * A working copy is allowed to gain lines and reorder nothing. Losing even one
+ * means the file on disk is damaged, and the last thing to do with a damaged
+ * log is publish it.
+ */
+
+const linesIn = (content: string): string[] =>
+	content.split('\n').filter(line => line.trim().length > 0);
+
+/** Lines present in `committed` that `working` no longer has. */
+export const findDroppedLines = (
+	committed: string,
+	working: string,
+): string[] => {
+	const present = new Set(linesIn(working));
+
+	return linesIn(committed).filter(line => !present.has(line));
+};
+
+export const describeDroppedLines = (
+	relativePath: string,
+	dropped: string[],
+	committedCount: number,
+): string =>
+	[
+		`Refusing to commit ${relativePath}: it is missing ${dropped.length} of ` +
+			`the ${committedCount} event(s) already committed.`,
+		'',
+		'The event log is append-only, so a line can never legitimately go',
+		'missing. The working copy on disk is damaged; committing it would',
+		'publish that damage to everyone who pulls, and the log carries no way',
+		'to undo it.',
+		'',
+		'Nothing has been committed. The committed history is intact — recover',
+		'the file from it before syncing again:',
+		`  git show HEAD:${relativePath}`,
+		'',
+		'First dropped event:',
+		`  ${dropped[0]?.slice(0, 200) ?? '<none>'}`,
+	].join('\n');
+
+/**
+ * Compares the working copy of one event log against the version already
+ * committed. `allowFail` because the file legitimately has no committed
+ * version on a first sync, and a missing path is not an integrity problem.
+ */
+export const assertLogOnlyGrew = async ({
+	stateBranchRoot,
+	relativePath,
+	workingContent,
+}: {
+	stateBranchRoot: string;
+	relativePath: string;
+	workingContent: string;
+}): Promise<Result<void>> => {
+	const committed = await execGitAllowFail({
+		args: ['show', `HEAD:${relativePath}`],
+		cwd: stateBranchRoot,
+	});
+
+	// No committed version yet, or no HEAD at all: nothing to have lost.
+	if (committed.exitCode !== 0) {
+		return succeeded('No committed log to compare against', undefined);
+	}
+
+	const dropped = findDroppedLines(committed.stdout, workingContent);
+
+	if (dropped.length > 0) {
+		return failed(
+			describeDroppedLines(
+				relativePath,
+				dropped,
+				linesIn(committed.stdout).length,
+			),
+		);
+	}
+
+	return succeeded('Event log only grew', undefined);
+};

--- a/source/gui/api/api-server.ts
+++ b/source/gui/api/api-server.ts
@@ -71,10 +71,13 @@ const readJsonBody = async <T>(
 	maxBytes = 1024 * 1024,
 ): Promise<T> =>
 	new Promise((resolve, reject) => {
-		let body = '';
+		// Buffers, decoded once at the end: `body += chunk` decodes each chunk on
+		// its own, so a character whose bytes straddle two socket reads came out
+		// as replacement characters — silently, and then straight into the log.
+		const chunks: Buffer[] = [];
 		let received = 0;
 
-		req.on('data', chunk => {
+		req.on('data', (chunk: Buffer) => {
 			received += chunk.length;
 
 			if (received > maxBytes) {
@@ -83,10 +86,12 @@ const readJsonBody = async <T>(
 				return;
 			}
 
-			body += chunk;
+			chunks.push(chunk);
 		});
 
 		req.on('end', () => {
+			const body = Buffer.concat(chunks).toString('utf8');
+
 			try {
 				resolve(body ? JSON.parse(body) : ({} as T));
 			} catch {

--- a/source/gui/api/api-server.ts
+++ b/source/gui/api/api-server.ts
@@ -19,6 +19,7 @@ import {
 } from '../../mcp/epiq-api.js';
 import {getTimeTravelStatus, runExclusive} from '../../mcp/epiq-time-travel.js';
 import {startGuiAutoSync} from './lib/api-autosync.js';
+import {refuseCrossSiteRequest} from './lib/origin-guard.js';
 import {setupWebsocket} from './lib/websocket.js';
 
 const distRoot = path.dirname(fileURLToPath(import.meta.url));
@@ -201,8 +202,27 @@ export const startGuiServer = async (input: {
 	// wrapper so the tests run the same configuration.
 	setVirtualNodesEnabled(false);
 
+	// Known only after `listen`, and the handler below closes over it.
+	let boundPort = 0;
+
 	const server = http.createServer(async (req, res) => {
 		const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+
+		const refusal = refuseCrossSiteRequest(
+			{
+				method: req.method,
+				origin: req.headers.origin,
+				contentType: req.headers['content-type'],
+			},
+			boundPort,
+		);
+
+		if (refusal) {
+			return sendJson(res, refusal.status, {
+				isError: true,
+				message: refusal.message,
+			});
+		}
 
 		if (url.pathname === '/api/state') {
 			return sendJson(res, 200, await getGuiState({repoRoot: input.repoRoot}));
@@ -415,7 +435,7 @@ export const startGuiServer = async (input: {
 	});
 
 	try {
-		await listen(server);
+		boundPort = await listen(server);
 	} catch (error) {
 		return failed(
 			error instanceof Error
@@ -430,6 +450,7 @@ export const startGuiServer = async (input: {
 
 	setupWebsocket(server, input.repoRoot, {
 		onStateChanged: () => guiAutoSync.queueSync(),
+		getPort: () => boundPort,
 	});
 
 	server.on('close', guiAutoSync.dispose);

--- a/source/gui/api/lib/origin-guard.ts
+++ b/source/gui/api/lib/origin-guard.ts
@@ -1,0 +1,74 @@
+/**
+ * Binding to loopback is not a security boundary in a browser. Any page the
+ * user happens to have open can POST to `http://127.0.0.1:<port>`, and a
+ * WebSocket handshake is exempt from the same-origin policy altogether — so
+ * without this, a drive-by page could drive the whole board and `git push` the
+ * damage.
+ *
+ * A browser always sends `Origin` on a WebSocket handshake and on any
+ * state-changing method, so "present and not ours" is the whole attack. A
+ * request with no `Origin` is not coming from a page and has nothing to spoof;
+ * it is left alone so curl and the test harness keep working.
+ */
+const LOOPBACK_HOSTS: ReadonlySet<string> = new Set([
+	'127.0.0.1',
+	'[::1]',
+	'localhost',
+	// What `startGuiServer` advertises.
+	'epiq.localhost',
+]);
+
+export const isForeignOrigin = (
+	origin: string | undefined,
+	port: number,
+): boolean => {
+	if (!origin) return false;
+
+	// A sandboxed iframe or a `file://` page. Opaque, so never ours.
+	if (origin === 'null') return true;
+
+	let url: URL;
+	try {
+		url = new URL(origin);
+	} catch {
+		return true;
+	}
+
+	if (url.protocol !== 'http:') return true;
+	if (url.port !== String(port)) return true;
+
+	return !LOOPBACK_HOSTS.has(url.hostname);
+};
+
+/**
+ * Two independent gates, because either alone leaves a hole: `Origin` catches
+ * a cross-origin request that carries one, and requiring JSON forces
+ * everything else into a preflight this server never answers. Without the
+ * second, a `text/plain` POST is a CORS *simple request* — no preflight, so
+ * any page the user has open could write to the board.
+ *
+ * Returns the refusal to send, or null to let the request through.
+ */
+export const refuseCrossSiteRequest = (
+	request: {
+		method: string | undefined;
+		origin: string | undefined;
+		contentType: string | undefined;
+	},
+	port: number,
+): {status: number; message: string} | null => {
+	if (request.method === 'GET' || request.method === 'HEAD') return null;
+
+	if (isForeignOrigin(request.origin, port)) {
+		return {status: 403, message: 'Cross-origin request'};
+	}
+
+	if (
+		request.method === 'POST' &&
+		!(request.contentType ?? '').toLowerCase().startsWith('application/json')
+	) {
+		return {status: 415, message: 'Expected content-type: application/json'};
+	}
+
+	return null;
+};

--- a/source/gui/api/lib/websocket.schema.ts
+++ b/source/gui/api/lib/websocket.schema.ts
@@ -1,0 +1,130 @@
+import {z} from 'zod';
+import {GuiMessage} from './websocket.model.js';
+
+/**
+ * `GuiMessage` is a compile-time type, so `JSON.parse(raw) as GuiMessage` was
+ * a promise the wire never had to keep. Two things follow from parsing for
+ * real instead:
+ *
+ * - Handlers spread the payload into an API call (`{repoRoot, ...payload}`),
+ *   and the spread wins — so an unknown `repoRoot` key in a frame pointed the
+ *   server at another project on the machine. `z.object` drops unknown keys,
+ *   which closes that for every handler at once.
+ * - A missing or wrong-typed field became a TypeError echoed back to the
+ *   client rather than a refusal.
+ */
+const id = z.string().min(1);
+
+const position = z.discriminatedUnion('at', [
+	z.object({at: z.literal('start')}),
+	z.object({at: z.literal('end')}),
+	z.object({at: z.literal('before'), sibling: id}),
+	z.object({at: z.literal('after'), sibling: id}),
+]);
+
+// Rejects NaN and ±Infinity, which reached `checkoutStateAt` and the timeline
+// bucketing as-is.
+const epochMs = z.number().finite();
+
+const message = <T extends string, P extends z.ZodTypeAny>(
+	type: T,
+	payload: P,
+) => z.object({type: z.literal(type), payload});
+
+const bare = <T extends string>(type: T) => z.object({type: z.literal(type)});
+
+export const GuiMessageSchema = z.discriminatedUnion('type', [
+	bare('state:get'),
+	bare('issues:list'),
+	bare('sync'),
+	bare('time-travel:live'),
+
+	message('issues:create', z.object({title: z.string(), parentId: id})),
+	message('swimlane:create', z.object({title: z.string(), boardId: id})),
+	message('swimlane:edit:title', z.object({swimlaneId: id, title: z.string()})),
+	message('swimlane:delete', z.object({swimlaneId: id})),
+	message(
+		'swimlane:move',
+		z.object({swimlaneId: id, boardId: id, position: position.optional()}),
+	),
+	message(
+		'issues:move',
+		z.object({issueId: id, parentId: id, position: position.optional()}),
+	),
+	message('issue:edit:title', z.object({issueId: id, title: z.string()})),
+	message(
+		'issue:edit:description',
+		z.object({issueId: id, description: z.string()}),
+	),
+	message('issue:tag:add', z.object({issueId: id, tagName: z.string()})),
+	message('issue:tag:remove', z.object({issueId: id, tagId: id})),
+	message('contributor:remove', z.object({contributorId: id})),
+	z.object({
+		type: z.literal('contributors:get'),
+		payload: z.object({boardId: id.optional()}).optional(),
+	}),
+	message(
+		'issue:assignee:add',
+		z.object({
+			issueId: id,
+			assigneeId: id.optional(),
+			assigneeName: z.string().optional(),
+			createUnlinked: z.boolean().optional(),
+		}),
+	),
+	message('issue:assignee:remove', z.object({issueId: id, assigneeId: id})),
+	message('issue:close', z.object({issueId: id})),
+	message('issue:reopen', z.object({issueId: id})),
+	message('issue:comment:add', z.object({issueId: id, body: z.string()})),
+	message('issue:comment:delete', z.object({issueId: id, commentId: id})),
+	message('issue:get', z.object({issueId: id})),
+	z.object({
+		type: z.literal('timeline:get'),
+		payload: z
+			.object({
+				start: epochMs.optional(),
+				end: epochMs.optional(),
+				boardId: id.optional(),
+				requestId: z.number().finite().optional(),
+			})
+			.optional(),
+	}),
+	z.object({
+		type: z.literal('commits:get'),
+		payload: z
+			.object({
+				start: epochMs.optional(),
+				end: epochMs.optional(),
+				requestId: z.number().finite().optional(),
+			})
+			.optional(),
+	}),
+	message('time-travel:scrub', z.object({targetTime: epochMs})),
+	message('commit:inspect', z.object({sha: z.string()})),
+	message('commit:diff:get', z.object({sha: z.string()})),
+	message('issue:commits:get', z.object({issueId: id})),
+]);
+
+// Proof the schema still covers the transport it validates: a message the
+// schema produces has to be assignable to the type the handlers switch on.
+type SchemaMessage = z.infer<typeof GuiMessageSchema>;
+const _assertSchemaMatchesModel: SchemaMessage extends GuiMessage
+	? true
+	: never = true;
+void _assertSchemaMatchesModel;
+
+export const parseGuiMessage = (
+	raw: unknown,
+): {ok: true; message: GuiMessage} | {ok: false; error: string} => {
+	const result = GuiMessageSchema.safeParse(raw);
+
+	if (!result.success) {
+		const detail = result.error.issues
+			.map(issue => `${issue.path.join('.') || '<root>'}: ${issue.message}`)
+			.join(', ');
+
+		return {ok: false, error: `Invalid message: ${detail}`};
+	}
+
+	return {ok: true, message: result.data};
+};

--- a/source/gui/api/lib/websocket.ts
+++ b/source/gui/api/lib/websocket.ts
@@ -46,6 +46,7 @@ import {
 import {MUTATING_MESSAGE_TYPES} from '../../client/lib/gui-mutations.js';
 import {GuiMessage} from './websocket.model.js';
 import {isForeignOrigin} from './origin-guard.js';
+import {parseGuiMessage} from './websocket.schema.js';
 import {issueDetail, slimStateResult} from './slim-state.js';
 
 // Derives rather than boots, so a live re-materialize can't stomp a checkout.
@@ -549,13 +550,6 @@ export const setupWebsocket = (
 				}
 
 				if (type === 'issue:close') {
-					if (!message.payload.issueId) {
-						return sendSocket(socket, {
-							type: 'error',
-							message: 'Missing issueId',
-						});
-					}
-
 					const result = await closeIssue({
 						repoRoot,
 						issueId: message.payload.issueId,
@@ -571,13 +565,6 @@ export const setupWebsocket = (
 				}
 
 				if (type === 'issue:reopen') {
-					if (!message.payload.issueId) {
-						return sendSocket(socket, {
-							type: 'error',
-							message: 'Missing issueId',
-						});
-					}
-
 					const result = await reopenIssue({
 						repoRoot,
 						issueId: message.payload.issueId,
@@ -599,7 +586,13 @@ export const setupWebsocket = (
 			};
 
 			try {
-				const message = JSON.parse(raw.toString()) as GuiMessage;
+				const parsed = parseGuiMessage(JSON.parse(raw.toString()));
+
+				if (!parsed.ok) {
+					return sendSocket(socket, {type: 'error', message: parsed.error});
+				}
+
+				const message = parsed.message;
 
 				if (!MUTATING_MESSAGE_TYPES.has(message.type)) {
 					return await dispatchMessage(message);

--- a/source/gui/api/lib/websocket.ts
+++ b/source/gui/api/lib/websocket.ts
@@ -45,6 +45,7 @@ import {
 } from '../../client/lib/gui-broadcast.js';
 import {MUTATING_MESSAGE_TYPES} from '../../client/lib/gui-mutations.js';
 import {GuiMessage} from './websocket.model.js';
+import {isForeignOrigin} from './origin-guard.js';
 import {issueDetail, slimStateResult} from './slim-state.js';
 
 // Derives rather than boots, so a live re-materialize can't stomp a checkout.
@@ -126,11 +127,19 @@ const sendMutationResult = async (
 export const setupWebsocket = (
 	server: http.Server<typeof http.IncomingMessage, typeof http.ServerResponse>,
 	repoRoot: string,
-	{onStateChanged}: {onStateChanged: () => void},
+	{
+		onStateChanged,
+		getPort,
+	}: {onStateChanged: () => void; getPort: () => number},
 ) => {
 	const wss = new WebSocketServer({
 		server,
 		path: '/ws',
+		// A handshake is not bound by the same-origin policy, so without this any
+		// page the user has open reaches every message below — including `sync`,
+		// which pushes to the shared remote.
+		verifyClient: (info: {origin: string}) =>
+			!isForeignOrigin(info.origin, getPort()),
 	});
 
 	wss.on('connection', socket => {

--- a/source/gui/client/components/IssueComments.tsx
+++ b/source/gui/client/components/IssueComments.tsx
@@ -14,7 +14,7 @@ import {
 	stripDiffCommentMarker,
 } from './IssueCommits';
 import {MarkdownContent} from './MarkdownContent';
-import {MAX_COMMENT_LENGTH} from '../../../lib/utils/comment.limits.js';
+import {MAX_COMMENT_LENGTH} from '../../../lib/utils/text.limits.js';
 
 // A diff-selection comment's quoted code is rendered through the same
 // highlighter the diff view uses, rather than as a markdown fence — the whole

--- a/source/lib/command-line/command-validation.ts
+++ b/source/lib/command-line/command-validation.ts
@@ -18,7 +18,7 @@ import {
 import {DEFAULT_ATTACHMENT_MAX_KB} from '../media/media-store.js';
 import {getState} from '../state/state.js';
 import {getGradientWord, getStringColor} from '../utils/color.js';
-import {MAX_COMMENT_LENGTH} from '../utils/comment.limits.js';
+import {MAX_COMMENT_LENGTH} from '../utils/text.limits.js';
 import {
 	ticketAssigneesFromBreadCrumb,
 	ticketTagsFromBreadCrumb,

--- a/source/lib/command-line/commands.ts
+++ b/source/lib/command-line/commands.ts
@@ -30,7 +30,7 @@ import {openUrl} from '../utils/open-in-browser.js';
 import {CmdKeywords} from './cmd-keywords.js';
 import {CmdIntent} from './command-intent.js';
 import {ConfigModifiers, getCmdModifiers} from './command-modifiers.js';
-import {MAX_COMMENT_LENGTH} from '../utils/comment.limits.js';
+import {MAX_COMMENT_LENGTH} from '../utils/text.limits.js';
 import {editCommand} from './commands/edit.cmd.js';
 import {initCommand} from './commands/init.cmd.js';
 import {moveCommand} from './commands/move.cmd.js';

--- a/source/lib/event/event-boot.ts
+++ b/source/lib/event/event-boot.ts
@@ -243,11 +243,26 @@ const isCheckedOutInThePast = (): boolean => {
 const reportUnreadableEvents = (unreadable: UnreadableEvent[]): void => {
 	if (unreadable.length === 0) return;
 
-	const detail = [...new Set(unreadable.map(event => event.detail))].join(', ');
+	const corrupt = unreadable.filter(event => event.reason === 'corrupt-line');
+	const newer = unreadable.filter(event => event.reason !== 'corrupt-line');
 
-	logger.info(
-		`This build cannot read ${unreadable.length} event(s) in the log (${detail}). They are skipped, so anything they changed may be out of date until you upgrade.`,
-	);
+	if (newer.length > 0) {
+		const detail = [...new Set(newer.map(event => event.detail))].join(', ');
+
+		logger.info(
+			`This build cannot read ${newer.length} event(s) in the log (${detail}). They are skipped, so anything they changed may be out of date until you upgrade.`,
+		);
+	}
+
+	// Not an upgrade problem: these lines have no envelope, so they are lost
+	// rather than pending. Named precisely so the damage can be located.
+	if (corrupt.length > 0) {
+		const detail = [...new Set(corrupt.map(event => event.detail))].join(', ');
+
+		logger.info(
+			`Skipped ${corrupt.length} corrupt line(s) in the event log (${detail}). The rest of the board loaded normally; those events are unrecoverable.`,
+		);
+	}
 };
 
 export function bootStateFromEventLog(

--- a/source/lib/event/event-boot.ts
+++ b/source/lib/event/event-boot.ts
@@ -37,8 +37,11 @@ export function getBootNavigationTarget(): Result<{
 		node => node.context === 'WORKSPACE',
 	);
 
+	// A replay that skipped `init.workspace` — unreadable, or cut off by a
+	// historical checkout — reaches here. Thrown, this escaped every `isFail`
+	// on the boot path and took the TUI down instead of showing the error.
 	if (!workspace) {
-		throw new Error('No workspace found in event log');
+		return failed('No workspace found in event log');
 	}
 
 	const [firstBoard] = getRenderedChildren(workspace.id);
@@ -55,14 +58,9 @@ export function getBootNavigationTarget(): Result<{
 			contextNode: firstBoard,
 			selectedIndex: 0,
 		});
-	} else if (workspace) {
-		return succeeded('Resolved boot nav target', {
-			contextNode: workspace,
-			selectedIndex: 0,
-		});
 	} else {
 		return succeeded('Resolved boot nav target', {
-			contextNode: state.nodes[state.rootNodeId] as NavNode<AnyContext>,
+			contextNode: workspace,
 			selectedIndex: 0,
 		});
 	}

--- a/source/lib/event/event-load.ts
+++ b/source/lib/event/event-load.ts
@@ -436,6 +436,26 @@ export function getEdgeRef(rootDir = process.cwd()): Result<string | null> {
 		persisted.value.at(-1)?.id?.[0] ?? null,
 	);
 }
+/**
+ * Total, so the order is a function of the event *set* alone.
+ *
+ * Two events can legitimately share a parent, and — through a reused id, or a
+ * line that reached two logs — they can share an id too. Comparing ids alone
+ * left equal ones tied, and a tie is settled by `readdirSync` order, so two
+ * machines holding the same events derived different boards. Falling through
+ * to the content breaks every tie the same way everywhere: the actor comes off
+ * the file name and the payload off the line, both identical on every replica.
+ */
+const compareEvents = (
+	a: ReconstructedEvent,
+	b: ReconstructedEvent,
+): number => {
+	const byId = a.id[0].localeCompare(b.id[0]);
+	if (byId !== 0) return byId;
+
+	return JSON.stringify(a).localeCompare(JSON.stringify(b));
+};
+
 export const getSortedEvents = (
 	reconstructedEvents: ReconstructedEvent[],
 ): ReconstructedEvent[] => {
@@ -454,7 +474,7 @@ export const getSortedEvents = (
 	}
 
 	for (const children of childrenByRef.values()) {
-		children.sort((a, b) => a.id[0].localeCompare(b.id[0]));
+		children.sort(compareEvents);
 	}
 
 	const result: ReconstructedEvent[] = [];
@@ -495,7 +515,7 @@ export const getSortedEvents = (
 
 			return !placed.has(eventId) && refId !== null && !byEventId.has(refId);
 		})
-		.sort((a, b) => a.id[0].localeCompare(b.id[0]));
+		.sort(compareEvents);
 
 	for (const orphanRoot of orphanRoots) {
 		visit(orphanRoot);
@@ -503,7 +523,7 @@ export const getSortedEvents = (
 
 	const remaining = reconstructedEvents
 		.filter(event => !placed.has(event.id[0]))
-		.sort((a, b) => a.id[0].localeCompare(b.id[0]));
+		.sort(compareEvents);
 
 	for (const event of remaining) {
 		visit(event);

--- a/source/lib/event/event-load.ts
+++ b/source/lib/event/event-load.ts
@@ -24,10 +24,12 @@ export type ReconstructedEvent = PersistedEnvelope & {
 	userName: string;
 };
 
-// Orderable but not interpretable. `targetNodeId` scopes the resulting lock.
+// Orderable but not interpretable — except `corrupt-line`, which has no
+// envelope to order by and is reported only so the gap is visible.
+// `targetNodeId` scopes the resulting lock.
 export type UnreadableEvent = {
-	eventId: string;
-	reason: 'unsupported-schema-version' | 'unknown-action';
+	eventId: string | null;
+	reason: 'unsupported-schema-version' | 'unknown-action' | 'corrupt-line';
 	detail: string;
 	targetNodeId: string | null;
 };
@@ -253,6 +255,7 @@ export const decodeReconstructedEvents = (
 
 export const parsePersistedEventsFile = (
 	filePath: string,
+	unreadable?: UnreadableEvent[],
 ): Result<ReconstructedEvent[]> => {
 	if (!fs.existsSync(filePath)) {
 		return succeeded('Event file missing', []);
@@ -262,8 +265,23 @@ export const parsePersistedEventsFile = (
 
 	const content = fs.readFileSync(filePath, 'utf8');
 	const entries: ReconstructedEvent[] = [];
+	const fileName = path.basename(filePath);
 
-	for (const line of content.split('\n')) {
+	// A line whose envelope will not parse carries no id, so unlike an
+	// unreadable payload it cannot keep its place in the chain. Skipping it
+	// loses that one event; failing the load loses the whole board, for
+	// everyone, permanently — `merge=union` splices a half-written line into
+	// every clone that pulls, and the log is append-only.
+	const quarantine = (lineNumber: number, reason: string) => {
+		unreadable?.push({
+			eventId: null,
+			reason: 'corrupt-line',
+			detail: `${fileName}:${lineNumber} (${reason})`,
+			targetNodeId: null,
+		});
+	};
+
+	for (const [index, line] of content.split('\n').entries()) {
 		const trimmed = line.trim();
 		if (!trimmed) continue;
 
@@ -271,14 +289,16 @@ export const parsePersistedEventsFile = (
 		try {
 			raw = JSON.parse(trimmed);
 		} catch {
-			return failed(`Failed to parse event JSON from ${filePath}: ${trimmed}`);
+			quarantine(index + 1, 'invalid JSON');
+			continue;
 		}
 
 		// Envelope only: an unreadable version is retained for its place in the
-		// chain. A malformed envelope is corruption and still fails the load.
+		// chain.
 		const parsedResult = parsePersistedEnvelope(raw);
 		if (isFail(parsedResult)) {
-			return failed(`${parsedResult.message} in ${filePath}: ${trimmed}`);
+			quarantine(index + 1, parsedResult.message);
+			continue;
 		}
 
 		entries.push({
@@ -293,6 +313,7 @@ export const parsePersistedEventsFile = (
 
 function loadAllPersistedEvents(
 	eventsRoot: string,
+	unreadable?: UnreadableEvent[],
 ): Result<ReconstructedEvent[]> {
 	const dir = getEventsDirPath(eventsRoot);
 
@@ -308,7 +329,7 @@ function loadAllPersistedEvents(
 	const entries: ReconstructedEvent[] = [];
 
 	for (const filePath of files) {
-		const result = parsePersistedEventsFile(filePath);
+		const result = parsePersistedEventsFile(filePath, unreadable);
 
 		if (isFail(result)) {
 			return failed(result.message);
@@ -332,12 +353,13 @@ export const getLastUnreadableEvents = (): UnreadableEvent[] => lastUnreadable;
 export function loadMergedEventsWithUnreadable(
 	stateBranchRoot: string,
 ): Result<{events: AppEvent[]; unreadable: UnreadableEvent[]}> {
-	const allEvents = loadAllPersistedEvents(stateBranchRoot);
+	const unreadable: UnreadableEvent[] = [];
+
+	const allEvents = loadAllPersistedEvents(stateBranchRoot, unreadable);
 	if (isFail(allEvents)) {
 		return failed(allEvents.message);
 	}
 
-	const unreadable: UnreadableEvent[] = [];
 	const decoded = decodeReconstructedEvents(allEvents.value, unreadable);
 	if (isFail(decoded)) return failed(decoded.message);
 

--- a/source/lib/event/event-load.ts
+++ b/source/lib/event/event-load.ts
@@ -438,17 +438,26 @@ export const getSortedEvents = (
 	const result: ReconstructedEvent[] = [];
 	const placed = new Set<string>();
 
-	const visit = (event: ReconstructedEvent) => {
-		const eventId = event.id[0];
+	// Depth-first, but on an explicit stack: every event refs its predecessor,
+	// so the forest is one chain as long as the log and recursion would blow
+	// the call stack a few thousand events in.
+	const visit = (root: ReconstructedEvent) => {
+		const stack: ReconstructedEvent[] = [root];
 
-		if (placed.has(eventId)) return;
+		while (stack.length > 0) {
+			const event = stack.pop() as ReconstructedEvent;
+			const eventId = event.id[0];
 
-		result.push(event);
-		placed.add(eventId);
+			if (placed.has(eventId)) continue;
 
-		const children = childrenByRef.get(eventId) ?? [];
-		for (const child of children) {
-			visit(child);
+			result.push(event);
+			placed.add(eventId);
+
+			// Reversed, so the lowest-ULID sibling is popped first.
+			const children = childrenByRef.get(eventId) ?? [];
+			for (let index = children.length - 1; index >= 0; index--) {
+				stack.push(children[index] as ReconstructedEvent);
+			}
 		}
 	};
 

--- a/source/lib/event/event-materialize.ts
+++ b/source/lib/event/event-materialize.ts
@@ -19,6 +19,7 @@ import {nodes} from '../state/node-builder.js';
 import {
 	getState,
 	initWorkspaceState,
+	isStateInitialized,
 	updateState,
 	withDeferredDerive,
 } from '../state/state.js';
@@ -890,6 +891,19 @@ export function materialize<A extends EventAction>(
 	if (!handler) {
 		return failed(
 			`Unknown event action "${event.action}", likely created by a newer epiq version. Evt id: ${event.id}`,
+		);
+	}
+
+	// Anything ordered ahead of `init.workspace` — a forged root, or an id that
+	// does not decode and so sorts before every real ULID — reaches its handler
+	// with no state to read. Most handlers land on `getState()`, which throws,
+	// and an uncaught throw here takes the whole process down on load rather
+	// than skipping one event. Replay is total: this is a precondition the
+	// replay never met, which is exactly what `materializeSkip` is for.
+	if (!isStateInitialized() && event.action !== 'init.workspace') {
+		return materializeSkip(
+			`${event.action} arrived before the workspace was initialized`,
+			event,
 		);
 	}
 

--- a/source/lib/event/event-persist.ts
+++ b/source/lib/event/event-persist.ts
@@ -22,6 +22,36 @@ const SCHEMA_VERSION = 1;
 
 const getNextId = monotonicFactory();
 
+// The largest timestamp ULID can encode. An id at this value has no encodable
+// successor.
+const ULID_TIME_MAX = 281474976710655;
+
+/**
+ * The edge's timestamp is a lower bound for the next id and nothing more —
+ * ordering comes from `refId`, not from this number.
+ *
+ * An edge whose id does not decode, or decodes to ULID's ceiling, has no
+ * usable successor: `decodeTime(edge) + 1` either throws on the spot or
+ * exceeds what `encodeTime` accepts. Letting that fail the mint left the board
+ * permanently unwritable on every machine at once, with no way back, because
+ * the log is append-only. So fall back to the wall clock rather than refuse.
+ * Neither shape can be produced by a well-behaved writer.
+ */
+const seedFromEdgeRef = (edgeRef: string): number => {
+	const now = Date.now();
+
+	let edgeTime: number;
+	try {
+		edgeTime = decodeTime(edgeRef);
+	} catch {
+		return now;
+	}
+
+	if (edgeTime >= ULID_TIME_MAX) return now;
+
+	return Math.max(now, edgeTime + 1);
+};
+
 type Id = string;
 type RefId = string;
 export type CompositeId = [Id, RefId | null];
@@ -185,7 +215,7 @@ export function persist({
 		if (isFail(edgeRef)) return failed(edgeRef.message);
 
 		const newId = edgeRef.value
-			? getNextId(Math.max(Date.now(), decodeTime(edgeRef.value) + 1))
+			? getNextId(seedFromEdgeRef(edgeRef.value))
 			: getNextId();
 
 		const entryResult = toPersistedEvent(stripActor(event), [

--- a/source/lib/utils/comment.limits.ts
+++ b/source/lib/utils/comment.limits.ts
@@ -1,3 +1,0 @@
-// Import-free so the browser client can reach it. Shared by GUI, TUI and MCP
-// so no client rejects what another accepts; storage imposes no limit.
-export const MAX_COMMENT_LENGTH = 4000;

--- a/source/lib/utils/file-part.ts
+++ b/source/lib/utils/file-part.ts
@@ -9,4 +9,9 @@ export const sanitizeFilePart = (value: string) =>
 		.trim()
 		.toLowerCase()
 		.replace(/[^a-z0-9._-]+/g, '-')
+		// A second `.jsonl` in the composed name fails `getEventLogPath`'s guard,
+		// which left anyone whose display name contained one unable to write at
+		// all. `.` survives sanitizing on purpose ("J. Lampa"), so the collision
+		// has to be broken here rather than by rejecting the path afterwards.
+		.replace(/\.jsonl/g, '-jsonl')
 		.replace(/^-+|-+$/g, '') || 'unknown';

--- a/source/lib/utils/text.limits.ts
+++ b/source/lib/utils/text.limits.ts
@@ -1,0 +1,26 @@
+// Import-free so the browser client can reach it. Shared by GUI, TUI and MCP
+// so no client rejects what another accepts; storage imposes no limit.
+//
+// Storage imposing none is exactly why these exist: every accepted string is
+// appended to a log that is never rewritten and is replicated to every clone,
+// so anything oversized is permanent for everybody.
+export const MAX_COMMENT_LENGTH = 4000;
+
+export const MAX_TITLE_LENGTH = 300;
+export const MAX_DESCRIPTION_LENGTH = 100_000;
+export const MAX_TAG_NAME_LENGTH = 60;
+export const MAX_ASSIGNEE_NAME_LENGTH = 80;
+
+// One call should not be able to mint an unbounded number of tags or
+// contributors either.
+export const MAX_TAGS_PER_CREATE = 20;
+export const MAX_ASSIGNEES_PER_CREATE = 20;
+
+export const tooLong = (
+	label: string,
+	value: string,
+	max: number,
+): string | null =>
+	value.length > max
+		? `${label} cannot exceed ${max} characters (got ${value.length})`
+		: null;

--- a/source/mcp/epiq-api.ts
+++ b/source/mcp/epiq-api.ts
@@ -433,6 +433,14 @@ export const createIssue = async (input: CreateIssueInput) => {
 	const stateResult = getStateResult();
 	if (isFail(stateResult)) return stateResult;
 
+	// The other three title paths all sanitize; this one used to write the raw
+	// input, so a newline or a control character landed in the log for good.
+	const title = sanitizeInlineText(input.title);
+
+	if (!title) {
+		return failed('Issue title cannot be empty');
+	}
+
 	const rankResult = resolveAndPersistRankForCreate(
 		input.parentId,
 		actorResult.value,
@@ -441,7 +449,7 @@ export const createIssue = async (input: CreateIssueInput) => {
 	if (isFail(rankResult)) return rankResult;
 
 	const issueEventsResult = createIssueEvents({
-		name: input.title,
+		name: title,
 		parent: input.parentId,
 		user: actorResult.value,
 		rank: rankResult.value,
@@ -529,7 +537,7 @@ export const createIssue = async (input: CreateIssueInput) => {
 
 	return succeeded('Created issue', {
 		id: issueId,
-		title: input.title,
+		title,
 		parentId: input.parentId,
 		description: input.description ?? '',
 		tags,

--- a/source/mcp/epiq-api.ts
+++ b/source/mcp/epiq-api.ts
@@ -40,7 +40,16 @@ import {
 } from '../lib/model/app-state.model.js';
 import {describeEvent} from '../lib/event/format-log-utils.js';
 import {getStringColor} from '../lib/utils/color.js';
-import {MAX_COMMENT_LENGTH} from '../lib/utils/comment.limits.js';
+import {
+	MAX_ASSIGNEE_NAME_LENGTH,
+	MAX_ASSIGNEES_PER_CREATE,
+	MAX_COMMENT_LENGTH,
+	MAX_DESCRIPTION_LENGTH,
+	MAX_TAG_NAME_LENGTH,
+	MAX_TAGS_PER_CREATE,
+	MAX_TITLE_LENGTH,
+	tooLong,
+} from '../lib/utils/text.limits.js';
 import {nodeRef} from '../lib/utils/node-ref.js';
 import {sanitizeInlineText} from '../lib/utils/string.utils.js';
 import {
@@ -441,6 +450,23 @@ export const createIssue = async (input: CreateIssueInput) => {
 		return failed('Issue title cannot be empty');
 	}
 
+	const description = input.description ?? '';
+
+	const overLong =
+		tooLong('Issue title', title, MAX_TITLE_LENGTH) ??
+		tooLong('Issue description', description, MAX_DESCRIPTION_LENGTH);
+	if (overLong) return failed(overLong);
+
+	if ((input.tagNames?.length ?? 0) > MAX_TAGS_PER_CREATE) {
+		return failed(`Cannot set more than ${MAX_TAGS_PER_CREATE} tags at once`);
+	}
+
+	if ((input.assigneeNames?.length ?? 0) > MAX_ASSIGNEES_PER_CREATE) {
+		return failed(
+			`Cannot set more than ${MAX_ASSIGNEES_PER_CREATE} assignees at once`,
+		);
+	}
+
 	const rankResult = resolveAndPersistRankForCreate(
 		input.parentId,
 		actorResult.value,
@@ -460,12 +486,12 @@ export const createIssue = async (input: CreateIssueInput) => {
 	const issueId = events.find(e => e.action === 'add.issue')?.payload.id;
 	if (!issueId) return failed('Unable to determine created issue id');
 
-	if (input.description) {
+	if (description) {
 		events.push({
 			id: ulid(),
 			...actorResult.value,
 			action: 'edit.description',
-			payload: {id: issueId, md: input.description},
+			payload: {id: issueId, md: description},
 		} satisfies AppEvent<'edit.description'>);
 	}
 
@@ -473,6 +499,9 @@ export const createIssue = async (input: CreateIssueInput) => {
 	for (const rawName of input.tagNames ?? []) {
 		const tagName = sanitizeInlineText(rawName).trim();
 		if (!tagName || tags.some(tag => tag.name === tagName)) continue;
+
+		const overLongTag = tooLong('Tag name', tagName, MAX_TAG_NAME_LENGTH);
+		if (overLongTag) return failed(overLongTag);
 
 		const existingTag = Object.values(stateResult.value.tags).find(
 			tag => tag.name === tagName,
@@ -504,6 +533,13 @@ export const createIssue = async (input: CreateIssueInput) => {
 		if (!assigneeName || assignees.some(a => a.name === assigneeName)) {
 			continue;
 		}
+
+		const overLongName = tooLong(
+			'Assignee name',
+			assigneeName,
+			MAX_ASSIGNEE_NAME_LENGTH,
+		);
+		if (overLongName) return failed(overLongName);
 
 		const existingAssignee = Object.values(stateResult.value.contributors).find(
 			contributor => contributor.name === assigneeName,
@@ -539,7 +575,7 @@ export const createIssue = async (input: CreateIssueInput) => {
 		id: issueId,
 		title,
 		parentId: input.parentId,
-		description: input.description ?? '',
+		description,
 		tags,
 		assignees,
 	});
@@ -735,6 +771,9 @@ export const createSwimlane = async (input: CreateSwimlaneInput) => {
 	const title = sanitizeInlineText(input.title);
 	if (!title.trim()) return failed('Swimlane title cannot be empty');
 
+	const overLongTitle = tooLong('Swimlane title', title, MAX_TITLE_LENGTH);
+	if (overLongTitle) return failed(overLongTitle);
+
 	const rankResult = resolveAndPersistRankForCreate(
 		input.boardId,
 		actorResult.value,
@@ -788,6 +827,9 @@ export const editSwimlaneTitle = async (input: EditSwimlaneTitleInput) => {
 
 	const title = sanitizeInlineText(input.title);
 	if (!title.trim()) return failed('Swimlane title cannot be empty');
+
+	const overLongTitle = tooLong('Swimlane title', title, MAX_TITLE_LENGTH);
+	if (overLongTitle) return failed(overLongTitle);
 
 	if (swimlane.title === title) {
 		return succeeded('No changes made', {
@@ -1154,6 +1196,13 @@ export const editIssueDescription = async (
 	if (!isTicketNode(issue)) return failed('Edit target must be an issue');
 	if (issue.readonly) return failed('Cannot edit readonly issue');
 
+	const overLongDescription = tooLong(
+		'Issue description',
+		input.description,
+		MAX_DESCRIPTION_LENGTH,
+	);
+	if (overLongDescription) return failed(overLongDescription);
+
 	const currentDescription = issue.props.description ?? '';
 
 	if (currentDescription === input.description) {
@@ -1208,6 +1257,9 @@ export const editIssueTitle = async (input: EditIssueTitleInput) => {
 		return failed('Issue title cannot be empty');
 	}
 
+	const overLongTitle = tooLong('Issue title', title, MAX_TITLE_LENGTH);
+	if (overLongTitle) return failed(overLongTitle);
+
 	if (issue.title === title) {
 		return succeeded('No changes made', {
 			id: input.issueId,
@@ -1256,6 +1308,9 @@ export const addIssueTag = async (input: AddIssueTagInput) => {
 
 	const tagName = sanitizeInlineText(input.tagName).trim();
 	if (!tagName) return failed('Tag name cannot be empty');
+
+	const overLongTag = tooLong('Tag name', tagName, MAX_TAG_NAME_LENGTH);
+	if (overLongTag) return failed(overLongTag);
 
 	const existingTag = Object.values(stateResult.value.tags).find(
 		tag => tag.name === tagName,
@@ -1433,6 +1488,13 @@ export const addIssueAssignee = async (input: AddIssueAssigneeInput) => {
 
 	const assigneeName = sanitizeInlineText(input.assigneeName ?? '').trim();
 	if (!assigneeName) return failed('Provide assigneeId, self or assigneeName');
+
+	const overLongName = tooLong(
+		'Assignee name',
+		assigneeName,
+		MAX_ASSIGNEE_NAME_LENGTH,
+	);
+	if (overLongName) return failed(overLongName);
 
 	// Registry *and* event log, so this matches the same union a picker offers;
 	// the registry alone reports log-only authors as unknown.

--- a/source/mcp/server.ts
+++ b/source/mcp/server.ts
@@ -3,6 +3,15 @@ import {StdioServerTransport} from '@modelcontextprotocol/sdk/server/stdio.js';
 import {z} from 'zod';
 import {isFail, Result} from '../lib/model/result-types.js';
 import {
+	MAX_ASSIGNEE_NAME_LENGTH,
+	MAX_ASSIGNEES_PER_CREATE,
+	MAX_COMMENT_LENGTH,
+	MAX_DESCRIPTION_LENGTH,
+	MAX_TAG_NAME_LENGTH,
+	MAX_TAGS_PER_CREATE,
+	MAX_TITLE_LENGTH,
+} from '../lib/utils/text.limits.js';
+import {
 	addIssueAssignee,
 	getBoardContributors,
 	tombstoneContributor,
@@ -101,7 +110,7 @@ export const createMcpServer = () => {
 			inputSchema: z.object({
 				repoRoot: z.string().optional(),
 				boardId: z.string().min(1),
-				title: z.string().min(1),
+				title: z.string().min(1).max(MAX_TITLE_LENGTH),
 			}),
 		},
 		async input => resultJson(await createSwimlane(input)),
@@ -114,7 +123,7 @@ export const createMcpServer = () => {
 			inputSchema: z.object({
 				repoRoot: z.string().optional(),
 				swimlaneId: z.string().min(1),
-				title: z.string().min(1),
+				title: z.string().min(1).max(MAX_TITLE_LENGTH),
 			}),
 		},
 		async input => resultJson(await editSwimlaneTitle(input)),
@@ -166,12 +175,18 @@ export const createMcpServer = () => {
 			description:
 				'Create an Epiq issue. Optionally set description, tags, and assignees atomically in the same call instead of separate follow-up edits.',
 			inputSchema: z.object({
-				title: z.string().min(1),
+				title: z.string().min(1).max(MAX_TITLE_LENGTH),
 				parentId: z.string().min(1),
 				repoRoot: z.string().optional(),
-				description: z.string().optional(),
-				tagNames: z.array(z.string()).optional(),
-				assigneeNames: z.array(z.string()).optional(),
+				description: z.string().max(MAX_DESCRIPTION_LENGTH).optional(),
+				tagNames: z
+					.array(z.string().max(MAX_TAG_NAME_LENGTH))
+					.max(MAX_TAGS_PER_CREATE)
+					.optional(),
+				assigneeNames: z
+					.array(z.string().max(MAX_ASSIGNEE_NAME_LENGTH))
+					.max(MAX_ASSIGNEES_PER_CREATE)
+					.optional(),
 			}),
 		},
 		async input => resultJson(await createIssue(input)),
@@ -183,7 +198,7 @@ export const createMcpServer = () => {
 			description: 'Edit the markdown description of an Epiq issue',
 			inputSchema: z.object({
 				issueId: z.string().min(1),
-				description: z.string(),
+				description: z.string().max(MAX_DESCRIPTION_LENGTH),
 				repoRoot: z.string().optional(),
 			}),
 		},
@@ -196,7 +211,7 @@ export const createMcpServer = () => {
 			description: 'Edit the title of an Epiq issue',
 			inputSchema: z.object({
 				issueId: z.string().min(1),
-				title: z.string().min(1),
+				title: z.string().min(1).max(MAX_TITLE_LENGTH),
 				repoRoot: z.string().optional(),
 			}),
 		},
@@ -210,7 +225,7 @@ export const createMcpServer = () => {
 				'Add a tag to an Epiq issue, creating the tag if it does not exist',
 			inputSchema: z.object({
 				issueId: z.string().min(1),
-				tagName: z.string().min(1),
+				tagName: z.string().min(1).max(MAX_TAG_NAME_LENGTH),
 				repoRoot: z.string().optional(),
 			}),
 		},
@@ -278,7 +293,11 @@ export const createMcpServer = () => {
 				issueId: z.string().min(1),
 				assigneeId: z.string().min(1).optional(),
 				self: z.boolean().optional(),
-				assigneeName: z.string().min(1).optional(),
+				assigneeName: z
+					.string()
+					.min(1)
+					.max(MAX_ASSIGNEE_NAME_LENGTH)
+					.optional(),
 				createUnlinked: z.boolean().optional(),
 				repoRoot: z.string().optional(),
 			}),
@@ -305,7 +324,7 @@ export const createMcpServer = () => {
 			description: 'Add a comment to an Epiq issue',
 			inputSchema: z.object({
 				issueId: z.string().min(1),
-				body: z.string().min(1),
+				body: z.string().min(1).max(MAX_COMMENT_LENGTH),
 				repoRoot: z.string().optional(),
 			}),
 		},

--- a/source/mcp/test/epiq-api.test.ts
+++ b/source/mcp/test/epiq-api.test.ts
@@ -745,6 +745,28 @@ describe('mcp tools', () => {
 		);
 	});
 
+	it('sanitizes the title, like every other title path does', async () => {
+		const result = await tools.createIssue({
+			repoRoot: '/repo',
+			title: 'Broken\ntitle\twith control',
+			parentId: 'swimlane-1',
+		});
+
+		expect(isFail(result)).toBe(false);
+		if (isFail(result)) return;
+		expect(result.value.title).toBe('Broken title with control');
+	});
+
+	it('refuses a title that is nothing but control characters', async () => {
+		const result = await tools.createIssue({
+			repoRoot: '/repo',
+			title: '\n\t  ',
+			parentId: 'swimlane-1',
+		});
+
+		expect(isFail(result)).toBe(true);
+	});
+
 	it('creates an issue with description, tags, and assignees atomically', async () => {
 		const result = await tools.createIssue({
 			repoRoot: '/repo',

--- a/source/mcp/test/epiq-api.test.ts
+++ b/source/mcp/test/epiq-api.test.ts
@@ -6,7 +6,13 @@ import {
 	succeeded,
 } from '../../lib/model/result-types.js';
 import {REMOVED_CONTRIBUTOR_NAME} from '../../lib/model/app-state.model.js';
-import {MAX_COMMENT_LENGTH} from '../../lib/utils/comment.limits.js';
+import {
+	MAX_COMMENT_LENGTH,
+	MAX_DESCRIPTION_LENGTH,
+	MAX_TAG_NAME_LENGTH,
+	MAX_TAGS_PER_CREATE,
+	MAX_TITLE_LENGTH,
+} from '../../lib/utils/text.limits.js';
 import {NavNode} from '../../lib/model/navigation-node.model.js';
 import {AnyContext} from '../../lib/model/context.model.js';
 
@@ -745,23 +751,99 @@ describe('mcp tools', () => {
 		);
 	});
 
-	it('sanitizes the title, like every other title path does', async () => {
-		const result = await tools.createIssue({
-			repoRoot: '/repo',
-			title: 'Broken\ntitle\twith control',
-			parentId: 'swimlane-1',
+	// Everything accepted here is appended to a log that is never rewritten and
+	// replicated to every clone, so nothing may be unbounded.
+	describe('createIssue input limits', () => {
+		it('sanitizes the title, like every other title path does', async () => {
+			const result = await tools.createIssue({
+				repoRoot: '/repo',
+				title: 'Broken\ntitle\twith control',
+				parentId: 'swimlane-1',
+			});
+
+			expect(isFail(result)).toBe(false);
+			if (isFail(result)) return;
+			expect(result.value.title).toBe('Broken title withcontrol');
 		});
 
-		expect(isFail(result)).toBe(false);
-		if (isFail(result)) return;
-		expect(result.value.title).toBe('Broken title with control');
+		it('refuses a title that is nothing but control characters', async () => {
+			const result = await tools.createIssue({
+				repoRoot: '/repo',
+				title: '\n\t  ',
+				parentId: 'swimlane-1',
+			});
+
+			expect(isFail(result)).toBe(true);
+		});
+
+		it('refuses an over-long title', async () => {
+			const result = await tools.createIssue({
+				repoRoot: '/repo',
+				title: 'x'.repeat(MAX_TITLE_LENGTH + 1),
+				parentId: 'swimlane-1',
+			});
+
+			expect(isFail(result)).toBe(true);
+			if (isFail(result)) {
+				expect(result.message).toContain(String(MAX_TITLE_LENGTH));
+			}
+		});
+
+		it('refuses an over-long description', async () => {
+			const result = await tools.createIssue({
+				repoRoot: '/repo',
+				title: 'New issue',
+				parentId: 'swimlane-1',
+				description: 'x'.repeat(MAX_DESCRIPTION_LENGTH + 1),
+			});
+
+			expect(isFail(result)).toBe(true);
+			if (isFail(result)) {
+				expect(result.message).toContain(String(MAX_DESCRIPTION_LENGTH));
+			}
+		});
+
+		it('refuses an over-long tag name', async () => {
+			const result = await tools.createIssue({
+				repoRoot: '/repo',
+				title: 'New issue',
+				parentId: 'swimlane-1',
+				tagNames: ['x'.repeat(MAX_TAG_NAME_LENGTH + 1)],
+			});
+
+			expect(isFail(result)).toBe(true);
+		});
+
+		it('refuses more tags than one call may mint', async () => {
+			const result = await tools.createIssue({
+				repoRoot: '/repo',
+				title: 'New issue',
+				parentId: 'swimlane-1',
+				tagNames: Array.from(
+					{length: MAX_TAGS_PER_CREATE + 1},
+					(_, index) => `tag-${index}`,
+				),
+			});
+
+			expect(isFail(result)).toBe(true);
+		});
 	});
 
-	it('refuses a title that is nothing but control characters', async () => {
-		const result = await tools.createIssue({
+	it('refuses an over-long issue title on edit', async () => {
+		const result = await tools.editIssueTitle({
 			repoRoot: '/repo',
-			title: '\n\t  ',
-			parentId: 'swimlane-1',
+			issueId: fixtureId('issue-1'),
+			title: 'x'.repeat(MAX_TITLE_LENGTH + 1),
+		});
+
+		expect(isFail(result)).toBe(true);
+	});
+
+	it('refuses an over-long issue description on edit', async () => {
+		const result = await tools.editIssueDescription({
+			repoRoot: '/repo',
+			issueId: fixtureId('issue-1'),
+			description: 'x'.repeat(MAX_DESCRIPTION_LENGTH + 1),
 		});
 
 		expect(isFail(result)).toBe(true);

--- a/source/test/command-validation.test.ts
+++ b/source/test/command-validation.test.ts
@@ -1,7 +1,7 @@
 import {beforeAll, describe, expect, it, vi} from 'vitest';
 import {cmdValidity} from '../lib/command-line/cmd-validity.js';
 import {CmdKeywords} from '../lib/command-line/cmd-keywords.js';
-import {MAX_COMMENT_LENGTH} from '../lib/utils/comment.limits.js';
+import {MAX_COMMENT_LENGTH} from '../lib/utils/text.limits.js';
 import {
 	ConfigModifiers,
 	EditModifiers,

--- a/source/test/e2e-collab/harness.ts
+++ b/source/test/e2e-collab/harness.ts
@@ -182,3 +182,66 @@ export const runActor = async (
 export const cleanUp = ({dirs}: Collaboration): void => {
 	for (const dir of dirs) fs.rmSync(dir, {recursive: true, force: true});
 };
+
+/**
+ * Where this actor's state worktree lives. Resolved the way the app resolves
+ * it — the committed project id under the actor's own global dir — rather than
+ * by importing `getStateBranchRoot`, which reads `EPIQ_GLOBAL_DIR` off *this*
+ * process and so would answer for the wrong machine.
+ *
+ * Only exists after the actor has synced at least once.
+ */
+export const stateBranchRootFor = (actor: Actor): string => {
+	const project = JSON.parse(
+		fs.readFileSync(path.join(actor.repoRoot, '.epiq', 'project.json'), 'utf8'),
+	) as {projectId: string};
+
+	return path.join(actor.globalDir, 'worktrees', project.projectId);
+};
+
+export const ownLogPathFor = (actor: Actor, fileName: string): string =>
+	path.join(stateBranchRootFor(actor), '.epiq', 'events', fileName);
+
+/**
+ * Appends bytes to an actor's own log without going through `persist`.
+ *
+ * This is the whole point of the hostile suite: a peer's log is arbitrary
+ * bytes that arrive over git, and nothing on the read path gets to assume a
+ * well-behaved writer produced them. `raw` is written verbatim, so a caller
+ * can leave off the trailing newline to reproduce a half-written line.
+ */
+export const appendRawToOwnLog = (
+	actor: Actor,
+	fileName: string,
+	raw: string,
+): void => {
+	const logPath = ownLogPathFor(actor, fileName);
+	fs.mkdirSync(path.dirname(logPath), {recursive: true});
+	fs.appendFileSync(logPath, raw, 'utf8');
+};
+
+/** Every event id in an actor's state worktree, in file order. */
+export const idsInStateWorktree = (actor: Actor): string[] => {
+	const dir = path.join(stateBranchRootFor(actor), '.epiq', 'events');
+	if (!fs.existsSync(dir)) return [];
+
+	return fs
+		.readdirSync(dir)
+		.filter(name => name.endsWith('.jsonl'))
+		.flatMap(name =>
+			fs
+				.readFileSync(path.join(dir, name), 'utf8')
+				.split('\n')
+				.flatMap(line => {
+					if (!line.trim()) return [];
+					try {
+						const id = (JSON.parse(line) as {id?: [string, string | null]}).id;
+						return Array.isArray(id) && typeof id[0] === 'string'
+							? [id[0]]
+							: [];
+					} catch {
+						return [];
+					}
+				}),
+		);
+};

--- a/source/test/e2e-collab/hostile-log.test.ts
+++ b/source/test/e2e-collab/hostile-log.test.ts
@@ -1,0 +1,257 @@
+/**
+ * A peer's event log arrives over git as arbitrary bytes. Nothing on the read
+ * path may assume a well-behaved writer produced them: a half-written line
+ * survives `merge=union` into every clone, an id is chosen by whoever writes
+ * it, and the log is append-only, so anything that stops the board here stops
+ * it for everybody, permanently.
+ *
+ * Every case asserts the same four things: the board still opens on both
+ * machines, both derive the same order from the same events, both see the same
+ * issues, and writes still work afterwards.
+ */
+import {afterEach, describe, expect, it} from 'vitest';
+import {encodeTime} from 'ulid';
+import {
+	appendRawToOwnLog,
+	cleanUp,
+	idsInStateWorktree,
+	runActor,
+	startCollaboration,
+	stateBranchRootFor,
+	type Actor,
+	type Collaboration,
+} from './harness.js';
+import {readEventIds} from './log-reader.js';
+
+const TIMEOUT_MS = 240_000;
+
+let running: Collaboration | null = null;
+
+afterEach(() => {
+	if (running) cleanUp(running);
+	running = null;
+});
+
+// The actor writes `<sanitized id>.<sanitized name>.jsonl`; the harness gives
+// every actor a plain lowercase name and a ULID id, so this matches.
+const logFileFor = (actor: Actor): string =>
+	`${actor.userId.toLowerCase()}.${actor.name}.jsonl`;
+
+const line = (id: string, ref: string | null, payload: object): string =>
+	JSON.stringify({v: 1, id: [id, ref], ...payload});
+
+type Pair = {alice: Actor; mallory: Actor};
+
+/** A project with two collaborators, both synced and holding the same board. */
+const openProject = async (): Promise<Pair> => {
+	const collab = await startCollaboration({names: ['alice', 'mallory']});
+	running = collab;
+
+	const [alice, mallory] = collab.actors as [Actor, Actor];
+
+	expect(
+		(await runActor(alice, {init: true, actions: [], sync: true})).problems,
+		'alice creating the project',
+	).toEqual([]);
+
+	expect(
+		(await runActor(mallory, {actions: [], sync: true})).problems,
+		'mallory joining',
+	).toEqual([]);
+
+	return {alice, mallory};
+};
+
+/**
+ * Mallory publishes whatever bytes she appended, then Alice pulls them and
+ * writes something of her own. The assertions live here because every case
+ * wants the same ones.
+ */
+const publishAndSettle = async ({alice, mallory}: Pair, label: string) => {
+	const published = await runActor(mallory, {actions: [], sync: true});
+	expect(published.problems, `${label}: mallory publishing`).toEqual([]);
+
+	const received = await runActor(alice, {
+		actions: [{kind: 'create', title: `${label}-after`}],
+		sync: true,
+	});
+
+	// The board opened, and it still accepts writes. Both were lost outright
+	// before the fixes these cases cover.
+	expect(received.problems, `${label}: alice after pulling`).toEqual([]);
+	expect(
+		received.issues.some(issue => issue.endsWith(`${label}-after`)),
+		`${label}: alice's own write is on her board`,
+	).toBe(true);
+
+	const settled = await runActor(mallory, {actions: [], sync: true});
+	expect(settled.problems, `${label}: mallory settling`).toEqual([]);
+
+	// Same events, same derived order, same board. This is the contract.
+	expect(new Set(settled.seenEventIds), `${label}: same event set`).toEqual(
+		new Set(received.seenEventIds),
+	);
+	expect(settled.orderedEventIds, `${label}: same derived order`).toEqual(
+		received.orderedEventIds,
+	);
+	expect(settled.issues, `${label}: same board`).toEqual(received.issues);
+
+	return {received, settled};
+};
+
+describe('a peer publishes a log this build cannot fully read', () => {
+	it(
+		'survives a half-written last line',
+		async () => {
+			const pair = await openProject();
+
+			// No trailing newline, which is what `merge=union` splices the other
+			// side's first line onto.
+			appendRawToOwnLog(
+				pair.mallory,
+				logFileFor(pair.mallory),
+				'{"v":1,"id":["01H0000000000000000000000Z",null],"lock.node"',
+			);
+
+			await publishAndSettle(pair, 'truncated');
+		},
+		TIMEOUT_MS,
+	);
+
+	it(
+		'survives a line that parses as JSON but not as an envelope',
+		async () => {
+			const pair = await openProject();
+
+			appendRawToOwnLog(
+				pair.mallory,
+				logFileFor(pair.mallory),
+				JSON.stringify({v: 1, id: 'not-a-tuple', 'lock.node': {id: 'x'}}) +
+					'\n',
+			);
+
+			await publishAndSettle(pair, 'bad-envelope');
+		},
+		TIMEOUT_MS,
+	);
+
+	it(
+		'survives an event id at the ULID timestamp ceiling',
+		async () => {
+			const pair = await openProject();
+
+			// `decodeTime(edge) + 1` cannot be encoded, so this used to make every
+			// later write fail on every machine, forever.
+			appendRawToOwnLog(
+				pair.mallory,
+				logFileFor(pair.mallory),
+				line('7ZZZZZZZZZZZZZZZZZZZZZZZZZ', null, {'lock.node': {id: 'x'}}) +
+					'\n',
+			);
+
+			await publishAndSettle(pair, 'ulid-ceiling');
+		},
+		TIMEOUT_MS,
+	);
+
+	it(
+		'survives an event id that is not a ULID at all',
+		async () => {
+			const pair = await openProject();
+
+			appendRawToOwnLog(
+				pair.mallory,
+				logFileFor(pair.mallory),
+				line('!!not-a-ulid!!', null, {'lock.node': {id: 'x'}}) + '\n',
+			);
+
+			await publishAndSettle(pair, 'non-ulid');
+		},
+		TIMEOUT_MS,
+	);
+
+	it(
+		'survives a second root event dated before the workspace',
+		async () => {
+			const pair = await openProject();
+
+			appendRawToOwnLog(
+				pair.mallory,
+				logFileFor(pair.mallory),
+				line(encodeTime(0, 10) + '0000000000000000', null, {
+					'lock.node': {id: 'x'},
+				}) + '\n',
+			);
+
+			await publishAndSettle(pair, 'forged-root');
+		},
+		TIMEOUT_MS,
+	);
+
+	// The convergence case: whichever of the two the loader keeps, both
+	// machines have to keep the same one. Ties used to be settled by
+	// `readdirSync` order, so each machine kept whichever it read first.
+	it(
+		'derives one order when two events share an id',
+		async () => {
+			const pair = await openProject();
+
+			const existing = idsInStateWorktree(pair.alice);
+			const victim = existing.at(-1);
+			expect(victim, 'a published event to collide with').toBeDefined();
+
+			appendRawToOwnLog(
+				pair.mallory,
+				logFileFor(pair.mallory),
+				line(victim as string, null, {
+					'edit.title': {id: 'x', name: 'collision'},
+				}) + '\n',
+			);
+
+			await publishAndSettle(pair, 'duplicate-id');
+		},
+		TIMEOUT_MS,
+	);
+});
+
+describe('a log longer than the call stack', () => {
+	it(
+		'opens on every machine past the old recursion ceiling',
+		async () => {
+			const pair = await openProject();
+
+			// Recursing the causal chain overflowed at ~4.7k events, and every
+			// event refs its predecessor, so a log is one chain as deep as it is
+			// long. Written straight into the log rather than through 6k API calls:
+			// this is a test of the loader, not of throughput.
+			const edge = idsInStateWorktree(pair.mallory).at(-1) ?? null;
+			const lines: string[] = [];
+			let previous = edge;
+
+			for (let index = 0; index < 6_000; index++) {
+				const id =
+					encodeTime(1_700_000_000_000 + index, 10) + 'CHAIN000000000M0';
+				lines.push(line(id, previous, {'lock.node': {id: 'x'}}));
+				previous = id;
+			}
+
+			appendRawToOwnLog(
+				pair.mallory,
+				logFileFor(pair.mallory),
+				lines.join('\n') + '\n',
+			);
+
+			const {received} = await publishAndSettle(pair, 'long-chain');
+
+			expect(
+				readEventIds(stateBranchRootFor(pair.alice)).length,
+				'alice holds the whole chain',
+			).toBeGreaterThan(6_000);
+			expect(
+				received.orderedEventIds.length,
+				'and the loader ordered all of it',
+			).toBeGreaterThan(6_000);
+		},
+		TIMEOUT_MS,
+	);
+});

--- a/source/test/event-load.test.ts
+++ b/source/test/event-load.test.ts
@@ -102,6 +102,20 @@ describe('getSortedEvents', () => {
 		expect(sorted.map(e => e.id[0])).toEqual(['01A', '01B', '01C']);
 	});
 
+	// Two events sharing an id used to be settled by input order, which is
+	// `readdirSync` order — so the same event set derived a different board on
+	// each machine.
+	it('orders two events sharing an id the same way whatever the input order', () => {
+		const root = event('01A', null);
+		const first = event('01B', '01A', 'edit.title');
+		const second = {...event('01B', '01A', 'edit.title'), userName: 'Other'};
+
+		const oneWay = getSortedEvents([root, first, second]);
+		const otherWay = getSortedEvents([root, second, first]);
+
+		expect(JSON.stringify(oneWay)).toBe(JSON.stringify(otherWay));
+	});
+
 	// Every event refs its predecessor, so a log is one chain as deep as it is
 	// long. Recursing it overflowed the call stack at ~4.7k events, which meant
 	// an ordinary board eventually stopped opening for everybody at once.

--- a/source/test/event-load.test.ts
+++ b/source/test/event-load.test.ts
@@ -320,6 +320,80 @@ describe('decodeReconstructedEvents', () => {
 	});
 });
 
+describe('loadMergedEvents with a corrupt line on disk', () => {
+	const seedLog = (lines: string[]): string => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), 'epiq-corrupt-'));
+		const eventsDir = path.join(root, '.epiq', 'events');
+		fs.mkdirSync(eventsDir, {recursive: true});
+		fs.writeFileSync(
+			path.join(eventsDir, '01ARZ3NDEKTSV4RRFFQ69G5FAV.alice.jsonl'),
+			lines.join('\n') + '\n',
+		);
+		return root;
+	};
+
+	const workspaceLine = JSON.stringify({
+		v: 1,
+		id: ['01H0000000000000000000000A', null],
+		'init.workspace': {id: 'ws1', name: 'Workspace', rank: 'a0'},
+	});
+
+	const titleLine = JSON.stringify({
+		v: 1,
+		id: ['01H0000000000000000000000C', '01H0000000000000000000000A'],
+		'edit.title': {id: 'ws1', name: 'Renamed'},
+	});
+
+	// `merge=union` splices a half-written line into every clone that pulls it,
+	// and the log is append-only. Failing the load there took the whole board
+	// offline for everybody, permanently.
+	it('skips a truncated line and still loads the rest', () => {
+		const root = seedLog([
+			workspaceLine,
+			'{"v":1,"id":["01H0000000000000000000000B",null],"lock.node"',
+			titleLine,
+		]);
+
+		const result = loadMergedEventsWithUnreadable(root);
+
+		expect(isFail(result)).toBe(false);
+		if (isFail(result)) return;
+
+		expect(result.value.events.map(event => event.action)).toEqual([
+			'init.workspace',
+			'edit.title',
+		]);
+		expect(result.value.unreadable).toEqual([
+			{
+				eventId: null,
+				reason: 'corrupt-line',
+				detail: '01ARZ3NDEKTSV4RRFFQ69G5FAV.alice.jsonl:2 (invalid JSON)',
+				targetNodeId: null,
+			},
+		]);
+	});
+
+	it('skips a line whose envelope is malformed and still loads the rest', () => {
+		const root = seedLog([
+			workspaceLine,
+			JSON.stringify({v: 1, id: 'not-a-tuple', 'lock.node': {id: 'ws1'}}),
+			titleLine,
+		]);
+
+		const result = loadMergedEventsWithUnreadable(root);
+
+		expect(isFail(result)).toBe(false);
+		if (isFail(result)) return;
+
+		expect(result.value.events.map(event => event.action)).toEqual([
+			'init.workspace',
+			'edit.title',
+		]);
+		expect(result.value.unreadable).toHaveLength(1);
+		expect(result.value.unreadable[0]?.reason).toBe('corrupt-line');
+	});
+});
+
 describe('loadMergedEvents with foreign events on disk', () => {
 	it('loads a log containing unknown actions without failing', () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), 'epiq-load-'));

--- a/source/test/event-load.test.ts
+++ b/source/test/event-load.test.ts
@@ -101,6 +101,25 @@ describe('getSortedEvents', () => {
 
 		expect(sorted.map(e => e.id[0])).toEqual(['01A', '01B', '01C']);
 	});
+
+	// Every event refs its predecessor, so a log is one chain as deep as it is
+	// long. Recursing it overflowed the call stack at ~4.7k events, which meant
+	// an ordinary board eventually stopped opening for everybody at once.
+	it('orders a chain far longer than the call stack allows', () => {
+		const chain: ReconstructedEvent[] = [];
+		let previous: string | null = null;
+
+		for (let index = 0; index < 50_000; index++) {
+			const id = ulid(index + 1);
+			chain.push(event(id, previous));
+			previous = id;
+		}
+
+		const sorted = getSortedEvents(chain);
+
+		expect(sorted).toHaveLength(chain.length);
+		expect(sorted.map(e => e.id[0])).toEqual(chain.map(e => e.id[0]));
+	});
 });
 
 describe('splitEventsAtTime', () => {

--- a/source/test/event-persist.test.ts
+++ b/source/test/event-persist.test.ts
@@ -172,6 +172,36 @@ describe('event persist', () => {
 
 		expect(secondLine.id[1]).toBe(firstLine.id[0]);
 	});
+
+	// The edge is only a lower bound for the next id. An edge that cannot have
+	// a successor used to throw inside the mint, which left every machine
+	// unable to write anything ever again — the log is append-only, so there
+	// was no way back.
+	const writeEdge = (id: string) => {
+		const eventsDir = path.join(rootDir, '.epiq', 'events');
+		fs.mkdirSync(eventsDir, {recursive: true});
+		fs.writeFileSync(
+			path.join(eventsDir, '01ARZ3NDEKTSV4RRFFQ69G5FAV.mallory.jsonl'),
+			JSON.stringify({v: 1, id: [id, null], 'lock.node': {id: 'x'}}) + '\n',
+		);
+	};
+
+	it('still writes when the edge sits at the ULID timestamp ceiling', () => {
+		// encodeTime(281474976710655) === '7ZZZZZZZZZ'
+		writeEdge('7ZZZZZZZZZZZZZZZZZZZZZZZZZ');
+
+		const result = persist({event: event(), rootDir});
+
+		expect(isFail(result)).toBe(false);
+	});
+
+	it('still writes when the edge id is not a decodable ULID', () => {
+		writeEdge('not-a-ulid');
+
+		const result = persist({event: event(), rootDir});
+
+		expect(isFail(result)).toBe(false);
+	});
 });
 
 describe('schema version support', () => {

--- a/source/test/event-persist.test.ts
+++ b/source/test/event-persist.test.ts
@@ -202,6 +202,19 @@ describe('event persist', () => {
 
 		expect(isFail(result)).toBe(false);
 	});
+
+	// `getEventLogPath` refuses a name containing two `.jsonl`, which used to
+	// lock this person out of writing anything at all.
+	it('writes for a display name containing ".jsonl"', () => {
+		const result = persist({
+			event: event({userName: 'a.jsonl.b'}),
+			rootDir,
+		});
+
+		expect(isFail(result)).toBe(false);
+		if (isFail(result)) return;
+		expect(path.basename(result.value.path)).toBe('u1.a-jsonl.b.jsonl');
+	});
 });
 
 describe('schema version support', () => {

--- a/source/test/log-integrity.test.ts
+++ b/source/test/log-integrity.test.ts
@@ -1,0 +1,132 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import {beforeEach, describe, expect, it} from 'vitest';
+import {execGit} from '../git/git-utils.js';
+import {stageStateBranchOwnEventFile} from '../git/git.js';
+import {assertLogOnlyGrew, findDroppedLines} from '../git/log-integrity.js';
+import {isFail} from '../lib/model/result-types.js';
+import {makeTempDir} from './helpers/git-repo.js';
+
+const EVENT_FILE = '01ksayra4ghekjp888wfbwbrdd.jola.jsonl';
+const RELATIVE = `.epiq/events/${EVENT_FILE}`;
+
+const line = (n: number) =>
+	JSON.stringify({
+		v: 1,
+		id: [`01H${String(n).padStart(23, '0')}`, null],
+		'lock.node': {id: 'x'},
+	});
+
+describe('findDroppedLines', () => {
+	it('sees nothing wrong in a pure append', () => {
+		expect(findDroppedLines('a\nb\n', 'a\nb\nc\n')).toEqual([]);
+	});
+
+	it('ignores blank lines and a missing trailing newline', () => {
+		expect(findDroppedLines('a\nb\n', 'a\n\nb')).toEqual([]);
+	});
+
+	// Order is not load-bearing; the loader derives it from refId.
+	it('does not mind reordering, only loss', () => {
+		expect(findDroppedLines('a\nb\n', 'b\na\n')).toEqual([]);
+	});
+
+	it('reports a dropped line', () => {
+		expect(findDroppedLines('a\nb\nc\n', 'a\nc\n')).toEqual(['b']);
+	});
+
+	// The shape of the incident: 2158 lines replaced by one new one.
+	it('reports a wholesale truncation', () => {
+		const committed = ['a', 'b', 'c', 'd'].join('\n') + '\n';
+
+		expect(findDroppedLines(committed, 'fresh\n')).toEqual([
+			'a',
+			'b',
+			'c',
+			'd',
+		]);
+	});
+});
+
+describe('the sync path refuses a truncated log', () => {
+	let root: string;
+
+	const write = (lines: string[]) =>
+		fs.writeFileSync(path.join(root, RELATIVE), lines.join('\n') + '\n');
+
+	beforeEach(async () => {
+		root = makeTempDir();
+		fs.mkdirSync(path.join(root, '.epiq', 'events'), {recursive: true});
+
+		await execGit({args: ['init', '-q', '-b', 'main', '.'], cwd: root});
+		await execGit({args: ['config', 'user.name', 'Test'], cwd: root});
+		await execGit({args: ['config', 'user.email', 't@test'], cwd: root});
+
+		write([line(1), line(2), line(3)]);
+		await execGit({args: ['add', '-A'], cwd: root});
+		await execGit({args: ['commit', '-qm', 'seed', '--no-verify'], cwd: root});
+	});
+
+	it('stages an appended log', async () => {
+		write([line(1), line(2), line(3), line(4)]);
+
+		const result = await stageStateBranchOwnEventFile({
+			stateBranchRoot: root,
+			eventFileName: EVENT_FILE,
+		});
+
+		expect(isFail(result)).toBe(false);
+	});
+
+	it('refuses a log that lost a line, and stages nothing', async () => {
+		write([line(1), line(3)]);
+
+		const result = await stageStateBranchOwnEventFile({
+			stateBranchRoot: root,
+			eventFileName: EVENT_FILE,
+		});
+
+		expect(isFail(result)).toBe(true);
+		if (!isFail(result)) return;
+		expect(result.message).toContain('missing 1');
+		expect(result.message).toContain(RELATIVE);
+
+		// Nothing reached the index, so an autosync has nothing to push.
+		const staged = await execGit({
+			args: ['diff', '--cached', '--name-only'],
+			cwd: root,
+		});
+		if (isFail(staged)) throw new Error(staged.message);
+		expect(staged.value.stdout.trim()).toBe('');
+	});
+
+	// What actually happened: the whole log replaced by one fresh bootstrap
+	// event, committed by autosync, pushed, and pulled by everybody.
+	it('refuses a wholesale truncation', async () => {
+		write([line(99)]);
+
+		const result = await stageStateBranchOwnEventFile({
+			stateBranchRoot: root,
+			eventFileName: EVENT_FILE,
+		});
+
+		expect(isFail(result)).toBe(true);
+		if (!isFail(result)) return;
+		expect(result.message).toContain('missing 3 of the 3');
+	});
+
+	it('allows a first sync, where nothing is committed yet', async () => {
+		const fresh = makeTempDir();
+		fs.mkdirSync(path.join(fresh, '.epiq', 'events'), {recursive: true});
+		await execGit({args: ['init', '-q', '-b', 'main', '.'], cwd: fresh});
+		fs.writeFileSync(path.join(fresh, RELATIVE), line(1) + '\n');
+
+		const result = await assertLogOnlyGrew({
+			stateBranchRoot: fresh,
+			relativePath: RELATIVE,
+			workingContent: line(1) + '\n',
+		});
+
+		expect(isFail(result)).toBe(false);
+	});
+});

--- a/source/test/origin-guard.test.ts
+++ b/source/test/origin-guard.test.ts
@@ -1,0 +1,85 @@
+import {describe, expect, it} from 'vitest';
+import {
+	isForeignOrigin,
+	refuseCrossSiteRequest,
+} from '../gui/api/lib/origin-guard.js';
+
+describe('isForeignOrigin', () => {
+	const PORT = 3710;
+
+	// Not a browser, so there is no page to be tricked and nothing to spoof.
+	it('lets a request with no Origin through', () => {
+		expect(isForeignOrigin(undefined, PORT)).toBe(false);
+	});
+
+	it.each([
+		'http://127.0.0.1:3710',
+		'http://localhost:3710',
+		'http://epiq.localhost:3710',
+		'http://[::1]:3710',
+	])('accepts our own origin %s', origin => {
+		expect(isForeignOrigin(origin, PORT)).toBe(false);
+	});
+
+	it.each([
+		// The whole point: any page the user happens to have open.
+		'https://evil.example',
+		'http://evil.example',
+		// Right host, wrong server — another local app on another port.
+		'http://127.0.0.1:8080',
+		// A hostname that merely ends in one of ours.
+		'http://notlocalhost:3710',
+		'http://evil.epiq.localhost:3710',
+		// https on our port is still not a page this server served.
+		'https://127.0.0.1:3710',
+		// A sandboxed iframe or a file:// page.
+		'null',
+		'not a url',
+	])('rejects %s', origin => {
+		expect(isForeignOrigin(origin, PORT)).toBe(true);
+	});
+});
+
+describe('refuseCrossSiteRequest', () => {
+	const PORT = 3710;
+
+	const refuse = (
+		method: string,
+		origin?: string,
+		contentType?: string,
+	): ReturnType<typeof refuseCrossSiteRequest> =>
+		refuseCrossSiteRequest({method, origin, contentType}, PORT);
+
+	it('never refuses a read', () => {
+		expect(refuse('GET', 'https://evil.example')).toBeNull();
+		expect(refuse('HEAD', 'https://evil.example')).toBeNull();
+	});
+
+	it('refuses a write carrying a foreign Origin', () => {
+		expect(refuse('POST', 'https://evil.example', 'application/json')).toEqual({
+			status: 403,
+			message: 'Cross-origin request',
+		});
+		expect(refuse('DELETE', 'https://evil.example')).toEqual({
+			status: 403,
+			message: 'Cross-origin request',
+		});
+	});
+
+	// The CSRF that needs no Origin to be wrong: `text/plain` is a CORS simple
+	// request, so the browser sends it with no preflight at all.
+	it('refuses a POST that is not JSON', () => {
+		expect(refuse('POST', undefined, 'text/plain;charset=UTF-8')).toEqual({
+			status: 415,
+			message: 'Expected content-type: application/json',
+		});
+		expect(refuse('POST', undefined, undefined)?.status).toBe(415);
+	});
+
+	it('allows the GUI page’s own writes', () => {
+		expect(
+			refuse('POST', 'http://epiq.localhost:3710', 'application/json'),
+		).toBeNull();
+		expect(refuse('DELETE', 'http://127.0.0.1:3710')).toBeNull();
+	});
+});

--- a/source/test/websocket-mutation-broadcast.test.ts
+++ b/source/test/websocket-mutation-broadcast.test.ts
@@ -94,11 +94,17 @@ describe('websocket post-mutation state refresh', () => {
 		vi.mocked(closeIssue).mockResolvedValue(succeeded('closed', {} as never));
 
 		server = http.createServer();
-		setupWebsocket(server, '/repo', {onStateChanged: vi.fn()});
+
+		let boundPort = 0;
+		setupWebsocket(server, '/repo', {
+			onStateChanged: vi.fn(),
+			getPort: () => boundPort,
+		});
 
 		await new Promise<void>(resolve => server.listen(0, resolve));
 
 		const {port} = server.address() as AddressInfo;
+		boundPort = port;
 		client = new WebSocket(`ws://127.0.0.1:${port}/ws`);
 		client.on('message', raw => {
 			received.push(JSON.parse(raw.toString()) as ReceivedMessage);

--- a/source/test/websocket-origin.test.ts
+++ b/source/test/websocket-origin.test.ts
@@ -1,0 +1,65 @@
+import http from 'node:http';
+import {AddressInfo} from 'node:net';
+import {WebSocket} from 'ws';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {setupWebsocket} from '../gui/api/lib/websocket.js';
+
+let server: http.Server;
+let port: number;
+
+beforeEach(async () => {
+	server = http.createServer();
+
+	let boundPort = 0;
+	setupWebsocket(server, '/repo', {
+		onStateChanged: vi.fn(),
+		getPort: () => boundPort,
+	});
+
+	await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+	port = (server.address() as AddressInfo).port;
+	boundPort = port;
+});
+
+afterEach(async () => {
+	await new Promise<void>(resolve => server.close(() => resolve()));
+});
+
+const connect = (origin?: string): Promise<'open' | 'refused'> =>
+	new Promise(resolve => {
+		const socket = new WebSocket(
+			`ws://127.0.0.1:${port}/ws`,
+			origin ? {headers: {Origin: origin}} : {},
+		);
+
+		socket.on('open', () => {
+			socket.close();
+			resolve('open');
+		});
+		socket.on('error', () => resolve('refused'));
+	});
+
+// A WebSocket handshake is exempt from the same-origin policy, so any page the
+// user has open reached the whole mutation surface — including `sync`, which
+// pushes to the shared remote.
+describe('websocket handshake origin', () => {
+	it('refuses a handshake from a foreign origin', async () => {
+		await expect(connect('https://evil.example')).resolves.toBe('refused');
+	});
+
+	it('refuses a handshake from another local port', async () => {
+		await expect(connect('http://127.0.0.1:9999')).resolves.toBe('refused');
+	});
+
+	it('accepts the page this server serves', async () => {
+		await expect(connect(`http://epiq.localhost:${port}`)).resolves.toBe(
+			'open',
+		);
+		await expect(connect(`http://127.0.0.1:${port}`)).resolves.toBe('open');
+	});
+
+	// curl and the test harness send none; there is no page to be tricked.
+	it('accepts a client that sends no Origin at all', async () => {
+		await expect(connect()).resolves.toBe('open');
+	});
+});

--- a/source/test/websocket-schema.test.ts
+++ b/source/test/websocket-schema.test.ts
@@ -1,0 +1,72 @@
+import {describe, expect, it} from 'vitest';
+import {parseGuiMessage} from '../gui/api/lib/websocket.schema.js';
+
+const issueId = '01H0000000000000000000000A';
+
+describe('parseGuiMessage', () => {
+	it('accepts a well-formed message', () => {
+		const parsed = parseGuiMessage({type: 'issue:close', payload: {issueId}});
+
+		expect(parsed).toEqual({
+			ok: true,
+			message: {type: 'issue:close', payload: {issueId}},
+		});
+	});
+
+	it('accepts a message whose payload is optional', () => {
+		expect(parseGuiMessage({type: 'state:get'}).ok).toBe(true);
+		expect(parseGuiMessage({type: 'timeline:get'}).ok).toBe(true);
+	});
+
+	// Handlers spread the payload into the API call, and the spread wins — so an
+	// unknown `repoRoot` key pointed the server at a different project on the
+	// machine.
+	it('drops keys the message does not declare', () => {
+		const parsed = parseGuiMessage({
+			type: 'issue:comment:add',
+			payload: {issueId, body: 'hi', repoRoot: '/somewhere/else'},
+		});
+
+		expect(parsed.ok).toBe(true);
+		if (!parsed.ok || parsed.message.type !== 'issue:comment:add') {
+			throw new Error('expected an issue:comment:add message');
+		}
+
+		expect(parsed.message.payload).toEqual({issueId, body: 'hi'});
+	});
+
+	it.each([
+		['null', null],
+		['a number', 123],
+		['a string', 'issue:close'],
+		['an unknown type', {type: 'rm -rf'}],
+		['a missing payload', {type: 'issue:close'}],
+		['a missing field', {type: 'issue:comment:add', payload: {issueId}}],
+		[
+			'a wrong-typed field',
+			{type: 'issue:edit:title', payload: {issueId, title: 42}},
+		],
+		['an empty id', {type: 'issue:close', payload: {issueId: ''}}],
+		[
+			'a non-finite time',
+			{type: 'time-travel:scrub', payload: {targetTime: Infinity}},
+		],
+		[
+			'NaN as a time',
+			{type: 'time-travel:scrub', payload: {targetTime: Number.NaN}},
+		],
+		[
+			'an unknown move position',
+			{
+				type: 'issues:move',
+				payload: {issueId, parentId: issueId, position: {at: 'middle'}},
+			},
+		],
+	])('refuses %s', (_label, raw) => {
+		const parsed = parseGuiMessage(raw);
+
+		expect(parsed.ok).toBe(false);
+		if (parsed.ok) return;
+		expect(parsed.error).toMatch(/^Invalid message: /);
+	});
+});


### PR DESCRIPTION
Adversarial audit of the event log, sync, and both client transports. 15 commits, one ticket each.

**A live incident happened during this work and is fixed here:** the shared event log was truncated from 2158 lines to 1 and pushed (`d4cbd0b3`). Recovered by hand (`0288a99d`, 2175 lines, derived board byte-identical). The code hole that turned a damaged working copy into permanent shared history is closed by `8PYTCM`.

## prio-1

| Ref | |
|---|---|
| `VW1Z3QE` | `getSortedEvents` recursion blew the call stack at **4,686 events** — board permanently unopenable for everyone. Now iterative. |
| `CB211FF` | One unparseable line took the whole board offline forever. Now quarantined as an unreadable event. |
| `1SWDEZA` | An event id at ULID's ceiling made **every write fail forever on every machine**. |
| `E13S7BF` | Two events sharing an id derived **different boards per machine** (readdir order). Tie now broken by content. |
| `9VSKT61` | GUI WebSocket accepted **cross-origin handshakes** — any website could drive the board and `git push`. Verified live. |
| `23Z1P5P` | `/api` mutations were CSRF-able (`text/plain`, no preflight). Verified live. |
| `8PYTCM` | Sync committed the log as it sat on disk. Nothing checked an append-only log had only been appended to. |
| `51H3F1` | An event ordered before `init.workspace` hit `getState()`, which **throws** — every client crashed on load. |

## prio-2 / prio-3

`N5PJ6W7` websocket frames are schema-parsed — this also closed a `repoRoot` override letting a frame retarget another project on the machine · `NQSAGFS` size caps on every free-text field · `6GFWYBK` `createIssue` was the only title path skipping sanitization · `2SQA4PM` request bodies decoded once, not per chunk · `Q52MXQX` no throwing from a `Result` function · `2VPXPJX` a `.jsonl` display name no longer locks a user out of writing.

## Tests

`RYTZFJV` — the collab suite now publishes **hostile logs** between two real clones over git: half-written lines, bad envelopes, ULID-ceiling ids, non-ULID ids, forged roots, reused ids, and a 6,000-event chain. Each asserts the board opens, both machines derive the same order and board, and writes still work. It found `51H3F1` on its first run.

**Gate:** 711 unit · 11 collab · 44 GUI · typecheck, gui-types, eslint, prettier all clean. Rebased on `main`, fast-forward, every commit ref-prefixed.

## Still open (filed, not fixed)

`Y76V1ZY` + `61G931Z` are one problem tagged `human-input-needed` — an implausible timestamp distorts every time-based view, and the guard has to sit in the view layer or it makes rendering depend on wall clock. `FV86AFC` asks you to decide the trust model (attribution comes off the log file name; anyone who can push can forge it). `01M177S28YT4A46FX8KPJ10QQP` — test runs write into the real state branch. `MCP tool handlers take no lock` — filed from reading, not reproduced.
