### PR TITLE
WBJ4HN7 let a browser test scale the reconnect schedule instead of sitting through it

### DIFF
--- a/source/gui/client/lib/reconnect.test.ts
+++ b/source/gui/client/lib/reconnect.test.ts
@@ -1,7 +1,11 @@
-import {describe, expect, it} from 'vitest';
+import {afterEach, describe, expect, it} from 'vitest';
 import {MAX_RECONNECT_ATTEMPTS, reconnectDelayMs} from './reconnect';
 
 describe('reconnectDelayMs', () => {
+	afterEach(() => {
+		delete (globalThis as {window?: unknown}).window;
+	});
+
 	it('starts quickly, so a server restart is picked up almost at once', () => {
 		expect(reconnectDelayMs(0)).toBe(500);
 	});
@@ -17,6 +21,14 @@ describe('reconnectDelayMs', () => {
 		expect(reconnectDelayMs(MAX_RECONNECT_ATTEMPTS - 1)).not.toBeNull();
 		expect(reconnectDelayMs(MAX_RECONNECT_ATTEMPTS)).toBeNull();
 		expect(reconnectDelayMs(MAX_RECONNECT_ATTEMPTS + 3)).toBeNull();
+	});
+
+	it('scales the whole schedule when a test asks it to', () => {
+		Object.assign(globalThis, {window: {__epiqReconnectScale: 0.1}});
+
+		expect(reconnectDelayMs(0)).toBe(50);
+		expect(reconnectDelayMs(4)).toBe(800);
+		expect(reconnectDelayMs(MAX_RECONNECT_ATTEMPTS)).toBeNull();
 	});
 
 	it('spends its attempts inside about fifteen seconds', () => {

--- a/source/gui/client/lib/reconnect.ts
+++ b/source/gui/client/lib/reconnect.ts
@@ -7,8 +7,19 @@ const MAX_DELAY_MS = 8_000;
 // cannot fix, and a silent loop gives the reader nothing to act on.
 export const MAX_RECONNECT_ATTEMPTS = 5;
 
+// The browser tests scale the schedule down rather than sit through it;
+// nothing else sets this, and the shape of the schedule is unchanged.
+declare global {
+	interface Window {
+		__epiqReconnectScale?: number;
+	}
+}
+
+const scale = (): number =>
+	typeof window === 'undefined' ? 1 : window.__epiqReconnectScale ?? 1;
+
 /** How long to wait before attempt `attempt`, or null once they are spent. */
 export const reconnectDelayMs = (attempt: number): number | null =>
 	attempt >= MAX_RECONNECT_ATTEMPTS
 		? null
-		: Math.min(MAX_DELAY_MS, BASE_DELAY_MS * 2 ** attempt);
+		: Math.min(MAX_DELAY_MS, BASE_DELAY_MS * 2 ** attempt) * scale();

--- a/source/test/e2e-gui/offline.pw.ts
+++ b/source/test/e2e-gui/offline.pw.ts
@@ -24,6 +24,10 @@ test('the board stands down while the socket is gone, and comes back', async ({
 		cut = () => ws.close();
 	});
 
+	// The retry schedule at a fifth of its length: the same shape, without
+	// sitting through fifteen seconds of it for the button to appear.
+	await page.addInitScript('window.__epiqReconnectScale = 0.2');
+
 	await page.goto(appUrl);
 	await expect(page.getByTestId('board-switcher')).toContainText('Default');
 	await expect(page.getByTestId('swimlane-menu').first()).toBeVisible();


### PR DESCRIPTION
`offline.pw.ts` was the GUI suite's longest file at 17s, ~15.5s of it the client's real reconnect schedule (0.5s→8s doubling, 5 attempts) that the test had to wait out before the connection-lost button appears.

`reconnectDelayMs` now multiplies by `window.__epiqReconnectScale` (default 1; nothing but a test sets it), so the schedule keeps its shape and is unchanged for users. The offline test sets it to 0.2 with `addInitScript` before the page loads — a fifth of the length, still long enough for the "reconnecting" state to be observable on the first, recoverable drop. Unit test covers the scale.

`offline.pw.ts`: 17s → 4s (three runs). Whole gate on this push: 38s, all green (803 unit / 12 e2e / 11 collab / 47 GUI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017V41kJNmbS6M8E6krcjK2J