### PR TITLE
2RSSZDR GUI suite: shorten its longest single-test files

### DIFF
--- a/source/test/e2e-gui/bulk-actions.pw.ts
+++ b/source/test/e2e-gui/bulk-actions.pw.ts
@@ -50,7 +50,11 @@ test('bulk actions only offer what applies to the selection', async ({
 	// Closing takes them to the Closed board, where the pair is all closed and
 	// the offer is the other way round.
 	await page.getByRole('button', {name: 'close 2 tickets'}).click();
-	await expect(page.getByText(titles[0]!, {exact: true})).toHaveCount(0);
+	// Two mutations and their broadcasts; under a full gate that outlasts the
+	// default expectation.
+	await expect(
+		page.locator('div[draggable="true"]').filter({hasText: titles[0]!}),
+	).toHaveCount(0, {timeout: 30_000});
 
 	await page.getByTestId('board-switcher').click();
 	await page

--- a/source/test/e2e-gui/bulk.pw.ts
+++ b/source/test/e2e-gui/bulk.pw.ts
@@ -73,14 +73,16 @@ test('picking several tickets opens a bulk overview', async ({
 		})()
 	`);
 
-	await expect(page.locator('aside')).toContainText('bulky');
+	await expect(page.locator('aside')).toContainText('bulky', {
+		timeout: 30_000,
+	});
 	await page.goto(boardUrl);
 	await expect(
 		page
 			.locator('div[draggable="true"]')
 			.filter({hasText: `${tag}-`})
 			.filter({hasText: 'bulky'}),
-	).toHaveCount(2);
+	).toHaveCount(2, {timeout: 30_000});
 
 	const tagged = await page.evaluate<number>(`
 		[...document.querySelectorAll('div[draggable="true"]')]

--- a/source/test/e2e-gui/entrance.pw.ts
+++ b/source/test/e2e-gui/entrance.pw.ts
@@ -37,29 +37,35 @@ test('the entrance plays for view changes, not for incoming data', async ({
 }) => {
 	await page.goto(appUrl);
 	await expect(page.getByTestId('board-switcher')).toContainText('Default');
-	// Let the first window land, which is itself an entrance.
-	await page.waitForTimeout(5000);
+	// Let the first window land, which is itself an entrance. The windows
+	// below are the entrance (BAR_ENTRANCE_TOTAL_MS, 760ms) plus a server
+	// round trip.
+	await page.waitForTimeout(1500);
 
 	await page.evaluate(WATCH);
 
 	await page.evaluate(RESET);
 	await page.getByRole('button', {name: 'Week', exact: true}).click();
-	await page.waitForTimeout(2500);
+	await page.waitForTimeout(1500);
 	const onScopeChange = await page.evaluate<number>(READ);
 
 	await page.evaluate(RESET);
 	await page.getByRole('button', {name: 'Events', exact: true}).click();
-	await page.waitForTimeout(2500);
+	await page.waitForTimeout(1500);
 	const onLayoutChange = await page.evaluate<number>(READ);
 	await page.getByRole('button', {name: 'Volume', exact: true}).click();
-	await page.waitForTimeout(2000);
+	await page.waitForTimeout(1500);
 
 	// A mutation makes the server broadcast fresh state; no view option changed.
 	await page.evaluate(RESET);
 	await page.getByRole('button', {name: '+', exact: true}).first().click();
-	await page.getByPlaceholder('issue name').fill(`E${Date.now()}`);
+	const title = `E${Date.now()}`;
+	await page.getByPlaceholder('issue name').fill(title);
 	await page.getByRole('button', {name: 'create', exact: true}).click();
-	await page.waitForTimeout(4000);
+	// The state carrying the ticket has landed once its title shows; the window
+	// after that is where an entrance would play if data alone triggered one.
+	await expect(page.getByText(title, {exact: true}).first()).toBeVisible();
+	await page.waitForTimeout(1500);
 	const onIncomingData = await page.evaluate<number>(READ);
 
 	console.log(

--- a/source/test/e2e-gui/move.pw.ts
+++ b/source/test/e2e-gui/move.pw.ts
@@ -31,6 +31,19 @@ new Promise(async resolve => {
 
 	const send = b => ws.send(JSON.stringify(b));
 	const wait = ms => new Promise(r => setTimeout(r, ms));
+	const next = type => new Promise(r => {
+		const handler = event => {
+			if (JSON.parse(event.data).type !== type) return;
+			ws.removeEventListener('message', handler);
+			r();
+		};
+		ws.addEventListener('message', handler);
+	});
+	const refresh = async () => {
+		const state = next('state');
+		send({type: 'state:get'});
+		await state;
+	};
 	const laneOf = (state, title) => {
 		for (const lane of state.boards[0].swimlanes) {
 			if (lane.issues.some(i => i.title === title)) return lane.title;
@@ -39,8 +52,7 @@ new Promise(async resolve => {
 	};
 
 	await new Promise(r => ws.addEventListener('open', r));
-	send({type: 'state:get'});
-	await wait(1500);
+	await refresh();
 
 	const tag = 'S' + Math.floor(Math.random() * 1e6);
 	const [from, to] = latest.boards[0].swimlanes;
@@ -49,12 +61,12 @@ new Promise(async resolve => {
 	for (let n = 0; n < 6; n++) {
 		const title = tag + '-' + n;
 		titles.push(title);
+		const created = next('issues:create:result');
 		send({type: 'issues:create', payload: {parentId: from.id, title}});
-		await wait(1500);
+		await created;
 	}
 
-	send({type: 'state:get'});
-	await wait(1500);
+	await refresh();
 
 	const outcomes = [];
 
@@ -73,9 +85,10 @@ new Promise(async resolve => {
 		await wait(250);
 	}
 
-	await wait(8000);
-	send({type: 'state:get'});
-	await wait(1500);
+	// Room for the syncs the moves scheduled to land, and to overwrite a move
+	// if one is going to.
+	await wait(3000);
+	await refresh();
 
 	for (const title of titles) {
 		outcomes.push({title, lane: laneOf(latest, title), want: to.title});

--- a/source/test/e2e-gui/scrubber.pw.ts
+++ b/source/test/e2e-gui/scrubber.pw.ts
@@ -41,7 +41,8 @@ test('a scope change animates each bar exactly once', async ({
 		await page.waitForTimeout(400);
 		const {bars} = await page.evaluate<{bars: number}>(SAMPLE);
 
-		await page.waitForTimeout(2000);
+		// Past the entrance (760ms) plus the round trip for the new window.
+		await page.waitForTimeout(1500);
 		const {starts} = await page.evaluate<{starts: number}>(SAMPLE);
 
 		expect(

--- a/source/test/e2e/e2e-common-steps.ts
+++ b/source/test/e2e/e2e-common-steps.ts
@@ -8,10 +8,10 @@ export const commonSteps = {
 		await tui.waitFor('choose your username', 20_000);
 		tui.input(':config username test\r');
 
-		await tui.waitFor('pick your editor');
+		await tui.waitFor('pick your editor', 20_000);
 		tui.input(':config editor vim\r');
 
-		await tui.waitFor('Configure auto sync');
+		await tui.waitFor('Configure auto sync', 20_000);
 		tui.input(':config autoSync on\r');
 
 		await tui.waitFor('Initialize project', 20_000);


### PR DESCRIPTION
The GUI suite's wall time is set by single-test files that run whole on one worker; setup is ~3s and the summed time is spread fine over six workers. This shortens the three that were the floor:

- **move.pw.ts** 23s → 6s — the in-page script waited fixed 1.5s slots around every create and `state:get` and 8s after the moves. It now waits on the server's own `issues:create:result` / `state` messages; the post-move settle is 3s. While here: `queueSync` is a no-op when autoSync is off, and the seed turns it off, so this test never actually exercised the sync it names — filed as its own ticket rather than fixed here.
- **entrance.pw.ts** 16.5s → 8s, **scrubber.pw.ts** 11.4s → 9.5s — the sampling windows were 2–5s around an entrance that is `BAR_ENTRANCE_TOTAL_MS` = 760ms long; they are 1.5s now (entrance plus a round trip), and the "incoming data" window starts once the created title is on screen.
- The bulk tests' post-mutation expectations get a 30s budget and are scoped to the cards — one gate run saw a close outlast the 10s default under a full gate.
- `7VX7KA9`: every first-run prompt in the shared e2e steps gets the 20s cold-start budget, not just the first (the `init.e2e` `beforeAll` tripped the 3s default on a gate run).

GUI suite: 32s → ~25s standalone, 31s inside the full gate; `offline.pw.ts` (17s of the client's real reconnect schedule) is the floor now. Whole gate on this push: 43s, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017V41kJNmbS6M8E6krcjK2J