### PR TITLE
YYMR85T pre-resolve the Commits tab count, reorder the ticket tabs

### DIFF
--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -146,9 +146,9 @@ export const App = () => {
 	// so the first render already picks the right layout instead of flashing.
 	const [commitDiffPanelWidth, setCommitDiffPanelWidth] =
 		useState(readStoredAsideWidth);
-	// The ticket detail Code tab's commit list. Reset per selected issue, like
-	// issueDetail below — refetched fresh each time the tab opens rather than
-	// cached, since a full ref-prefix log scan is cheap next to the round trip.
+	// The ticket detail Commits tab's commit list, fetched on selection so the
+	// tab can show its count up front. Reset per selected issue, like
+	// issueDetail below.
 	const [issueCommits, setIssueCommits] = useState<{
 		issueId: string;
 		loading: boolean;
@@ -406,11 +406,11 @@ export const App = () => {
 		if (changed) setIssueCommitDiffs({});
 	}, [selectedIssue?.id]);
 
-	// Fetched lazily on entering the Code tab rather than alongside issue:get
-	// above: a full ref-prefix log scan on every ticket selection would be
-	// wasted on the common case where nobody opens the tab.
+	// Separate from issue:get above, which re-runs on every state broadcast:
+	// the commit list comes from git, not the event log, so a board change is
+	// no reason to rescan it.
 	useEffect(() => {
-		if (!selectedIssue || selectedTab !== 'code') {
+		if (!selectedIssue) {
 			setIssueCommits(null);
 			return;
 		}
@@ -425,7 +425,7 @@ export const App = () => {
 			type: 'issue:commits:get',
 			payload: {issueId: selectedIssue.id},
 		});
-	}, [selectedIssue?.id, selectedTab]);
+	}, [selectedIssue?.id]);
 
 	const loadIssueCommitDiff = useCallback((sha: string) => {
 		setIssueCommitDiffs(prev => ({
@@ -1725,10 +1725,12 @@ export const App = () => {
 										? issueCommits.commits
 										: []
 								}
+								// No entry for this ticket yet means its fetch is about to be
+								// sent, not that it has nothing.
 								commitsLoading={
 									issueCommits?.issueId === selectedIssue.id
 										? issueCommits.loading
-										: false
+										: true
 								}
 								commitsError={
 									issueCommits?.issueId === selectedIssue.id

--- a/source/gui/client/components/IssueDetails.tsx
+++ b/source/gui/client/components/IssueDetails.tsx
@@ -163,10 +163,13 @@ export const IssueDetails = ({
 	const tabs: TabItem<IssueDetailsTab>[] = [
 		{id: 'overview', label: 'Overview'},
 		{id: 'comments', label: 'Comments', count: comments.length},
+		// No count until the list has arrived: 0 would misread as "no commits".
+		{
+			id: 'code',
+			label: 'Commits',
+			count: commitsLoading || commitsError ? undefined : commits.length,
+		},
 		{id: 'history', label: 'Log', count: history.length},
-		// No count before the first load: commits are fetched lazily on opening
-		// this tab, so showing 0 until then would misread as "no commits yet".
-		{id: 'code', label: 'Commits', count: commits.length || undefined},
 	];
 
 	const saveTitle = () => {

--- a/source/test/e2e-gui/tab-persistence.pw.ts
+++ b/source/test/e2e-gui/tab-persistence.pw.ts
@@ -86,6 +86,26 @@ test('switching tickets with the Commits tab already open still loads the new ti
 	expect(pageErrors).toEqual([]);
 });
 
+test('the Commits tab shows its count before being opened, after Comments', async ({
+	page,
+	pageErrors,
+}) => {
+	await addTicket(page, `Commit count ${Date.now()}`);
+	await expect(page).toHaveURL(/tab=overview/);
+
+	const tabs = page
+		.locator('aside')
+		.getByRole('button', {name: /^(Overview|Comments|Commits|Log)\b/});
+	await expect(tabs).toHaveText([
+		/^Overview$/,
+		/^Comments \(0\)$/,
+		/^Commits \(0\)$/,
+		/^Log \(\d+\)$/,
+	]);
+
+	expect(pageErrors).toEqual([]);
+});
+
 test('the comment count on a card still opens comments', async ({page}) => {
 	const title = `Count ${Date.now()}`;
 	await addTicket(page, title);


### PR DESCRIPTION
Ticket YYMR85T.

- Linked commits are fetched when a ticket is selected instead of on opening the Commits tab, so the tab shows its count up front. No count is shown while the list is still loading (or if it failed) so 0 never misreads as "no commits".
- Tab order is now Overview, Comments, Commits, Log.
- e2e: asserts the count is present without clicking the tab, and the tab order. Verified red against the previous build.

Trade-off: every ticket selection now does the ref-prefix log scan that 9825TMR is about (it hits the 5s timeline cache when the scrubber just loaded).