### PR TITLE
Guard the two state-worktree deletions that destroy unsynced events

### DIFF
--- a/source/git/git-utils.ts
+++ b/source/git/git-utils.ts
@@ -570,6 +570,32 @@ export const isAheadOfUpstream = async (
 	);
 };
 
+/**
+ * Anything git would lose if this worktree were removed with `--force`:
+ * modified, staged and untracked alike. Untracked counts — a contributor's
+ * first event log is untracked until their first sync, so ignoring it would
+ * miss exactly the events most easily lost.
+ */
+export const hasUncommittedChanges = async (
+	worktreeRoot: string,
+): Promise<Result<boolean>> => {
+	const result = await execGitAllowFail({
+		args: ['status', '--porcelain', '--untracked-files=all'],
+		cwd: worktreeRoot,
+	});
+
+	if (result.exitCode !== 0) {
+		return failed(
+			result.stderr.trim() || 'Unable to inspect the worktree for changes',
+		);
+	}
+
+	return succeeded(
+		'Inspected worktree for changes',
+		result.stdout.trim().length > 0,
+	);
+};
+
 export const hasStagedChanges = async (
 	repoRoot: string,
 	pathspec?: string[],

--- a/source/git/git.ts
+++ b/source/git/git.ts
@@ -24,6 +24,7 @@ import {
 	hasLocalBranch,
 	hasRemote,
 	hasRemoteBranch,
+	hasUncommittedChanges,
 	hasUpstream,
 	hasWorktree,
 	normalizeExistingPath,
@@ -343,6 +344,35 @@ export const ensureStateBranchWorktree = async ({
 	}
 
 	if (existing && existing !== expected) {
+		// `worktreeRemove` passes `--force`, which is exactly what overrides
+		// git's refusal to delete a worktree holding uncommitted work — and the
+		// state worktree nearly always holds some, because every `persist`
+		// appends to the log and nothing commits until the next sync.
+		//
+		// The paths disagree whenever two processes resolve `EPIQ_GLOBAL_DIR`
+		// differently: a dev server, a test run, an agent with its own
+		// environment. Relocating then threw away every event the other process
+		// had written since its last sync, silently, and reported success.
+		const dirtyResult = await hasUncommittedChanges(existing);
+		if (isFail(dirtyResult)) return failed(dirtyResult.message);
+
+		if (dirtyResult.value) {
+			return failed(
+				[
+					`Refusing to move the state branch worktree away from ${existing}.`,
+					'',
+					'It holds changes that are not committed yet, which for this',
+					'branch means events no sync has published. Removing it would',
+					'destroy them outright — there is no stash or reflog to recover',
+					'a deleted worktree from.',
+					'',
+					`This worktree is expected at ${expected}, so something else is`,
+					'using a different EPIQ_GLOBAL_DIR against the same repository.',
+					'Sync from that location first, or point both at the same one.',
+				].join('\n'),
+			);
+		}
+
 		logger.info('Moving state branch worktree to expected location');
 
 		const removeResult = await git.worktreeRemove({

--- a/source/git/git.ts
+++ b/source/git/git.ts
@@ -4,7 +4,7 @@ import {failed, isFail, Result, succeeded} from '../lib/model/result-types.js';
 import {logger} from '../logger.js';
 import {git} from './git-commands.js';
 import {ORIGIN, getStateBranch} from './git-constants.js';
-import {assertLogOnlyGrew} from './log-integrity.js';
+import {assertLogOnlyGrew, findStrandedEventLogs} from './log-integrity.js';
 import {
 	EMPTY_TREE_SHA,
 	ensureDir,
@@ -295,6 +295,29 @@ const createStateBranchWorktree = async ({
 		fs.existsSync(stateBranchRoot) &&
 		!fs.existsSync(path.join(stateBranchRoot, '.git'))
 	) {
+		// A worktree missing its `.git` pointer is broken, but broken is not the
+		// same as empty: the event logs are still sitting in it, and without
+		// `.git` there is no committed copy here to recover them from. `rm -rf`
+		// would be the one deletion in this codebase that no git object survives.
+		const strandedResult = findStrandedEventLogs(stateBranchRoot);
+		if (isFail(strandedResult)) return failed(strandedResult.message);
+
+		if (strandedResult.value.length > 0) {
+			return failed(
+				[
+					`Refusing to delete ${stateBranchRoot}.`,
+					'',
+					'It is not a usable worktree — it has no .git — but it still holds',
+					`${strandedResult.value.length} event log(s) with content:`,
+					...strandedResult.value.map(name => `  ${name}`),
+					'',
+					'Deleting it would destroy them, and with no .git here there is no',
+					'committed copy to recover from. Move the directory aside and',
+					'salvage the logs before letting epiq recreate the worktree.',
+				].join('\n'),
+			);
+		}
+
 		logger.info('Removing broken state branch worktree path');
 		removePath(stateBranchRoot);
 	}

--- a/source/git/log-integrity.ts
+++ b/source/git/log-integrity.ts
@@ -1,5 +1,8 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import {execGitAllowFail} from './git-utils.js';
 import {failed, Result, succeeded} from '../lib/model/result-types.js';
+import {EPIQ_DIR_NAME, EVENTS_DIR_NAME} from '../lib/storage/paths.js';
 
 /**
  * The event log is append-only. That is not a style preference — it is what
@@ -19,6 +22,36 @@ import {failed, Result, succeeded} from '../lib/model/result-types.js';
 
 const linesIn = (content: string): string[] =>
 	content.split('\n').filter(line => line.trim().length > 0);
+
+/**
+ * Event logs sitting in a directory that is about to be deleted wholesale.
+ * Non-empty ones only: an empty file is nothing to save, and refusing over one
+ * would strand the very cleanup that unblocks the user.
+ */
+export const findStrandedEventLogs = (root: string): Result<string[]> => {
+	const dir = path.join(root, EPIQ_DIR_NAME, EVENTS_DIR_NAME);
+
+	try {
+		if (!fs.existsSync(dir)) return succeeded('No events directory', []);
+
+		const stranded = fs
+			.readdirSync(dir)
+			.filter(name => name.endsWith('.jsonl'))
+			.filter(
+				name =>
+					linesIn(fs.readFileSync(path.join(dir, name), 'utf8')).length > 0,
+			);
+
+		return succeeded('Looked for stranded event logs', stranded);
+	} catch (error) {
+		// Unreadable is not "safe to delete".
+		return failed(
+			`Unable to check ${dir} for event logs before deleting it: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+	}
+};
 
 /** Lines present in `committed` that `working` no longer has. */
 export const findDroppedLines = (

--- a/source/test/worktree-move-data-loss.test.ts
+++ b/source/test/worktree-move-data-loss.test.ts
@@ -77,6 +77,50 @@ describe('relocating the state worktree must not discard unsynced events', () =>
 		expect(fs.readFileSync(logPath(), 'utf8')).toContain('UNSYNCED EVENT');
 	});
 
+	// The other deletion on this path: a directory with no `.git` is treated as
+	// a broken worktree and `rm -rf`'d. Broken is not empty — the logs are
+	// still in it, and with no `.git` there is no committed copy here to
+	// recover them from. That is the one deletion no git object survives.
+	it('refuses to delete a broken worktree that still holds event logs', async () => {
+		// Its own repo with no worktree registered yet, so this reaches the
+		// delete rather than the relocation guard above.
+		const freshRepo = makeTempDir();
+		await execGit({args: ['init', '-q', '-b', 'main', '.'], cwd: freshRepo});
+		await execGit({args: ['config', 'user.name', 'Test'], cwd: freshRepo});
+		await execGit({args: ['config', 'user.email', 't@test'], cwd: freshRepo});
+		fs.writeFileSync(path.join(freshRepo, 'README.md'), 'x\n');
+		await execGit({args: ['add', '-A'], cwd: freshRepo});
+		await execGit({
+			args: ['commit', '-qm', 'init', '--no-verify'],
+			cwd: freshRepo,
+		});
+
+		const branch = await ensureLocalStateBranch({
+			repoRoot: freshRepo,
+			stateBranchName: BRANCH,
+		});
+		if (isFail(branch)) throw new Error(branch.message);
+
+		// A directory where the worktree should be, holding logs but no `.git`.
+		const stranded = path.join(makeTempDir(), 'worktrees', 'project');
+		fs.mkdirSync(path.join(stranded, '.epiq', 'events'), {recursive: true});
+		fs.writeFileSync(path.join(stranded, LOG), 'STRANDED EVENT\n');
+
+		const result = await ensureStateBranchWorktree({
+			repoRoot: freshRepo,
+			stateBranchRoot: stranded,
+			stateBranchName: BRANCH,
+		});
+
+		expect(isFail(result)).toBe(true);
+		if (!isFail(result)) return;
+		expect(result.message).toContain('event log');
+
+		expect(fs.readFileSync(path.join(stranded, LOG), 'utf8')).toContain(
+			'STRANDED EVENT',
+		);
+	});
+
 	// The relocation itself is legitimate; only doing it over unsynced work is
 	// not. A committed worktree still moves.
 	it('still relocates a worktree with nothing to lose', async () => {

--- a/source/test/worktree-move-data-loss.test.ts
+++ b/source/test/worktree-move-data-loss.test.ts
@@ -1,0 +1,101 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import {beforeEach, describe, expect, it} from 'vitest';
+import {execGit} from '../git/git-utils.js';
+import {ensureLocalStateBranch, ensureStateBranchWorktree} from '../git/git.js';
+import {isFail} from '../lib/model/result-types.js';
+import {makeTempDir} from './helpers/git-repo.js';
+
+const BRANCH = 'epiq/state';
+const LOG = '.epiq/events/01h0000000000000000000000a.alice.jsonl';
+
+/**
+ * `ensureStateBranchWorktree` relocates the state worktree with
+ * `git worktree remove --force` whenever the path it resolves differs from
+ * where the branch is currently checked out — which is what happens the moment
+ * two processes disagree about `EPIQ_GLOBAL_DIR`.
+ *
+ * `--force` is precisely the flag that overrides git's refusal to delete a
+ * worktree with uncommitted changes, and the state worktree is *always*
+ * carrying uncommitted changes: every `persist` appends to the log and nothing
+ * commits until the next sync. So relocating it throws away every event
+ * written since the last sync, with no stash and no reflog to recover from.
+ */
+describe('relocating the state worktree must not discard unsynced events', () => {
+	let repoRoot: string;
+	let originalRoot: string;
+	let otherRoot: string;
+
+	const logPath = () => path.join(originalRoot, LOG);
+
+	beforeEach(async () => {
+		repoRoot = makeTempDir();
+		originalRoot = path.join(makeTempDir(), 'worktrees', 'project');
+		otherRoot = path.join(makeTempDir(), 'worktrees', 'project');
+
+		await execGit({args: ['init', '-q', '-b', 'main', '.'], cwd: repoRoot});
+		await execGit({args: ['config', 'user.name', 'Test'], cwd: repoRoot});
+		await execGit({args: ['config', 'user.email', 't@test'], cwd: repoRoot});
+		fs.writeFileSync(path.join(repoRoot, 'README.md'), 'x\n');
+		await execGit({args: ['add', '-A'], cwd: repoRoot});
+		await execGit({
+			args: ['commit', '-qm', 'init', '--no-verify'],
+			cwd: repoRoot,
+		});
+
+		const branch = await ensureLocalStateBranch({
+			repoRoot,
+			stateBranchName: BRANCH,
+		});
+		if (isFail(branch)) throw new Error(branch.message);
+
+		const created = await ensureStateBranchWorktree({
+			repoRoot,
+			stateBranchRoot: originalRoot,
+			stateBranchName: BRANCH,
+		});
+		if (isFail(created)) throw new Error(created.message);
+
+		// The steady state of a live board: events appended, not yet synced.
+		fs.mkdirSync(path.dirname(logPath()), {recursive: true});
+		fs.writeFileSync(logPath(), 'UNSYNCED EVENT\n');
+	});
+
+	it('refuses to relocate, and leaves the events where they are', async () => {
+		const result = await ensureStateBranchWorktree({
+			repoRoot,
+			stateBranchRoot: otherRoot,
+			stateBranchName: BRANCH,
+		});
+
+		expect(isFail(result)).toBe(true);
+		if (!isFail(result)) return;
+		expect(result.message).toContain('not committed yet');
+		expect(result.message).toContain('EPIQ_GLOBAL_DIR');
+
+		expect(fs.existsSync(logPath())).toBe(true);
+		expect(fs.readFileSync(logPath(), 'utf8')).toContain('UNSYNCED EVENT');
+	});
+
+	// The relocation itself is legitimate; only doing it over unsynced work is
+	// not. A committed worktree still moves.
+	it('still relocates a worktree with nothing to lose', async () => {
+		await execGit({args: ['add', '-A'], cwd: originalRoot});
+		await execGit({
+			args: ['commit', '-qm', 'sync', '--no-verify'],
+			cwd: originalRoot,
+		});
+
+		const result = await ensureStateBranchWorktree({
+			repoRoot,
+			stateBranchRoot: otherRoot,
+			stateBranchName: BRANCH,
+		});
+
+		expect(isFail(result)).toBe(false);
+		expect(fs.existsSync(path.join(otherRoot, LOG))).toBe(true);
+		expect(fs.readFileSync(path.join(otherRoot, LOG), 'utf8')).toContain(
+			'UNSYNCED EVENT',
+		);
+	});
+});


### PR DESCRIPTION
Follow-up to #117, narrowed to one class: **operations that destroy shared state or kill the process outright.**

Both fixes here are on the code path behind the incident in #117 — the state worktree being emptied and the truncation then committed and pushed.

## `2WFGV2` — relocating the state worktree force-deletes unsynced events, and reports success

`ensureStateBranchWorktree` runs `git worktree remove --force` whenever the path it resolves differs from where the branch is checked out. `--force` is exactly the flag that overrides git's refusal to delete a dirty worktree — and the state worktree is nearly always dirty, because every `persist` appends to the log and nothing commits until the next sync.

The paths disagree the moment two processes resolve `EPIQ_GLOBAL_DIR` differently: a dev server, a test run, an agent started from a different shell. **`boot()` reaches this on every MCP call and every GUI request.**

It then returned success, so the caller carried on and the next `persist` recreated the log from empty — which is exactly the one-line file found at the scene in #117.

Now checks `git status --porcelain --untracked-files=all` first and refuses, naming both paths. Untracked is the half that matters: a contributor's first log is untracked until their first sync.

## `NYC33Q4` — a broken worktree is `rm -rf`'d with its event logs still in it

`createStateBranchWorktree` deletes the directory outright when it has no `.git`. But broken is not empty, and no `.git` is precisely the case where there is **no committed copy at that path to recover from** — the one deletion here that no git object survives. Everything else that goes wrong with the log is recoverable because git is content-addressed; this is not.

Now scans `.epiq/events` for non-empty logs and refuses, listing them.

Both verified red without the guard. A clean worktree still relocates, covered by its own case.

## Investigated and deliberately not changed

- **`getState()` throwing.** 115 call sites looked alarming, but `resetState()` re-initialises rather than clearing, so the singleton is only ever undefined before the first `initWorkspaceState`. The `materializeSkip` guard shipped in #117 already covers the reachable path. No change.
- **`1TCS14` — sync aborts an in-flight rebase before checking whether one is in flight.** Real ordering bug: `bootstrapStateBranchStorage` runs `git rebase --abort` before the `hasInProgressGitOperation` check that exists to prevent exactly that. I implemented the reorder and reverted it — it breaks `recovers from a stale rebase left behind by an interrupted sync`, deliberately, because that blind abort *is* the crash-recovery path. Filed with the trade-off table and options instead; it needs a call on stale-vs-live detection, not a patch.

**Gate:** 724 unit · 11 collab (container) · 11 TUI e2e (container) · 44 GUI · lint, typecheck, format. Rebased on latest `main`.
