### PR TITLE
1KFGCHG wait for the TUI to exit and kill its process group before removing an e2e repo

### DIFF
--- a/source/test/e2e/attachments.e2e.test.ts
+++ b/source/test/e2e/attachments.e2e.test.ts
@@ -73,7 +73,7 @@ describe('issue attachments', () => {
 	let remoteDir: string;
 	let stateRoot: string;
 	let issueId: string;
-	let cleanupTui: (() => void) | null = null;
+	let cleanupTui: (() => Promise<void>) | null = null;
 
 	beforeAll(async () => {
 		const setupTuiSession = setupTui();
@@ -81,7 +81,7 @@ describe('issue attachments', () => {
 		try {
 			await commonSteps.configureInitialSettings(setupTuiSession);
 		} finally {
-			setupTuiSession.destroy();
+			await setupTuiSession.destroy();
 		}
 
 		// Bootstrap a real project and one issue through the actual TUI, then
@@ -100,7 +100,7 @@ describe('issue attachments', () => {
 
 		await run(tui, ':new issue Attachment target', 'new issue Attachment');
 		await tui.waitFor('Todo (1)', 4_000);
-		tui.destroy();
+		await tui.destroy();
 		cleanupTui = null;
 
 		// Remote is added after the TUI exits so background auto-sync cannot
@@ -126,8 +126,8 @@ describe('issue attachments', () => {
 		issueId = issue.id;
 	}, testTimeout);
 
-	afterAll(() => {
-		cleanupTui?.();
+	afterAll(async () => {
+		await cleanupTui?.();
 		removeTempRepo(repoRoot);
 		removeTempRepo(remoteDir);
 	});
@@ -258,7 +258,7 @@ describe('issue attachments', () => {
 				const afterOpen = await indicatorTui.waitFor('screenshot.png', 4_000);
 				expect(afterOpen).toContain('screenshot.png');
 			} finally {
-				indicatorTui.destroy();
+				await indicatorTui.destroy();
 			}
 
 			// --- delete removes the reference but never the blob (time travel)

--- a/source/test/e2e/e2e-common-steps.ts
+++ b/source/test/e2e/e2e-common-steps.ts
@@ -22,7 +22,7 @@ export const commonSteps = {
 		input: (...values: string[]) => void;
 		output: () => string;
 		waitFor: (text: string, timeoutMs?: number) => Promise<string>;
-		destroy: () => void;
+		destroy: () => Promise<void>;
 	}) => {
 		let output;
 		execSync('git init', {

--- a/source/test/e2e/e2e.helper.ts
+++ b/source/test/e2e/e2e.helper.ts
@@ -41,7 +41,8 @@ type TuiSession = {
 		timeoutMs?: number,
 	) => Promise<string>;
 	clear: () => void;
-	destroy: () => void;
+	destroy: () => Promise<void>;
+	pid: number;
 };
 
 // Per-file isolation, so concurrent files never share a global config dir.
@@ -86,12 +87,8 @@ const commandLineContent = (frame: string): string => {
  * True when the command line holds no typed command. Not "contains the
  * placeholder": the caption is absent in some contexts, so waiting on it hangs.
  */
-/**
- * The TUI spawns git, which can still be writing into `.git/objects` when a
- * test tears its repo down — the removal then finds the directory repopulated
- * and throws ENOTEMPTY, failing a test that had already passed. Retrying is
- * what `rmSync` offers for exactly this.
- */
+// `destroy()` waits for the TUI and kills its process group first, so by now
+// nothing should be writing here; the retries cover a git that escaped anyway.
 export const removeTempRepo = (dir: string): void => {
 	fs.rmSync(dir, {
 		recursive: true,
@@ -147,6 +144,10 @@ export const setupTui = (
 		rows: height,
 		cwd,
 		env: createTuiEnv(options.env),
+	});
+
+	const exited = new Promise<void>(resolve => {
+		child.onExit(() => resolve());
 	});
 
 	const renderOutput = () => {
@@ -209,7 +210,13 @@ export const setupTui = (
 		renderOutput();
 	};
 
-	const destroy = () => {
+	// Removing the repo while the TUI or a git it spawned is still writing to
+	// it fails with ENOTEMPTY, so the process goes first: wait for it to exit,
+	// then kill its whole group — the pty made it a session leader, so the
+	// group is exactly the children it left behind.
+	const EXIT_WAIT_MS = 5_000;
+
+	const destroy = async () => {
 		if (destroyed) return;
 		destroyed = true;
 
@@ -218,6 +225,14 @@ export const setupTui = (
 			child.kill();
 		} catch {
 			// noop
+		}
+
+		await Promise.race([exited, sleep(EXIT_WAIT_MS)]);
+
+		try {
+			process.kill(-child.pid, 'SIGKILL');
+		} catch {
+			// Nothing left in the group.
 		}
 
 		if (ownsCwd) {
@@ -275,5 +290,6 @@ export const setupTui = (
 		},
 
 		destroy,
+		pid: child.pid,
 	};
 };

--- a/source/test/e2e/edit-scope.e2e.test.ts
+++ b/source/test/e2e/edit-scope.e2e.test.ts
@@ -85,7 +85,7 @@ beforeAll(async () => {
 
 		await tui.waitFor('Initialize project', 8_000);
 	} finally {
-		tui.destroy();
+		await tui.destroy();
 	}
 });
 
@@ -140,7 +140,7 @@ describe('TUI edit-command scope e2e', () => {
 				await run(tui, ':edit description', 'edit description');
 				await tui.waitFor(EDITED_DESCRIPTION, 8_000);
 			} finally {
-				tui.destroy();
+				await tui.destroy();
 			}
 		},
 		testTimeout,

--- a/source/test/e2e/filter.e2e.test.ts
+++ b/source/test/e2e/filter.e2e.test.ts
@@ -41,7 +41,7 @@ beforeAll(async () => {
 	try {
 		await commonSteps.configureInitialSettings(tui);
 	} finally {
-		tui.destroy();
+		await tui.destroy();
 	}
 });
 
@@ -128,7 +128,7 @@ describe('TUI board filtering e2e', () => {
 				expect(byTitle).not.toContain('DB sync');
 				expect(byTitle).not.toContain('Nav menu');
 			} finally {
-				tui.destroy();
+				await tui.destroy();
 			}
 		},
 		testTimeout,

--- a/source/test/e2e/init.e2e.test.ts
+++ b/source/test/e2e/init.e2e.test.ts
@@ -11,7 +11,7 @@ beforeAll(async () => {
 	try {
 		await commonSteps.configureInitialSettings(tui);
 	} finally {
-		tui.destroy();
+		await tui.destroy();
 	}
 });
 
@@ -26,7 +26,7 @@ describe('TUI e2e', () => {
 
 				expect(output).toContain('Default (0 issues)');
 			} finally {
-				tui.destroy();
+				await tui.destroy();
 			}
 		},
 		testTimeout,
@@ -55,7 +55,7 @@ describe('TUI e2e', () => {
 
 				expect(output).toContain(issueTitle);
 			} finally {
-				tui.destroy();
+				await tui.destroy();
 			}
 		},
 		testTimeout,
@@ -99,7 +99,7 @@ describe('TUI e2e', () => {
 				expect(finalOutput).not.toContain(':edit title Test create EDITED');
 				expect(finalOutput).toContain('Test create EDITED');
 			} finally {
-				tui.destroy();
+				await tui.destroy();
 			}
 		},
 		testTimeout,
@@ -172,7 +172,7 @@ describe('TUI e2e', () => {
 				expect(normalizedLogOutput).toContain('Tagged with important');
 				expect(normalizedLogOutput).toContain('Removed tag prio');
 			} finally {
-				tui.destroy();
+				await tui.destroy();
 			}
 		},
 		testTimeout,

--- a/source/test/e2e/lifecycle.e2e.test.ts
+++ b/source/test/e2e/lifecycle.e2e.test.ts
@@ -34,7 +34,7 @@ beforeAll(async () => {
 	try {
 		await commonSteps.configureInitialSettings(tui);
 	} finally {
-		tui.destroy();
+		await tui.destroy();
 	}
 });
 
@@ -120,7 +120,7 @@ describe('TUI issue lifecycle e2e', () => {
 				expect(normalized).toContain('Moved issue to Done');
 				expect(normalized).toContain('Closed');
 			} finally {
-				tui.destroy();
+				await tui.destroy();
 			}
 		},
 		testTimeout,

--- a/source/test/e2e/peek.e2e.test.ts
+++ b/source/test/e2e/peek.e2e.test.ts
@@ -31,7 +31,7 @@ beforeAll(async () => {
 	try {
 		await commonSteps.configureInitialSettings(tui);
 	} finally {
-		tui.destroy();
+		await tui.destroy();
 	}
 });
 
@@ -185,7 +185,7 @@ describe('TUI peek / time-travel e2e', () => {
 				);
 				expect(stillLive).not.toContain('Readonly');
 			} finally {
-				tui.destroy();
+				await tui.destroy();
 			}
 		},
 		testTimeout,

--- a/source/test/e2e/reboot.e2e.test.ts
+++ b/source/test/e2e/reboot.e2e.test.ts
@@ -13,7 +13,7 @@ beforeAll(async () => {
 	try {
 		await commonSteps.configureInitialSettings(tui);
 	} finally {
-		tui.destroy();
+		await tui.destroy();
 	}
 });
 
@@ -50,7 +50,7 @@ describe('TUI reboot / event-log replay e2e', () => {
 					expect(created).toContain('Persisted issue two');
 				} finally {
 					// Ctrl-C + kill the process. The cwd is preserved (caller-owned).
-					first.destroy();
+					await first.destroy();
 				}
 
 				// --- Second process: a brand new boot in the same directory. ---
@@ -83,7 +83,7 @@ describe('TUI reboot / event-log replay e2e', () => {
 					expect(appended).toContain('Persisted issue one');
 					expect(appended).toContain('Persisted issue two');
 				} finally {
-					second.destroy();
+					await second.destroy();
 				}
 			} finally {
 				removeTempRepo(cwd);

--- a/source/test/e2e/teardown.e2e.test.ts
+++ b/source/test/e2e/teardown.e2e.test.ts
@@ -1,0 +1,80 @@
+import {execFileSync, execSync} from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {describe, expect, it} from 'vitest';
+import {commonSteps} from './e2e-common-steps.js';
+import {removeTempRepo, setupTui} from './e2e.helper.js';
+
+// A git stand-in the TUI resolves ahead of the real one: it holds every push,
+// shrugging off the hangup the pty sends when the TUI dies, and keeps writing
+// into the repo's `.epiq` the whole time — the child that outlives the TUI and
+// repopulates the directory the teardown is trying to remove.
+const fakeGit = (): {binDir: string; holdDir: string} => {
+	const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'epiq-e2e-fakegit-'));
+	const holdDir = fs.mkdtempSync(path.join(os.tmpdir(), 'epiq-e2e-hold-'));
+	const realGit = execFileSync('sh', ['-c', 'command -v git'], {
+		encoding: 'utf8',
+	}).trim();
+
+	fs.writeFileSync(
+		path.join(binDir, 'git'),
+		[
+			'#!/bin/sh',
+			'if [ "$1" = push ]; then',
+			"  trap '' HUP INT TERM",
+			`  : > "${path.join(holdDir, 'held')}"`,
+			'  i=0; while [ $i -lt 300 ]; do',
+			'    mkdir -p "$EPIQ_E2E_REPO/.epiq/hold" && : > "$EPIQ_E2E_REPO/.epiq/hold/$i"',
+			'    sleep 0.1; i=$((i+1))',
+			'  done',
+			'fi',
+			`exec "${realGit}" "$@"`,
+			'',
+		].join('\n'),
+		{mode: 0o755},
+	);
+
+	return {binDir, holdDir};
+};
+
+const waitForFile = async (file: string, timeoutMs: number): Promise<void> => {
+	const deadline = Date.now() + timeoutMs;
+
+	while (!fs.existsSync(file)) {
+		if (Date.now() > deadline) throw new Error(`Timed out waiting for ${file}`);
+		await new Promise(resolve => setTimeout(resolve, 50));
+	}
+};
+
+describe('TUI e2e teardown', () => {
+	it('destroy() takes the whole process group down, not just the TUI', async () => {
+		const {binDir, holdDir} = fakeGit();
+		const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'epiq-e2e-teardown-'));
+		const tui = setupTui([], {
+			cwd: repo,
+			env: {
+				PATH: `${binDir}${path.delimiter}${process.env['PATH'] ?? ''}`,
+				EPIQ_E2E_REPO: repo,
+			},
+		});
+
+		await commonSteps.configureInitialSettings(tui);
+
+		// Init pushes the state branch before the board renders, so this drives
+		// init by hand and waits for the push to be held rather than for a frame.
+		execSync('git init', {cwd: tui.cwd, stdio: 'ignore'});
+		await tui.waitFor('This folder is not an epiq project yet.', 8_000);
+		tui.input(':init');
+		await tui.waitFor('<ENTER> to confirm', 8_000);
+		tui.input('\r');
+		await waitForFile(path.join(holdDir, 'held'), 10_000);
+
+		await tui.destroy();
+
+		// A writer that survived teardown would put the directory straight back.
+		removeTempRepo(repo);
+		await new Promise(resolve => setTimeout(resolve, 500));
+		expect(fs.existsSync(repo)).toBe(false);
+	}, 60_000);
+});

--- a/source/test/e2e/time-travel-guard.e2e.test.ts
+++ b/source/test/e2e/time-travel-guard.e2e.test.ts
@@ -114,7 +114,7 @@ describe('GUI mutation guard while time-travelling', () => {
 					server.close();
 				}
 			} finally {
-				tui.destroy();
+				await tui.destroy();
 			}
 		},
 		testTimeout,


### PR DESCRIPTION
`init.e2e > Can initialize a project inside a Git repository` failed under load with `ENOTEMPTY` on `<repo>/.epiq` from `tui.destroy()` — after the test's own assertions had already passed. `destroy()` sent Ctrl-C + SIGHUP to the TUI and removed the repo in the same breath, so a git the TUI had in flight (autosync after init) kept repopulating `.epiq` while `rmSync` burned its whole ~21s retry budget.

`destroy()` is now async: it waits for the pty child to exit (bounded at 5s), SIGKILLs the child's process group — the pty made the TUI a session leader, so the group is exactly what it left behind — and only then removes the repo. Every call site awaits it.

Regression test `teardown.e2e.test.ts` puts a fake `git` ahead on the TUI's PATH that holds `push`, ignores hangup, and keeps writing into `.epiq`; it fails against the old helper (the repo comes straight back) and passes with the fix.

Ticket: 1KFGCHG

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017V41kJNmbS6M8E6krcjK2J