### PR TITLE
7RS8KKX wait for the server's answer to a swimlane drag instead of sleeping

### DIFF
--- a/source/test/e2e-gui/drag-swimlane.pw.ts
+++ b/source/test/e2e-gui/drag-swimlane.pw.ts
@@ -38,13 +38,39 @@ new Promise(async resolve => {
 	fire(targetColumn, 'drop', clientX);
 	fire(src, 'dragend');
 
-	await wait(2500);
 	resolve({indicators});
 });
 `;
 
 const ORDER = `[...document.querySelectorAll('[data-testid="swimlane-handle"]')]
 	.map(h => h.textContent.trim().split('(')[0].trim())`;
+
+// A drop reorders optimistically; the order that counts is the one left once
+// the server has answered, since that answer can put a lane back. The tap
+// counts those answers so a test can wait for the one its drag earned.
+const tapMoveResults = async (page: Page): Promise<{count: () => number}> => {
+	let answered = 0;
+
+	await page.routeWebSocket(/\/ws/, ws => {
+		const server = ws.connectToServer();
+		ws.onMessage(message => server.send(message));
+		server.onMessage(message => {
+			if (
+				typeof message === 'string' &&
+				message.includes('"type":"swimlane:move:result"')
+			) {
+				answered += 1;
+			}
+
+			ws.send(message);
+		});
+	});
+
+	return {count: () => answered};
+};
+
+const moved = async (answers: {count: () => number}, n: number) =>
+	expect.poll(answers.count, {timeout: 15_000}).toBe(n);
 
 // Only this test's own lanes. The suite shares one board and other files add
 // columns to it, so asserting the whole row would depend on their run order.
@@ -89,6 +115,7 @@ test('dragging a swimlane header reorders the board', async ({
 	appUrl,
 	pageErrors,
 }) => {
+	const answers = await tapMoveResults(page);
 	await page.goto(appUrl);
 	await expect(page.getByTestId('board-switcher')).toContainText('Default');
 
@@ -107,6 +134,7 @@ test('dragging a swimlane header reorders the board', async ({
 
 	// Exactly one edge line, on the column being dropped against.
 	expect(indicators).toBe(1);
+	await moved(answers, 1);
 	expect(await orderOf(page, [first, second])).toEqual([second, first]);
 
 	// Survives the round-trip, rather than only living in the optimistic state.
@@ -116,6 +144,7 @@ test('dragging a swimlane header reorders the board', async ({
 
 	// And back the other way, so the reverse index is covered too.
 	await page.evaluate(dragLane(first, second, 'left'));
+	await moved(answers, 2);
 	expect(await orderOf(page, [first, second])).toEqual([first, second]);
 
 	await deleteLane(page, first);
@@ -182,7 +211,6 @@ new Promise(async resolve => {
 	fire(card, 'drop', clientX);
 	fire(src, 'dragend');
 
-	await wait(2500);
 	resolve({ticketIndicators});
 });
 `;
@@ -192,6 +220,7 @@ test('a swimlane dropped over a card still reorders', async ({
 	appUrl,
 	pageErrors,
 }) => {
+	const answers = await tapMoveResults(page);
 	await page.goto(appUrl);
 	await expect(page.getByTestId('board-switcher')).toContainText('Default');
 
@@ -223,6 +252,7 @@ test('a swimlane dropped over a card still reorders', async ({
 
 	// The ticket insertion line belongs to a ticket drag, not a column one.
 	expect(ticketIndicators).toBe(0);
+	await moved(answers, 1);
 	expect(await orderOf(page, [first, second])).toEqual([second, first]);
 
 	await deleteLane(page, first);


### PR DESCRIPTION
Each of the three drags in `drag-swimlane.pw.ts` ended in a 2.5s sleep inside the in-page script — 7.5s of the file's ~10s — standing in for "the server has answered the move", so an optimistic reorder the server would put back gets caught.

The test now taps the websocket (the way `scrub-dispatch.pw.ts` does), counts `swimlane:move:result` messages, and asserts the order only once the drag's answer has arrived. Same assertions, still server-confirmed, no sleep. 10.1s → ~3s over three runs.

`scrubber.pw.ts` was looked at and left alone: its remaining windows are the entrance animation itself and the round trip a second, wrong entrance would need to show up in; shortening them would trade coverage for ~1s.

Whole gate on this push: 43s, all green (803 unit / 12 e2e / 11 collab / 47 GUI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017V41kJNmbS6M8E6krcjK2J