### PR TITLE
7CDYBC2 resolve the git binary once so every spawn skips the PATH walk

### DIFF
--- a/source/git/git-utils.ts
+++ b/source/git/git-utils.ts
@@ -13,6 +13,32 @@ export type GitExecResult = {
 
 const GIT_TIMEOUT_MS = 10_000;
 
+// A bare `spawn('git')` has execvp attempt an execve in every PATH directory
+// ahead of git's, and each miss costs milliseconds; resolve the path once.
+const resolveGitBinary = (): string => {
+	const names = process.platform === 'win32' ? ['git.exe', 'git'] : ['git'];
+
+	for (const dir of (process.env['PATH'] ?? '').split(path.delimiter)) {
+		if (!dir) continue;
+
+		for (const name of names) {
+			const candidate = path.join(dir, name);
+
+			try {
+				if (!fs.statSync(candidate).isFile()) continue;
+				fs.accessSync(candidate, fs.constants.X_OK);
+				return candidate;
+			} catch {
+				continue;
+			}
+		}
+	}
+
+	return 'git';
+};
+
+export const GIT_BIN = resolveGitBinary();
+
 export const gitEnv = {
 	...process.env,
 	GIT_TERMINAL_PROMPT: '0',
@@ -48,7 +74,7 @@ const runGit = ({
 			return;
 		}
 
-		const child = spawn('git', args, {
+		const child = spawn(GIT_BIN, args, {
 			cwd,
 			stdio: ['ignore', 'pipe', 'pipe'],
 			env: gitEnv,
@@ -170,7 +196,7 @@ export const readGitBlobsBatch = (
 			return;
 		}
 
-		const child = spawn('git', ['cat-file', '--batch'], {
+		const child = spawn(GIT_BIN, ['cat-file', '--batch'], {
 			cwd,
 			stdio: ['pipe', 'pipe', 'pipe'],
 			env: gitEnv,

--- a/source/test/git-safety.test.ts
+++ b/source/test/git-safety.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import {afterEach, describe, expect, it} from 'vitest';
 import {git} from '../git/git-commands.js';
 import {ensureInitialCommit, INITIAL_COMMIT_MESSAGE} from '../git/git.js';
+import {GIT_BIN} from '../git/git-utils.js';
 import {isFail} from '../lib/model/result-types.js';
 
 // epiq writes commits in the user's own repository in exactly one place, and
@@ -14,7 +15,7 @@ import {isFail} from '../lib/model/result-types.js';
 const created: string[] = [];
 
 const gitIn = (repo: string, args: string[]): string =>
-	execFileSync('git', args, {cwd: repo, encoding: 'utf8'}).trim();
+	execFileSync(GIT_BIN, args, {cwd: repo, encoding: 'utf8'}).trim();
 
 const makeRepo = (): string => {
 	const repo = fs.realpathSync(

--- a/source/test/git-utils.test.ts
+++ b/source/test/git-utils.test.ts
@@ -7,6 +7,7 @@ import {
 	execGit,
 	execGitAllowFail,
 	getCurrentBranch,
+	GIT_BIN,
 	gitEnv,
 	hasInProgressGitOperation,
 	isDetachedHead,
@@ -90,6 +91,11 @@ describe('git-utils', () => {
 		// usable agent/key opens /dev/tty to prompt, which can get a background
 		// process group (e.g. the MCP server) SIGTTIN-stopped instead of failing.
 		expect(gitEnv['GIT_SSH_COMMAND']).toContain('BatchMode=yes');
+	});
+
+	it('resolves git to an absolute executable so a spawn skips the PATH walk', () => {
+		expect(path.isAbsolute(GIT_BIN)).toBe(true);
+		expect(() => fs.accessSync(GIT_BIN, fs.constants.X_OK)).not.toThrow();
 	});
 
 	it('execGit fails when cwd does not exist', async () => {


### PR DESCRIPTION
\`runGit\` spawned bare \`git\`, so libuv's \`execvp\` tried an \`execve\` in every PATH directory ahead of git's on each call — ~9 on a typical mac, each miss costing milliseconds. From Node a \`git rev-parse\` took 67–95ms vs ~10ms by absolute path, and under 14 parallel vitest workers that compounded to 2–30s per git-backed test.

\`GIT_BIN\` is now resolved once at module load by a stat-based PATH walk and both spawn sites use it; \`git-safety\`'s \`gitIn\` helper uses it too. Every runtime git call in the TUI/MCP/GUI gets the same saving.

\`npm test\` on the same 721 tests, coverage on: **96.2s → 13.0s wall, 302.5s → 31.7s summed**.

Ticket: 7CDYBC2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017V41kJNmbS6M8E6krcjK2J