### PR TITLE
15NX51E ticket panel: tighter description box, one text scale

### DIFF
--- a/source/gui/client/components/CodeSnippet.tsx
+++ b/source/gui/client/components/CodeSnippet.tsx
@@ -57,7 +57,7 @@ export const CodeSnippet = ({
 		<div
 			data-testid="code-snippet"
 			style={{
-				marginTop: 8,
+				marginTop: 12,
 				border: `1px solid ${GUI_THEME.line}`,
 				borderRadius: 8,
 				overflow: 'hidden',

--- a/source/gui/client/components/CodeSnippet.tsx
+++ b/source/gui/client/components/CodeSnippet.tsx
@@ -57,7 +57,6 @@ export const CodeSnippet = ({
 		<div
 			data-testid="code-snippet"
 			style={{
-				marginTop: 12,
 				border: `1px solid ${GUI_THEME.line}`,
 				borderRadius: 8,
 				overflow: 'hidden',

--- a/source/gui/client/components/CodeSnippet.tsx
+++ b/source/gui/client/components/CodeSnippet.tsx
@@ -1,6 +1,6 @@
 import {useState} from 'react';
 import {File} from '@pierre/diffs/react';
-import {GUI_THEME} from '../lib/gui-theme';
+import {GUI_THEME, TEXT} from '../lib/gui-theme';
 import {CopyShaButton} from './CopyShaButton';
 import {IconChevronDown} from './IconChevronDown';
 import {IconChevronRight} from './IconChevronRight';
@@ -17,7 +17,7 @@ const CODE_FONT =
 // Pinned on the highlighter through its own CSS variables so the gutter drawn
 // beside it lands on the same line grid.
 const LINE_HEIGHT = 20;
-const FONT_SIZE = 12;
+const FONT_SIZE = TEXT.ui;
 const BLOCK_GAP = 8;
 
 const bareButton: React.CSSProperties = {
@@ -73,7 +73,7 @@ export const CodeSnippet = ({
 						background: 'rgba(255,255,255,0.03)',
 						borderBottom: collapsed ? 'none' : `1px solid ${GUI_THEME.line}`,
 						fontFamily: CODE_FONT,
-						fontSize: 11,
+						fontSize: TEXT.meta,
 						color: GUI_THEME.secondary,
 					}}
 				>

--- a/source/gui/client/components/IssueAttachments.tsx
+++ b/source/gui/client/components/IssueAttachments.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from 'react';
-import {GUI_THEME} from '../lib/gui-theme';
+import {GUI_THEME, TEXT} from '../lib/gui-theme';
 import {GuiAttachment} from '../lib/gui-state.model';
 import {Empty} from './FormPrimitives';
 import {Section} from './Section';
@@ -132,7 +132,7 @@ export const IssueAttachments = ({
 												width: '100%',
 												height: '100%',
 												color: GUI_THEME.dim2,
-												fontSize: 9,
+												fontSize: TEXT.label,
 												padding: 4,
 												textAlign: 'center',
 											}}
@@ -174,7 +174,7 @@ export const IssueAttachments = ({
 											borderRadius: 3,
 											background: 'rgba(4, 5, 8, 0.75)',
 											color: GUI_THEME.secondary,
-											fontSize: 10,
+											fontSize: TEXT.label,
 											cursor: 'pointer',
 										}}
 									>
@@ -191,7 +191,7 @@ export const IssueAttachments = ({
 						style={{
 							marginTop: 8,
 							color: GUI_THEME.dim2,
-							fontSize: 10,
+							fontSize: TEXT.label,
 						}}
 					>
 						drop an image to attach
@@ -203,7 +203,7 @@ export const IssueAttachments = ({
 						style={{
 							marginTop: 8,
 							color: GUI_THEME.secondary,
-							fontSize: 11,
+							fontSize: TEXT.meta,
 						}}
 					>
 						uploading {uploadStatus.name}…
@@ -215,7 +215,7 @@ export const IssueAttachments = ({
 						style={{
 							marginTop: 8,
 							color: GUI_THEME.red,
-							fontSize: 11,
+							fontSize: TEXT.meta,
 						}}
 					>
 						{uploadStatus.message}
@@ -249,7 +249,7 @@ export const IssueAttachments = ({
 							border: `1px solid ${GUI_THEME.line}`,
 						}}
 					/>
-					<div style={{color: GUI_THEME.secondary, fontSize: 11}}>
+					<div style={{color: GUI_THEME.secondary, fontSize: TEXT.meta}}>
 						{lightbox.name} · {Math.max(1, Math.round(lightbox.bytes / 1024))}{' '}
 						KB · esc to close
 					</div>

--- a/source/gui/client/components/IssueComments.tsx
+++ b/source/gui/client/components/IssueComments.tsx
@@ -1,5 +1,5 @@
 import {useState} from 'react';
-import {CONTENT_FONT, GUI_THEME} from '../lib/gui-theme';
+import {CONTENT_FONT, GUI_THEME, TEXT} from '../lib/gui-theme';
 import {Button} from './Button';
 import {CodeSnippet} from './CodeSnippet';
 import {IconComment} from './IconComment';
@@ -145,7 +145,9 @@ export const IssueComments = ({
 										marginBottom: 4,
 									}}
 								>
-									<div style={{color: GUI_THEME.secondary, fontSize: 11}}>
+									<div
+										style={{color: GUI_THEME.secondary, fontSize: TEXT.meta}}
+									>
 										{comment.author.name ?? 'unknown'}
 										{comment.createdAt && (
 											<span style={{color: GUI_THEME.dim2}}>
@@ -199,7 +201,7 @@ export const IssueComments = ({
 							minHeight: 45,
 							font: 'inherit',
 							fontFamily: CONTENT_FONT,
-							fontSize: 13,
+							fontSize: TEXT.prose,
 						}}
 					/>
 
@@ -209,7 +211,7 @@ export const IssueComments = ({
 							<span
 								style={{
 									alignSelf: 'center',
-									fontSize: 11,
+									fontSize: TEXT.meta,
 									color: tooLong ? GUI_THEME.red : GUI_THEME.dim,
 								}}
 							>

--- a/source/gui/client/components/IssueComments.tsx
+++ b/source/gui/client/components/IssueComments.tsx
@@ -121,9 +121,6 @@ export const IssueComments = ({
 						<div
 							key={comment.id}
 							style={{
-								display: 'flex',
-								alignItems: 'flex-start',
-								gap: 8,
 								border: `1px solid ${GUI_THEME.line}`,
 								borderLeft: `2px solid ${GUI_THEME.accent}`,
 								borderRadius: 6,
@@ -131,53 +128,62 @@ export const IssueComments = ({
 								background: GUI_THEME.tertiary,
 							}}
 						>
-							<span
-								style={{color: GUI_THEME.accent, flexShrink: 0, marginTop: 1}}
+							{/* Only the header carries the icon; the body runs the card's
+							    full width underneath. */}
+							<div
+								style={{
+									display: 'flex',
+									alignItems: 'center',
+									gap: 8,
+									marginBottom: 6,
+								}}
 							>
-								<IconComment size={12} />
-							</span>
-							<div style={{flex: 1, minWidth: 0}}>
-								<div
+								<span
 									style={{
-										display: 'flex',
-										justifyContent: 'space-between',
-										gap: 12,
-										marginBottom: 4,
+										display: 'inline-flex',
+										color: GUI_THEME.accent,
+										flexShrink: 0,
 									}}
 								>
-									<div
-										style={{color: GUI_THEME.secondary, fontSize: TEXT.meta}}
-									>
-										{comment.author.name ?? 'unknown'}
-										{comment.createdAt && (
-											<span style={{color: GUI_THEME.dim2}}>
-												{' '}
-												· {timeAgo(comment.createdAt)}
-											</span>
-										)}
-									</div>
-
-									{!readonly &&
-										comment.author.id === whoAmI.id &&
-										onDeleteComment && (
-											<Button
-												variant="ghost"
-												onClick={event => {
-													event.preventDefault();
-													event.stopPropagation();
-													onDeleteComment(issueId, comment.id);
-												}}
-											>
-												×
-											</Button>
-										)}
+									<IconComment size={12} />
+								</span>
+								<div
+									style={{
+										flex: 1,
+										minWidth: 0,
+										color: GUI_THEME.secondary,
+										fontSize: TEXT.meta,
+									}}
+								>
+									{comment.author.name ?? 'unknown'}
+									{comment.createdAt && (
+										<span style={{color: GUI_THEME.dim2}}>
+											{' '}
+											· {timeAgo(comment.createdAt)}
+										</span>
+									)}
 								</div>
 
-								<CommentBody
-									body={comment.body}
-									onOpenDiffLocation={onOpenDiffLocation}
-								/>
+								{!readonly &&
+									comment.author.id === whoAmI.id &&
+									onDeleteComment && (
+										<Button
+											variant="ghost"
+											onClick={event => {
+												event.preventDefault();
+												event.stopPropagation();
+												onDeleteComment(issueId, comment.id);
+											}}
+										>
+											×
+										</Button>
+									)}
 							</div>
+
+							<CommentBody
+								body={comment.body}
+								onOpenDiffLocation={onOpenDiffLocation}
+							/>
 						</div>
 					))}
 				</div>

--- a/source/gui/client/components/IssueComments.tsx
+++ b/source/gui/client/components/IssueComments.tsx
@@ -45,7 +45,9 @@ export const CommentBody = ({
 	} ${formatSelectionLabel(meta)}`;
 
 	return (
-		<>
+		// A flex column: sibling margins don't collapse here, so the gap between
+		// note and snippet is the gap it says it is.
+		<div style={{display: 'flex', flexDirection: 'column', gap: 12}}>
 			{meta.note && <MarkdownContent content={meta.note} softBreaks />}
 
 			{/* Only clickable when the marker recorded which commit the selection
@@ -66,7 +68,7 @@ export const CommentBody = ({
 						: undefined
 				}
 			/>
-		</>
+		</div>
 	);
 };
 

--- a/source/gui/client/components/IssueCommits.tsx
+++ b/source/gui/client/components/IssueCommits.tsx
@@ -491,16 +491,21 @@ const DiffCommentAnnotation = ({
 				borderRadius: 6,
 				background: GUI_THEME.tertiary,
 				fontSize: TEXT.ui,
-				display: 'flex',
-				alignItems: 'flex-start',
-				gap: 8,
 			}}
 		>
-			<span style={{color: GUI_THEME.accent, flexShrink: 0, marginTop: 1}}>
-				<IconComment size={12} />
-			</span>
-			<div style={{flex: 1, minWidth: 0}}>
-				<div style={{color: GUI_THEME.secondary, fontSize: TEXT.meta}}>
+			<div
+				style={{
+					display: 'flex',
+					alignItems: 'center',
+					gap: 8,
+					color: GUI_THEME.secondary,
+					fontSize: TEXT.meta,
+				}}
+			>
+				<span style={{display: 'inline-flex', color: GUI_THEME.accent}}>
+					<IconComment size={12} />
+				</span>
+				<span>
 					{comment.author.name ?? 'unknown'}
 					{comment.createdAt && (
 						<span style={{color: GUI_THEME.dim2}}>
@@ -508,10 +513,10 @@ const DiffCommentAnnotation = ({
 							· {timeAgo(comment.createdAt)}
 						</span>
 					)}
-				</div>
-				<div style={{marginTop: 2}}>
-					{meta.note || <em style={{color: GUI_THEME.dim}}>commented</em>}
-				</div>
+				</span>
+			</div>
+			<div style={{marginTop: 4}}>
+				{meta.note || <em style={{color: GUI_THEME.dim}}>commented</em>}
 			</div>
 		</div>
 	);

--- a/source/gui/client/components/IssueCommits.tsx
+++ b/source/gui/client/components/IssueCommits.tsx
@@ -9,7 +9,7 @@ import {
 	GuiCommitDiffFile,
 	GuiRefCommitEntry,
 } from '../lib/gui-state.model';
-import {GUI_THEME} from '../lib/gui-theme';
+import {CONTENT_FONT, GUI_THEME, TEXT} from '../lib/gui-theme';
 import {timeAgo} from '../lib/gui-format.helper';
 import {ActionRow, Textarea} from './FormPrimitives';
 import {Button} from './Button';
@@ -293,7 +293,7 @@ const disclosureStyle: React.CSSProperties = {
 	cursor: 'pointer',
 	color: GUI_THEME.primary,
 	font: 'inherit',
-	fontSize: 12,
+	fontSize: TEXT.ui,
 };
 
 // A rounded pill rather than GitHub's five solid squares — matches the
@@ -318,7 +318,7 @@ const DiffStat = ({
 				gap: 6,
 				flexShrink: 0,
 				fontFamily: 'ui-monospace, monospace',
-				fontSize: 11,
+				fontSize: TEXT.meta,
 			}}
 		>
 			<span style={{color: GUI_THEME.green}}>+{insertions}</span>
@@ -415,7 +415,7 @@ const SelectionComposer = ({
 				boxShadow: `0 0 0 1px ${GUI_THEME.accent}33`,
 			}}
 		>
-			<div style={{fontSize: 11, color: GUI_THEME.secondary}}>
+			<div style={{fontSize: TEXT.meta, color: GUI_THEME.secondary}}>
 				{selectionLabel}
 			</div>
 
@@ -431,7 +431,13 @@ const SelectionComposer = ({
 						if (onAddComment) comment();
 					}
 				}}
-				style={{marginTop: 8, minHeight: 45, font: 'inherit', fontSize: 12}}
+				style={{
+					marginTop: 8,
+					minHeight: 45,
+					font: 'inherit',
+					fontFamily: CONTENT_FONT,
+					fontSize: TEXT.prose,
+				}}
 			/>
 
 			<ActionRow>
@@ -484,7 +490,7 @@ const DiffCommentAnnotation = ({
 				borderLeft: `2px solid ${GUI_THEME.accent}`,
 				borderRadius: 6,
 				background: GUI_THEME.tertiary,
-				fontSize: 12,
+				fontSize: TEXT.ui,
 				display: 'flex',
 				alignItems: 'flex-start',
 				gap: 8,
@@ -494,7 +500,7 @@ const DiffCommentAnnotation = ({
 				<IconComment size={12} />
 			</span>
 			<div style={{flex: 1, minWidth: 0}}>
-				<div style={{color: GUI_THEME.secondary, fontSize: 11}}>
+				<div style={{color: GUI_THEME.secondary, fontSize: TEXT.meta}}>
 					{comment.author.name ?? 'unknown'}
 					{comment.createdAt && (
 						<span style={{color: GUI_THEME.dim2}}>
@@ -644,7 +650,7 @@ const FileRow = ({
 							gap: 3,
 							flexShrink: 0,
 							color: GUI_THEME.accent,
-							fontSize: 10,
+							fontSize: TEXT.label,
 						}}
 					>
 						<IconComment size={10} />

--- a/source/gui/client/components/IssueCommits.tsx
+++ b/source/gui/client/components/IssueCommits.tsx
@@ -909,6 +909,7 @@ export const IssueCommits = ({
 	onFileTicket,
 	comments,
 	focus,
+	expandAll = false,
 }: {
 	issueRef: string;
 	commits: GuiRefCommitEntry[];
@@ -922,11 +923,57 @@ export const IssueCommits = ({
 	comments: GuiComment[];
 	// Where a comment permalink points, read from the URL by the caller.
 	focus?: DiffLocation | null;
+	// Open every commit and file as it appears — for a layout meant for
+	// reading rather than scanning. Each is opened once, so collapsing it by
+	// hand afterwards sticks.
+	expandAll?: boolean;
 }) => {
 	const [expandedShas, setExpandedShas] = useState<Set<string>>(new Set());
 	const [expandedFilesBySha, setExpandedFilesBySha] = useState<
 		Record<string, Set<string>>
 	>({});
+
+	const autoOpenedShas = useRef(new Set<string>());
+	const autoOpenedFiles = useRef(new Set<string>());
+
+	useEffect(() => {
+		if (!expandAll) return;
+
+		const fresh = commits.filter(
+			commit => !autoOpenedShas.current.has(commit.sha),
+		);
+		if (fresh.length === 0) return;
+
+		for (const commit of fresh) autoOpenedShas.current.add(commit.sha);
+		setExpandedShas(prev => {
+			const next = new Set(prev);
+			for (const commit of fresh) next.add(commit.sha);
+			return next;
+		});
+		for (const commit of fresh) {
+			const existing = diffsBySha[commit.sha];
+			if (!existing || existing.error) onLoadDiff(commit.sha);
+		}
+	}, [expandAll, commits]);
+
+	// Files are only known once a diff has arrived, so this runs as they land.
+	useEffect(() => {
+		if (!expandAll) return;
+
+		for (const commit of commits) {
+			const files = diffsBySha[commit.sha]?.files;
+			if (!files || autoOpenedFiles.current.has(commit.sha)) continue;
+
+			autoOpenedFiles.current.add(commit.sha);
+			setExpandedFilesBySha(prev => ({
+				...prev,
+				[commit.sha]: new Set([
+					...(prev[commit.sha] ?? []),
+					...files.map(file => file.path),
+				]),
+			}));
+		}
+	}, [expandAll, commits, diffsBySha]);
 
 	// Opens the commit and file a permalink names. Deliberately additive — it
 	// never collapses anything the reader already had open, so following a

--- a/source/gui/client/components/IssueDetails.tsx
+++ b/source/gui/client/components/IssueDetails.tsx
@@ -634,6 +634,7 @@ export const IssueDetails = ({
 						error={commitsError}
 						diffsBySha={commitDiffsBySha}
 						onLoadDiff={onLoadCommitDiff}
+						expandAll={laneView}
 						diffStyle={commitsWidth >= STACKED_DIFF_WIDTH ? 'split' : 'unified'}
 						comments={comments}
 						onAddComment={

--- a/source/gui/client/components/IssueDetails.tsx
+++ b/source/gui/client/components/IssueDetails.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useRef, useState} from 'react';
-import {CONTENT_FONT, GUI_THEME} from '../lib/gui-theme';
+import {CONTENT_FONT, GUI_THEME, TEXT} from '../lib/gui-theme';
 import {
 	GuiContributor,
 	GuiUser,
@@ -73,7 +73,7 @@ const Lane = ({
 		<div
 			style={{
 				color: GUI_THEME.secondary,
-				fontSize: 10,
+				fontSize: TEXT.label,
 				textTransform: 'uppercase',
 				letterSpacing: '0.08em',
 				paddingBottom: 10,
@@ -312,7 +312,7 @@ export const IssueDetails = ({
 								data-testid="issue-created-at"
 								title={formatAbsolute(issue.createdAt)}
 								style={{
-									fontSize: 11,
+									fontSize: TEXT.meta,
 									color: GUI_THEME.dim,
 									marginBottom: 14,
 								}}
@@ -355,7 +355,7 @@ export const IssueDetails = ({
 										style={{
 											font: 'inherit',
 											fontFamily: CONTENT_FONT,
-											fontSize: 13,
+											fontSize: TEXT.prose,
 											maxHeight: 320,
 											overflowY: 'auto',
 										}}
@@ -372,10 +372,10 @@ export const IssueDetails = ({
 								<div
 									style={{
 										marginTop: 8,
-										padding: '12px 16px',
+										padding: '8px 10px',
 										maxHeight: 320,
 										overflowY: 'auto',
-										background: GUI_THEME.tertiary,
+										background: GUI_THEME.panel2,
 										borderRadius: 8,
 									}}
 								>
@@ -662,7 +662,7 @@ export const IssueDetails = ({
 									<span
 										style={{
 											color: GUI_THEME.secondary,
-											fontSize: 10,
+											fontSize: TEXT.label,
 											textTransform: 'uppercase',
 											letterSpacing: '0.08em',
 										}}
@@ -712,7 +712,7 @@ export const IssueDetails = ({
 											padding: '6px 10px',
 											outline: 'none',
 											font: 'inherit',
-											fontSize: 18,
+											fontSize: TEXT.title,
 											fontWeight: 600,
 											lineHeight: 1.35,
 											marginBottom: 20,
@@ -724,7 +724,7 @@ export const IssueDetails = ({
 										style={{
 											marginBottom: 18,
 											color: GUI_THEME.primary,
-											fontSize: 18,
+											fontSize: TEXT.title,
 											fontWeight: 600,
 											lineHeight: 1.35,
 											wordBreak: 'break-word',

--- a/source/gui/client/components/IssueHistory.tsx
+++ b/source/gui/client/components/IssueHistory.tsx
@@ -1,5 +1,5 @@
 import {GuiIssueHistoryEntry} from '../lib/gui-state.model';
-import {GUI_THEME, CONTENT_FONT} from '../lib/gui-theme';
+import {GUI_THEME, CONTENT_FONT, TEXT} from '../lib/gui-theme';
 import {formatAbsolute, timeAgo} from '../lib/gui-format.helper';
 import {User} from './User';
 
@@ -12,7 +12,9 @@ export const IssueHistory = ({
 }) => {
 	if (entries.length === 0) {
 		return (
-			<div style={{color: GUI_THEME.dim, fontSize: 12}}>No history yet</div>
+			<div style={{color: GUI_THEME.dim, fontSize: TEXT.ui}}>
+				No history yet
+			</div>
 		);
 	}
 
@@ -36,7 +38,7 @@ export const IssueHistory = ({
 						gap: 14,
 						padding: '8px 0',
 						borderTop: index === 0 ? 'none' : `1px solid ${GUI_THEME.line}`,
-						fontSize: 12,
+						fontSize: TEXT.ui,
 					}}
 				>
 					<User user={entry.actor} />

--- a/source/gui/client/components/MarkdownContent.tsx
+++ b/source/gui/client/components/MarkdownContent.tsx
@@ -5,7 +5,7 @@ import ReactMarkdown, {
 } from 'react-markdown';
 import remarkBreaks from 'remark-breaks';
 import remarkGfm from 'remark-gfm';
-import {CONTENT_FONT, GUI_THEME} from '../lib/gui-theme';
+import {CONTENT_FONT, GUI_THEME, TEXT} from '../lib/gui-theme';
 import {
 	remarkTicketRefs,
 	TICKET_REF_URL_PREFIX,
@@ -58,13 +58,13 @@ const buildComponents = (
 	),
 	li: ({children}) => <li style={{margin: '2px 0'}}>{children}</li>,
 	h1: ({children}) => (
-		<h1 style={{fontSize: 16, margin: '0 0 14px'}}>{children}</h1>
+		<h1 style={{fontSize: TEXT.prose + 2, margin: '0 0 14px'}}>{children}</h1>
 	),
 	h2: ({children}) => (
-		<h2 style={{fontSize: 14, margin: '0 0 14px'}}>{children}</h2>
+		<h2 style={{fontSize: TEXT.prose + 1, margin: '0 0 14px'}}>{children}</h2>
 	),
 	h3: ({children}) => (
-		<h3 style={{fontSize: 13, margin: '0 0 14px'}}>{children}</h3>
+		<h3 style={{fontSize: TEXT.prose, margin: '0 0 14px'}}>{children}</h3>
 	),
 	a: ({children, href}) => {
 		// A ticket ref opens a ticket in this app, not a URL in a new tab, so it
@@ -127,7 +127,7 @@ const buildComponents = (
 			<code
 				style={
 					isBlock
-						? {fontFamily: CODE_FONT, fontSize: 12}
+						? {fontFamily: CODE_FONT, fontSize: TEXT.ui}
 						: {
 								fontFamily: CODE_FONT,
 								fontSize: '0.9em',
@@ -197,7 +197,7 @@ export const MarkdownContent = ({
 		<div
 			style={{
 				fontFamily: CONTENT_FONT,
-				fontSize: 13,
+				fontSize: TEXT.prose,
 				lineHeight: 1.6,
 				color: GUI_THEME.primary,
 				wordBreak: 'break-word',

--- a/source/gui/client/components/Section.tsx
+++ b/source/gui/client/components/Section.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {GUI_THEME} from '../lib/gui-theme';
+import {GUI_THEME, TEXT} from '../lib/gui-theme';
 
 export const Section = ({
 	title,
@@ -29,7 +29,7 @@ export const Section = ({
 			<span
 				style={{
 					color: GUI_THEME.secondary,
-					fontSize: 10,
+					fontSize: TEXT.label,
 					textTransform: 'uppercase',
 					letterSpacing: '0.08em',
 				}}

--- a/source/gui/client/components/Tabs.tsx
+++ b/source/gui/client/components/Tabs.tsx
@@ -1,4 +1,4 @@
-import {GUI_THEME} from '../lib/gui-theme';
+import {GUI_THEME, TEXT} from '../lib/gui-theme';
 
 export type TabItem<T extends string> = {
 	id: T;
@@ -43,7 +43,7 @@ export const Tabs = <T extends string>({
 						padding: '0 8px 10px',
 						marginBottom: -1,
 						font: 'inherit',
-						fontSize: 11,
+						fontSize: TEXT.meta,
 						cursor: 'pointer',
 					}}
 				>

--- a/source/gui/client/lib/gui-theme.tsx
+++ b/source/gui/client/lib/gui-theme.tsx
@@ -3,6 +3,16 @@
 export const CONTENT_FONT =
 	'-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif';
 
+// The side panel's text sizes. Prose (descriptions, comments, notes) sits a
+// step above the mono UI text so the two fonts read at the same visual size.
+export const TEXT = {
+	label: 10,
+	meta: 11,
+	ui: 12,
+	prose: 13,
+	title: 18,
+} as const;
+
 export const GUI_THEME = {
 	bg: '#06070a',
 	bgHighlight: '#10111a65',

--- a/source/test/e2e-gui/diff-composer.pw.ts
+++ b/source/test/e2e-gui/diff-composer.pw.ts
@@ -1,28 +1,12 @@
-import {execFileSync} from 'node:child_process';
-import fs from 'node:fs';
-import path from 'node:path';
 import type {Page} from '@playwright/test';
 import {expect, test} from './fixtures.js';
+import {COMMIT_CACHE_MS, commitLinkedFile} from './linked-commit.js';
 
 const addTicket = async (page: Page, title: string) => {
 	await page.getByTitle('Add issue').first().click();
 	await page.getByPlaceholder('issue name').fill(title);
 	await page.getByPlaceholder('issue name').press('Enter');
 	await expect(page.locator('aside')).toContainText(title);
-};
-
-// The seeded repo has no code history: link one commit to the ticket by
-// prefixing its subject with the ref shown in the panel.
-const commitFor = (repoRoot: string, ref: string, subject: string) => {
-	fs.writeFileSync(path.join(repoRoot, 'notes.txt'), 'alpha\nbeta\ngamma\n');
-	const git = (...args: string[]) =>
-		execFileSync(
-			'git',
-			['-c', 'user.name=e2e', '-c', 'user.email=e2e@example.com', ...args],
-			{cwd: repoRoot, stdio: 'pipe'},
-		);
-	git('add', 'notes.txt');
-	git('commit', '-q', '-m', `${ref} ${subject}`);
 };
 
 const expandDiff = async (page: Page, subject: string) => {
@@ -55,10 +39,8 @@ test('selecting lines opens one composer under them; write, then comment or file
 	)?.trim();
 	expect(ref).toBeTruthy();
 
-	commitFor(repoRoot, ref!, 'add notes');
-	// The server caches the full commit timeline for 5s; outlive it so the
-	// reload sees the new commit.
-	await page.waitForTimeout(5_500);
+	commitLinkedFile(repoRoot, ref!, 'add notes');
+	await page.waitForTimeout(COMMIT_CACHE_MS);
 	await page.reload();
 	await expect(page.locator('aside')).toContainText(`Composer ${stamp}`);
 

--- a/source/test/e2e-gui/fullscreen-lanes.pw.ts
+++ b/source/test/e2e-gui/fullscreen-lanes.pw.ts
@@ -1,5 +1,6 @@
 import type {Page} from '@playwright/test';
 import {expect, test} from './fixtures.js';
+import {COMMIT_CACHE_MS, commitLinkedFile} from './linked-commit.js';
 
 const addTicket = async (page: Page, title: string) => {
 	await page.getByTitle('Add issue').first().click();
@@ -85,6 +86,45 @@ test('a narrow fullscreen panel keeps the tabs', async ({page, pageErrors}) => {
 	await page.setViewportSize({width: 1600, height: 800});
 	await expect(tabButtons(page)).toHaveCount(0);
 	await expect(page.getByTestId('lane-commits')).toBeVisible();
+
+	expect(pageErrors).toEqual([]);
+});
+
+test('the lanes open every commit and file, ready to read', async ({
+	page,
+	pageErrors,
+	repoRoot,
+}) => {
+	await page.setViewportSize({width: 1600, height: 900});
+	await addTicket(page, `Open diffs ${Date.now()}`);
+	const ref = (
+		await page.locator('aside button[title^="Copy "]').first().textContent()
+	)?.trim();
+	expect(ref).toBeTruthy();
+
+	commitLinkedFile(repoRoot, ref!, 'add notes');
+	await page.waitForTimeout(COMMIT_CACHE_MS);
+	await page.reload();
+	await expect(
+		page.getByRole('button', {name: /^Commits \(1\)/}),
+	).toBeVisible();
+
+	// Tabbed: collapsed, as before.
+	await page.getByRole('button', {name: /^Commits/}).click();
+	await expect(
+		page.getByRole('button', {name: 'add notes +3 -0'}),
+	).toHaveAttribute('aria-expanded', 'false');
+	await expect(page.locator('[data-line]')).toHaveCount(0);
+
+	// Lanes: the diff is simply there.
+	await page.getByTitle('Fullscreen').click();
+	await expect(page.getByTestId('lane-commits')).toBeVisible();
+	await expect(page.locator('[data-line]')).toHaveCount(3);
+	await expect(page.locator('[data-line]').first()).toHaveText('alpha');
+
+	// And collapsing by hand sticks.
+	await page.getByRole('button', {name: 'notes.txt'}).click();
+	await expect(page.locator('[data-line]')).toHaveCount(0);
 
 	expect(pageErrors).toEqual([]);
 });

--- a/source/test/e2e-gui/linked-commit.ts
+++ b/source/test/e2e-gui/linked-commit.ts
@@ -1,0 +1,27 @@
+import {execFileSync} from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+// The seeded repo has no code history: link one commit to a ticket by
+// prefixing its subject with the ref shown in the panel. The server caches the
+// commit timeline for this long, so a page that already asked once has to
+// outlive it before a reload sees the commit.
+export const COMMIT_CACHE_MS = 5_500;
+
+export const commitLinkedFile = (
+	repoRoot: string,
+	ref: string,
+	subject: string,
+	fileName = 'notes.txt',
+	contents = 'alpha\nbeta\ngamma\n',
+) => {
+	fs.writeFileSync(path.join(repoRoot, fileName), contents);
+	const git = (...args: string[]) =>
+		execFileSync(
+			'git',
+			['-c', 'user.name=e2e', '-c', 'user.email=e2e@example.com', ...args],
+			{cwd: repoRoot, stdio: 'pipe'},
+		);
+	git('add', fileName);
+	git('commit', '-q', '-m', `${ref} ${subject}`);
+};


### PR DESCRIPTION
Ticket 15NX51E. Stacked on #133 (touches the same comment card).

- Description box: padding 12/16 → 8/10, background `tertiary` → `panel2`, so it sits closer to the panel it's in.
- One text scale for the side panel, `TEXT` in `gui-theme`: label 10 · meta 11 · ui 12 · prose 13 · title 18. Every literal size in the panel components now reads from it (the attachments badge's 9 and the markdown headings' 16/14 were the stragglers; headings are now prose+2 / prose+1 / prose).
- The composer's note box uses the prose font/size like the comment box, instead of 12px mono.

No behavior change; the e2e suite is unchanged and green.