### PR TITLE
Cross-process lock over the state worktree

### DIFF
--- a/source/git/git-utils.ts
+++ b/source/git/git-utils.ts
@@ -309,7 +309,7 @@ export const commitAndGetSha = async ({
 		shaResult.value.stdout.trim(),
 	);
 };
-const getGitDir = async (repoRoot: string): Promise<Result<string>> => {
+export const getGitDir = async (repoRoot: string): Promise<Result<string>> => {
 	const result = await execGit({
 		cwd: repoRoot,
 		args: ['rev-parse', '--git-dir'],

--- a/source/git/sync-lock.ts
+++ b/source/git/sync-lock.ts
@@ -1,0 +1,245 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {failed, isFail, Result, succeeded} from '../lib/model/result-types.js';
+import {getGitDir} from './git-utils.js';
+import {logger} from '../logger.js';
+
+/**
+ * A cross-process lock over the state branch worktree.
+ *
+ * `runExclusive` serializes work inside one process; it is a promise chain and
+ * dies with the process, so it says nothing about the several other processes
+ * writing this same worktree — a TUI, a GUI autosync, an MCP server per agent.
+ *
+ * The case that forced this: `ensureStateBranchCheckedOut` runs
+ * `git rebase --abort` whenever HEAD is not on the state branch, and mid-rebase
+ * HEAD is detached. A live sync's rebase and a rebase abandoned by a crashed
+ * process are indistinguishable from git alone, so aborting recovered from the
+ * second by destroying the first. Whether a process still holds the worktree is
+ * not something git knows, but it is something the operating system knows.
+ *
+ * Advisory, deliberately: it binds epiq processes, not a person running git in
+ * the worktree by hand. Git's own `index.lock` and `rebase-merge/` remain the
+ * hard boundary. Every writer here is an epiq process, so in practice this
+ * covers the cases that actually occur.
+ *
+ * Assumes the worktree is on a local filesystem, which `~/.epiq-global` is.
+ * `pid` means nothing across hosts and `wx` is not reliably atomic on NFS, so
+ * `hostname` is recorded and a lock from elsewhere is never broken on liveness.
+ */
+
+const LOCK_FILE = 'epiq-sync.lock';
+
+/**
+ * Backstop for the one case liveness cannot settle: a dead holder whose pid has
+ * been recycled by an unrelated process. Generous — every git call this lock
+ * spans already caps itself at 10s, and being wrong here means breaking a live
+ * lock, which is the failure this whole mechanism exists to avoid.
+ */
+const STALE_AFTER_MS = 10 * 60 * 1000;
+
+type LockHolder = {
+	pid: number;
+	hostname: string;
+	startedAt: number;
+	operation: string;
+};
+
+export type LockOutcome =
+	| {acquired: true; release: () => void}
+	| {acquired: false; heldBy: LockHolder};
+
+const parseHolder = (raw: string): LockHolder | null => {
+	try {
+		const value = JSON.parse(raw) as Partial<LockHolder>;
+
+		if (
+			typeof value.pid !== 'number' ||
+			typeof value.hostname !== 'string' ||
+			typeof value.startedAt !== 'number' ||
+			typeof value.operation !== 'string'
+		) {
+			return null;
+		}
+
+		return value as LockHolder;
+	} catch {
+		return null;
+	}
+};
+
+/**
+ * `kill(pid, 0)` sends nothing; it only asks whether the pid can be signalled.
+ * `EPERM` means the process exists but belongs to another user — alive, and
+ * emphatically not ours to break.
+ */
+const isProcessAlive = (pid: number): boolean => {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		return (error as NodeJS.ErrnoException).code === 'EPERM';
+	}
+};
+
+/**
+ * A lock nobody is holding any more. Unreadable counts: a truncated or
+ * half-written lock file has no holder to protect, and leaving it would wedge
+ * the worktree permanently.
+ */
+const isAbandoned = (holder: LockHolder | null): boolean => {
+	if (!holder) return true;
+
+	// Another machine's pid is not ours to interpret, so only age can settle it.
+	if (holder.hostname !== os.hostname()) {
+		return Date.now() - holder.startedAt > STALE_AFTER_MS;
+	}
+
+	if (!isProcessAlive(holder.pid)) return true;
+
+	return Date.now() - holder.startedAt > STALE_AFTER_MS;
+};
+
+export const describeHolder = (holder: LockHolder): string =>
+	`${holder.operation} (pid ${holder.pid} on ${
+		holder.hostname
+	}, started ${new Date(holder.startedAt).toISOString()})`;
+
+const readHolder = (lockPath: string): LockHolder | null => {
+	try {
+		return parseHolder(fs.readFileSync(lockPath, 'utf8'));
+	} catch {
+		// Gone between the failed write and this read: another process released
+		// it, which is the same as never having held it.
+		return null;
+	}
+};
+
+const write = (lockPath: string, operation: string): boolean => {
+	const holder: LockHolder = {
+		pid: process.pid,
+		hostname: os.hostname(),
+		startedAt: Date.now(),
+		operation,
+	};
+
+	try {
+		// `wx` fails when the file exists, which is the whole acquisition: the
+		// check and the claim are one syscall, so two processes cannot both win.
+		fs.writeFileSync(lockPath, JSON.stringify(holder), {flag: 'wx'});
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+/**
+ * Takes the lock, or reports who holds it. Never waits: a caller that cannot
+ * have the worktree wants to say so and move on, not to queue behind a sync
+ * that may be stuck on an unreachable remote.
+ */
+export const acquireSyncLock = async ({
+	worktreeRoot,
+	operation,
+}: {
+	worktreeRoot: string;
+	operation: string;
+}): Promise<Result<LockOutcome>> => {
+	// The gitdir, never the worktree tree: nothing here may ever become
+	// committable, and `.epiq/` is staged by glob.
+	const gitDirResult = await getGitDir(worktreeRoot);
+	if (isFail(gitDirResult)) return failed(gitDirResult.message);
+
+	const lockPath = path.join(gitDirResult.value, LOCK_FILE);
+
+	const release = () => {
+		try {
+			// Only ours: a lock we broke and then lost a race for belongs to
+			// whoever wrote it after us.
+			const current = readHolder(lockPath);
+			if (current && current.pid === process.pid) fs.rmSync(lockPath);
+		} catch {
+			// Releasing is best-effort. A lock left behind is recovered by the
+			// liveness check on the next attempt, which is exactly its job.
+		}
+	};
+
+	if (write(lockPath, operation)) {
+		return succeeded('Acquired sync lock', {acquired: true, release});
+	}
+
+	const holder = readHolder(lockPath);
+
+	if (!isAbandoned(holder)) {
+		return succeeded('Sync lock is held', {
+			acquired: false,
+			heldBy: holder as LockHolder,
+		});
+	}
+
+	logger.info(
+		`Breaking an abandoned sync lock: ${
+			holder ? describeHolder(holder) : 'unreadable lock file'
+		}`,
+	);
+
+	try {
+		fs.rmSync(lockPath, {force: true});
+	} catch {
+		// Someone else broke it first; the retry below settles who wins.
+	}
+
+	if (write(lockPath, operation)) {
+		return succeeded('Acquired sync lock after breaking a stale one', {
+			acquired: true,
+			release,
+		});
+	}
+
+	// Lost the race to whoever else was breaking the same stale lock. They hold
+	// it legitimately now, so this is a refusal, not an error.
+	const winner = readHolder(lockPath);
+
+	return succeeded('Sync lock taken by another process', {
+		acquired: false,
+		heldBy: winner ?? {
+			pid: -1,
+			hostname: os.hostname(),
+			startedAt: Date.now(),
+			operation: 'unknown',
+		},
+	});
+};
+
+/** Runs `fn` holding the lock, or returns null if somebody else has it. */
+export const withSyncLock = async <T>({
+	worktreeRoot,
+	operation,
+	fn,
+}: {
+	worktreeRoot: string;
+	operation: string;
+	fn: () => Promise<T>;
+}): Promise<Result<T | null>> => {
+	const lockResult = await acquireSyncLock({worktreeRoot, operation});
+	if (isFail(lockResult)) return failed(lockResult.message);
+
+	if (!lockResult.value.acquired) {
+		logger.info(
+			`Skipping ${operation}: the state worktree is held by ${describeHolder(
+				lockResult.value.heldBy,
+			)}`,
+		);
+
+		return succeeded('State worktree is held by another process', null);
+	}
+
+	const {release} = lockResult.value;
+
+	try {
+		return succeeded('Ran under the sync lock', await fn());
+	} finally {
+		release();
+	}
+};

--- a/source/git/sync.ts
+++ b/source/git/sync.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import {failed, isFail, Result, succeeded} from '../lib/model/result-types.js';
 import {
 	failSync,
@@ -30,6 +31,7 @@ import {
 	stageStateBranchMediaFiles,
 	stageStateBranchOwnEventFile,
 } from './git.js';
+import {withSyncLock} from './sync-lock.js';
 
 type SyncSummary = {
 	repoRoot: string;
@@ -41,6 +43,8 @@ type SyncSummary = {
 	bootstrapped: boolean;
 	// Local work is committed; the remote could not be reached.
 	offline: boolean;
+	// Another process held the state worktree; nothing was attempted.
+	skipped?: boolean;
 };
 
 type SyncArgs = {
@@ -261,7 +265,7 @@ const offlineSummary = (
 	});
 };
 
-export const syncEpiqWithRemote = async ({
+const runSync = async ({
 	cwd = process.cwd(),
 	ownEventFileName,
 }: SyncArgs): Promise<Result<SyncSummary>> => {
@@ -491,4 +495,62 @@ export const syncEpiqWithRemote = async ({
 		bootstrapped,
 		offline: false,
 	});
+};
+
+/**
+ * Only one process may drive the state worktree at a time.
+ *
+ * `runExclusive` covers a single process; this covers the several that share
+ * one board — a TUI, a GUI autosync, an MCP server per agent. Without it,
+ * bootstrap's `git rebase --abort` could not tell a live sync's rebase from one
+ * a crashed process abandoned, and recovered from the second by destroying the
+ * first.
+ */
+export const syncEpiqWithRemote = async (
+	args: SyncArgs,
+): Promise<Result<SyncSummary>> => {
+	const cwd = args.cwd ?? process.cwd();
+
+	const repoRootResult = await getRepoRootDir(cwd);
+	if (isFail(repoRootResult)) return failSync(repoRootResult.message);
+
+	const stateBranchRootResult = getStateBranchRoot({
+		repoRoot: repoRootResult.value,
+	});
+	if (isFail(stateBranchRootResult)) {
+		return failSync(stateBranchRootResult.message);
+	}
+
+	const stateBranchRoot = stateBranchRootResult.value;
+
+	// There is no worktree to hold before bootstrap creates one. Two processes
+	// racing a project's very first sync is a narrower window than this lock
+	// addresses, and taking a lock inside a directory that does not exist yet
+	// would need somewhere else to put it.
+	if (!fs.existsSync(stateBranchRoot)) return runSync(args);
+
+	const lockedResult = await withSyncLock({
+		worktreeRoot: stateBranchRoot,
+		operation: 'sync',
+		fn: () => runSync(args),
+	});
+	if (isFail(lockedResult)) return failSync(lockedResult.message);
+
+	// Held elsewhere. Reported as a skip rather than a failure: autosync runs
+	// every few seconds, and a contended worktree is normal traffic, not an
+	// error worth putting in front of the user each time.
+	if (lockedResult.value === null) {
+		return succeeded('Another process is syncing this board', {
+			repoRoot: repoRootResult.value,
+			stateBranchRoot,
+			createdCommit: false,
+			pulled: false,
+			pushed: false,
+			bootstrapped: false,
+			offline: false,
+			skipped: true,
+		});
+	}
+
+	return lockedResult.value;
 };

--- a/source/test/sync-lock.test.ts
+++ b/source/test/sync-lock.test.ts
@@ -1,0 +1,202 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {beforeEach, describe, expect, it} from 'vitest';
+import {execGit, getGitDir} from '../git/git-utils.js';
+import {acquireSyncLock, withSyncLock} from '../git/sync-lock.js';
+import {isFail} from '../lib/model/result-types.js';
+import {makeTempDir} from './helpers/git-repo.js';
+
+/**
+ * The distinction this exists to make: a lock held by a process that is still
+ * running must be respected, and one left behind by a process that is gone must
+ * not wedge the worktree forever. Git cannot tell those apart, which is why
+ * `rebase --abort` recovered from a crash by destroying a live sync.
+ */
+describe('sync lock', () => {
+	let worktree: string;
+	let lockPath: string;
+
+	const writeLock = (holder: Record<string, unknown>) =>
+		fs.writeFileSync(lockPath, JSON.stringify(holder));
+
+	beforeEach(async () => {
+		worktree = makeTempDir();
+		await execGit({args: ['init', '-q', '-b', 'main', '.'], cwd: worktree});
+
+		const gitDir = await getGitDir(worktree);
+		if (isFail(gitDir)) throw new Error(gitDir.message);
+		lockPath = path.join(gitDir.value, 'epiq-sync.lock');
+	});
+
+	it('acquires when nobody holds it, and releases after', async () => {
+		const result = await acquireSyncLock({
+			worktreeRoot: worktree,
+			operation: 'sync',
+		});
+
+		expect(isFail(result)).toBe(false);
+		if (isFail(result) || !result.value.acquired) throw new Error('not held');
+
+		expect(fs.existsSync(lockPath)).toBe(true);
+		result.value.release();
+		expect(fs.existsSync(lockPath)).toBe(false);
+	});
+
+	// The whole point: process 1 is mid-rebase, process 2 must not touch it.
+	it('refuses while a live process holds it', async () => {
+		writeLock({
+			pid: process.pid,
+			hostname: os.hostname(),
+			startedAt: Date.now(),
+			operation: 'sync',
+		});
+
+		const result = await acquireSyncLock({
+			worktreeRoot: worktree,
+			operation: 'sync',
+		});
+
+		expect(isFail(result)).toBe(false);
+		if (isFail(result)) return;
+		expect(result.value.acquired).toBe(false);
+	});
+
+	// The other half: a crashed sync must not lock the board out permanently.
+	it('breaks a lock whose holder is gone', async () => {
+		// Vanishingly unlikely to be live, and the liveness check is what decides
+		// — not the number itself.
+		writeLock({
+			pid: 0x7ffffff,
+			hostname: os.hostname(),
+			startedAt: Date.now(),
+			operation: 'sync',
+		});
+
+		const result = await acquireSyncLock({
+			worktreeRoot: worktree,
+			operation: 'sync',
+		});
+
+		expect(isFail(result)).toBe(false);
+		if (isFail(result)) return;
+		expect(result.value.acquired).toBe(true);
+	});
+
+	it('breaks a lock left by a live process that has held it far too long', async () => {
+		writeLock({
+			pid: process.pid,
+			hostname: os.hostname(),
+			startedAt: Date.now() - 60 * 60 * 1000,
+			operation: 'sync',
+		});
+
+		const result = await acquireSyncLock({
+			worktreeRoot: worktree,
+			operation: 'sync',
+		});
+
+		expect(isFail(result)).toBe(false);
+		if (isFail(result)) return;
+		expect(result.value.acquired).toBe(true);
+	});
+
+	// A half-written lock has no holder to protect, and leaving it would wedge
+	// the worktree with no way out.
+	it('breaks an unreadable lock', async () => {
+		fs.writeFileSync(lockPath, '{"pid": ');
+
+		const result = await acquireSyncLock({
+			worktreeRoot: worktree,
+			operation: 'sync',
+		});
+
+		expect(isFail(result)).toBe(false);
+		if (isFail(result)) return;
+		expect(result.value.acquired).toBe(true);
+	});
+
+	// Another host's pid means nothing here, so only age may settle it.
+	it('respects a fresh lock from another machine', async () => {
+		writeLock({
+			pid: 0x7ffffff,
+			hostname: `${os.hostname()}-elsewhere`,
+			startedAt: Date.now(),
+			operation: 'sync',
+		});
+
+		const result = await acquireSyncLock({
+			worktreeRoot: worktree,
+			operation: 'sync',
+		});
+
+		expect(isFail(result)).toBe(false);
+		if (isFail(result)) return;
+		expect(result.value.acquired).toBe(false);
+	});
+
+	describe('withSyncLock', () => {
+		it('runs the work and releases even when it throws', async () => {
+			await expect(
+				withSyncLock({
+					worktreeRoot: worktree,
+					operation: 'sync',
+					fn: async () => {
+						throw new Error('boom');
+					},
+				}),
+			).rejects.toThrow('boom');
+
+			expect(fs.existsSync(lockPath)).toBe(false);
+		});
+
+		it('skips the work entirely when the lock is held', async () => {
+			writeLock({
+				pid: process.pid,
+				hostname: os.hostname(),
+				startedAt: Date.now(),
+				operation: 'sync',
+			});
+
+			let ran = false;
+			const result = await withSyncLock({
+				worktreeRoot: worktree,
+				operation: 'sync',
+				fn: async () => {
+					ran = true;
+					return 'done';
+				},
+			});
+
+			expect(isFail(result)).toBe(false);
+			if (isFail(result)) return;
+			expect(result.value).toBeNull();
+			expect(ran).toBe(false);
+
+			// Somebody else's lock is still theirs afterwards.
+			expect(fs.existsSync(lockPath)).toBe(true);
+		});
+
+		it('does not hand the lock to two callers at once', async () => {
+			let concurrent = 0;
+			let peak = 0;
+
+			const attempt = () =>
+				withSyncLock({
+					worktreeRoot: worktree,
+					operation: 'sync',
+					fn: async () => {
+						concurrent += 1;
+						peak = Math.max(peak, concurrent);
+						await new Promise(resolve => setTimeout(resolve, 30));
+						concurrent -= 1;
+						return true;
+					},
+				});
+
+			await Promise.all([attempt(), attempt(), attempt()]);
+
+			expect(peak).toBe(1);
+		});
+	});
+});


### PR DESCRIPTION
Implements option 2 from `W1TCS14`: a cross-process lock over the state branch worktree.

## The problem

`ensureStateBranchCheckedOut` runs `git rebase --abort` whenever HEAD is not on the state branch — and mid-rebase HEAD is detached. So a **live** sync's rebase and one **abandoned by a crashed process** look identical, and recovering from the second destroyed the first. `runExclusive` cannot help: it is a promise chain that dies with the process, and the writers here are separate processes — a TUI, a GUI autosync, an MCP server per agent.

Which of the two it is isn't something git knows. It is something the OS knows.

## Why a lock rather than the two cheaper options

I tried the reorder (move the `hasInProgressGitOperation` check before bootstrap) in the previous branch and reverted it: it breaks `recovers from a stale rebase left behind by an earlier interrupted sync`, deliberately, because that blind abort *is* the crash-recovery path. A timeout heuristic just guesses.

The lock is the only option that keeps **both** properties, and the proof is that the vetoing test passes unchanged:

| lock file | holder | action |
|---|---|---|
| absent | — | proceed |
| present, pid dead | crashed | break it, abort the rebase, recover |
| present, pid alive | live sync | refuse, report a skip |

## Mechanics

- Acquire is one `writeFileSync(..., {flag: 'wx'})` — check and claim in a single syscall, so two processes cannot both win. `process.kill(pid, 0)` tests liveness; `EPERM` counts as alive.
- Lives in the **gitdir**, never the worktree tree: nothing here may ever become committable, and `.epiq/` is staged by glob.
- Held elsewhere is a **skip**, not a failure (`skipped` on `SyncSummary`). Autosync contends constantly; an error every few seconds would be noise. Nothing touches sync state on a skip, so the indicator stays truthful.
- Taken at `syncEpiqWithRemote` alone. Sprinkling it per-caller is exactly how `runExclusive` ended up covering the GUI transports but not the MCP tools.

## Limits, recorded rather than papered over

- **Advisory** — binds epiq processes, not a person running git by hand. Git's own `index.lock` / `rebase-merge/` remain the hard boundary.
- **Pid reuse** can make a dead holder look alive; `STALE_AFTER_MS` (10 min) is the backstop. The failure direction is *refuse*, not *destroy* — the safe way to be wrong, and the main argument for this over a timeout.
- **Local filesystem assumed.** A foreign `hostname` is never broken on liveness, only on age.
- **First sync is unlocked** — there is no worktree to hold before bootstrap creates one.

Not done here on purpose: extending the lock to serialise the MCP tool handlers. It would subsume that ticket, but widening this past sync is how a scoped fix becomes unreviewable.

**Gate:** 734 unit · 11 collab (container) · 11 TUI e2e (container) · 44 GUI · lint, typecheck, format. Rebased on `7CDYBC2`, which takes the unit suite from 93s to 12.5s.
