### PR TITLE
M7SERD9 suggest recently opened projects when epiq boots outside a project

### DIFF
--- a/source/boot-tui.tsx
+++ b/source/boot-tui.tsx
@@ -1,15 +1,7 @@
-import {getStateBranchRoot} from './git/git-storage.js';
-import {execGit} from './git/git-utils.js';
-import {ensureStateBranchWorktree} from './git/git.js';
 import {renderApp} from './Index.js';
+import {loadProject, loadWithoutProject} from './lib/boot/load-project.js';
 import {resolveEnvActor} from './lib/config/actor-env.js';
 import {loadSettingsFromConfig} from './lib/config/user-config.js';
-import {bootStateFromEventLog} from './lib/event/event-boot.js';
-import {
-	loadMergedEventsWithUnreadable,
-	UnreadableEvent,
-} from './lib/event/event-load.js';
-import {AppEvent} from './lib/event/event.model.js';
 import {initListeners} from './lib/listeners/keypress-listener.js';
 import {
 	Result,
@@ -17,9 +9,7 @@ import {
 	isFail,
 	succeeded,
 } from './lib/model/result-types.js';
-import {getProjectFileContents} from './lib/project-setup/project-setup.js';
 import {patchSettingsState} from './lib/state/settings.state.js';
-import {patchState} from './lib/state/state.js';
 import {resolveClosestEpiqProjectRoot} from './lib/storage/paths.js';
 import {failAt, formatUnknownError} from './lib/utils/logger.utils.js';
 
@@ -36,55 +26,11 @@ export async function bootTui(): Promise<Result<void>> {
 
 		const repoRootResult = resolveClosestEpiqProjectRoot(process.cwd());
 
-		let eventLog: AppEvent[] = [];
-		let unreadable: UnreadableEvent[] = [];
+		const loadResult = isSuccess(repoRootResult)
+			? await loadProject(repoRootResult.value)
+			: loadWithoutProject();
 
-		if (isSuccess(repoRootResult)) {
-			const stateBranchRootResult = getStateBranchRoot({
-				repoRoot: repoRootResult.value,
-			});
-
-			if (isFail(stateBranchRootResult)) {
-				return failAt(3, stateBranchRootResult.message);
-			}
-
-			const projectFileContents = getProjectFileContents();
-
-			const ensureWorktreeResult = await ensureStateBranchWorktree({
-				repoRoot: repoRootResult.value,
-				stateBranchRoot: stateBranchRootResult.value,
-				stateBranchName: projectFileContents.stateBranch,
-			});
-
-			if (isFail(ensureWorktreeResult)) {
-				return failAt(3, ensureWorktreeResult.message);
-			}
-
-			const pullResult = await execGit({
-				cwd: stateBranchRootResult.value,
-				args: ['pull', '--ff-only'],
-			});
-
-			if (isFail(pullResult)) {
-				logger.info(3, pullResult.message);
-			}
-
-			const eventsResult = loadMergedEventsWithUnreadable(
-				stateBranchRootResult.value,
-			);
-			if (isFail(eventsResult)) return failAt(3, eventsResult.message);
-
-			eventLog = eventsResult.value.events;
-			unreadable = eventsResult.value.unreadable;
-		}
-
-		const bootStateResult = bootStateFromEventLog(eventLog, unreadable);
-		if (isFail(bootStateResult)) return failAt(4, bootStateResult.message);
-
-		patchState({
-			hasProjectDefinition: isSuccess(repoRootResult),
-			hasInitializingEvents: Boolean(eventLog.length),
-		});
+		if (isFail(loadResult)) return loadResult;
 
 		const renderResult = renderApp();
 		if (isFail(renderResult)) return failAt(6, renderResult.message);

--- a/source/gui/api/api-server.ts
+++ b/source/gui/api/api-server.ts
@@ -20,6 +20,7 @@ import {
 import {getTimeTravelStatus, runExclusive} from '../../mcp/epiq-time-travel.js';
 import {startGuiAutoSync} from './lib/api-autosync.js';
 import {refuseCrossSiteRequest} from './lib/origin-guard.js';
+import {GuiProject} from './lib/gui-project.js';
 import {setupWebsocket} from './lib/websocket.js';
 
 const distRoot = path.dirname(fileURLToPath(import.meta.url));
@@ -210,6 +211,9 @@ export const startGuiServer = async (input: {
 	// Known only after `listen`, and the handler below closes over it.
 	let boundPort = 0;
 
+	// Read at each request rather than captured: `project:open` moves it.
+	const project: GuiProject = {repoRoot: input.repoRoot};
+
 	const server = http.createServer(async (req, res) => {
 		const url = new URL(req.url ?? '/', 'http://127.0.0.1');
 
@@ -230,7 +234,11 @@ export const startGuiServer = async (input: {
 		}
 
 		if (url.pathname === '/api/state') {
-			return sendJson(res, 200, await getGuiState({repoRoot: input.repoRoot}));
+			return sendJson(
+				res,
+				200,
+				await getGuiState({repoRoot: project.repoRoot}),
+			);
 		}
 
 		if (req.method === 'POST' && url.pathname === '/api/comments') {
@@ -252,7 +260,7 @@ export const startGuiServer = async (input: {
 
 				return await runMutation(res, async () => {
 					const result = await addIssueComment({
-						repoRoot: input.repoRoot,
+						repoRoot: project.repoRoot,
 						issueId,
 						body: commentBody,
 					});
@@ -267,7 +275,7 @@ export const startGuiServer = async (input: {
 					return sendJson(
 						res,
 						200,
-						await getGuiState({repoRoot: input.repoRoot}),
+						await getGuiState({repoRoot: project.repoRoot}),
 					);
 				});
 			} catch (error) {
@@ -300,7 +308,7 @@ export const startGuiServer = async (input: {
 
 				return await runMutation(res, async () => {
 					const result = await addIssueAttachment({
-						repoRoot: input.repoRoot,
+						repoRoot: project.repoRoot,
 						issueId,
 						name,
 						dataBase64,
@@ -316,7 +324,7 @@ export const startGuiServer = async (input: {
 					return sendJson(
 						res,
 						200,
-						await getGuiState({repoRoot: input.repoRoot}),
+						await getGuiState({repoRoot: project.repoRoot}),
 					);
 				});
 			} catch (error) {
@@ -345,7 +353,7 @@ export const startGuiServer = async (input: {
 
 			return runMutation(res, async () => {
 				const result = await deleteIssueAttachment({
-					repoRoot: input.repoRoot,
+					repoRoot: project.repoRoot,
 					attachmentId,
 				});
 
@@ -359,7 +367,7 @@ export const startGuiServer = async (input: {
 				return sendJson(
 					res,
 					200,
-					await getGuiState({repoRoot: input.repoRoot}),
+					await getGuiState({repoRoot: project.repoRoot}),
 				);
 			});
 		}
@@ -368,7 +376,7 @@ export const startGuiServer = async (input: {
 			const fileName = decodeURIComponent(url.pathname.replace('/media/', ''));
 
 			const blobResult = await getAttachmentBlob({
-				repoRoot: input.repoRoot,
+				repoRoot: project.repoRoot,
 				fileName,
 			});
 
@@ -413,7 +421,7 @@ export const startGuiServer = async (input: {
 
 			return runMutation(res, async () => {
 				const result = await deleteIssueComment({
-					repoRoot: input.repoRoot,
+					repoRoot: project.repoRoot,
 					commentId,
 				});
 
@@ -427,7 +435,7 @@ export const startGuiServer = async (input: {
 				return sendJson(
 					res,
 					200,
-					await getGuiState({repoRoot: input.repoRoot}),
+					await getGuiState({repoRoot: project.repoRoot}),
 				);
 			});
 		}
@@ -449,11 +457,9 @@ export const startGuiServer = async (input: {
 		);
 	}
 
-	const guiAutoSync = startGuiAutoSync({
-		repoRoot: input.repoRoot,
-	});
+	const guiAutoSync = startGuiAutoSync({project});
 
-	setupWebsocket(server, input.repoRoot, {
+	setupWebsocket(server, project, {
 		onStateChanged: () => guiAutoSync.queueSync(),
 		getPort: () => boundPort,
 	});

--- a/source/gui/api/lib/api-autosync.ts
+++ b/source/gui/api/lib/api-autosync.ts
@@ -1,3 +1,4 @@
+import {GuiProject} from './gui-project.js';
 import {
 	loadSettingsFromConfig,
 	readEpiqConfig,
@@ -13,7 +14,7 @@ import {broadcastGuiMessage} from '../../client/lib/gui-broadcast.js';
 
 const DEFAULT_INTERVAL_MS = 15_000;
 
-export const startGuiAutoSync = (input: {repoRoot: string}) => {
+export const startGuiAutoSync = (input: {project: GuiProject}) => {
 	let timer: NodeJS.Timeout | undefined;
 	let disposed = false;
 	let syncing = false;
@@ -62,7 +63,7 @@ export const startGuiAutoSync = (input: {repoRoot: string}) => {
 			await runExclusive(async () => {
 				if (getTimeTravelStatus().mode !== 'live') return;
 
-				const result = await sync({repoRoot: input.repoRoot});
+				const result = await sync({repoRoot: input.project.repoRoot});
 				if (isFail(result)) return;
 
 				const {pulled, createdCommit, bootstrapped} = result.value;
@@ -74,7 +75,7 @@ export const startGuiAutoSync = (input: {repoRoot: string}) => {
 
 				broadcastGuiMessage({
 					type: 'state',
-					payload: await getGuiState({repoRoot: input.repoRoot}),
+					payload: await getGuiState({repoRoot: input.project.repoRoot}),
 				});
 			});
 		} finally {

--- a/source/gui/api/lib/gui-project.ts
+++ b/source/gui/api/lib/gui-project.ts
@@ -1,0 +1,45 @@
+import {
+	listRecentProjects,
+	recentProjectName,
+} from '../../../lib/config/recent-projects.js';
+import {
+	failed,
+	isFail,
+	Result,
+	succeeded,
+} from '../../../lib/model/result-types.js';
+
+// The project a GUI server is serving. Mutable so `project:open` can point a
+// server started outside any project at one from the recent list.
+export type GuiProject = {repoRoot: string};
+
+export type RecentProjectView = {
+	projectId: string;
+	name: string;
+	root: string;
+	lastOpenedAt: number;
+};
+
+export const recentProjectViews = (exclude: string): RecentProjectView[] => {
+	const result = listRecentProjects({exclude});
+	if (isFail(result)) return [];
+
+	return result.value.map(entry => ({
+		projectId: entry.projectId,
+		name: recentProjectName(entry.root),
+		root: entry.root,
+		lastOpenedAt: entry.lastOpenedAt,
+	}));
+};
+
+// Only a root the registry currently lists: the socket is origin-guarded, but
+// a message still should not be able to aim the server at an arbitrary path.
+export const resolveRecentProjectRoot = (root: string): Result<string> => {
+	const result = listRecentProjects();
+	if (isFail(result)) return failed(result.message);
+
+	const entry = result.value.find(candidate => candidate.root === root);
+	if (!entry) return failed(`Not a recent project: ${root}`);
+
+	return succeeded('Resolved recent project', entry.root);
+};

--- a/source/gui/api/lib/websocket.model.ts
+++ b/source/gui/api/lib/websocket.model.ts
@@ -2,6 +2,7 @@ import {MovePosition} from '../../../lib/event/event.model.js';
 
 export type GuiMessage =
 	| {type: 'state:get'}
+	| {type: 'project:open'; payload: {root: string}}
 	| {type: 'issues:list'}
 	| {type: 'issues:create'; payload: {title: string; parentId: string}}
 	| {type: 'swimlane:create'; payload: {title: string; boardId: string}}

--- a/source/gui/api/lib/websocket.schema.ts
+++ b/source/gui/api/lib/websocket.schema.ts
@@ -39,6 +39,7 @@ export const GuiMessageSchema = z.discriminatedUnion('type', [
 	bare('sync'),
 	bare('time-travel:live'),
 
+	message('project:open', z.object({root: z.string().min(1)})),
 	message(
 		'issues:create',
 		z.object({

--- a/source/gui/api/lib/websocket.ts
+++ b/source/gui/api/lib/websocket.ts
@@ -46,6 +46,11 @@ import {
 	registerGuiSocket,
 } from '../../client/lib/gui-broadcast.js';
 import {MUTATING_MESSAGE_TYPES} from '../../client/lib/gui-mutations.js';
+import {
+	GuiProject,
+	recentProjectViews,
+	resolveRecentProjectRoot,
+} from './gui-project.js';
 import {GuiMessage} from './websocket.model.js';
 import {isForeignOrigin} from './origin-guard.js';
 import {parseGuiMessage} from './websocket.schema.js';
@@ -73,7 +78,11 @@ const sendGuiState = async (socket: WebSocket, repoRoot: string) => {
 	if (isFail(payload) && payload.message === NO_PROJECT_MESSAGE) {
 		return sendSocket(socket, {
 			type: 'state:unavailable',
-			payload: {message: payload.message, repoRoot},
+			payload: {
+				message: payload.message,
+				repoRoot,
+				recentProjects: recentProjectViews(repoRoot),
+			},
 		});
 	}
 
@@ -129,7 +138,7 @@ const sendMutationResult = async (
 
 export const setupWebsocket = (
 	server: http.Server<typeof http.IncomingMessage, typeof http.ServerResponse>,
-	repoRoot: string,
+	project: GuiProject,
 	{
 		onStateChanged,
 		getPort,
@@ -151,6 +160,18 @@ export const setupWebsocket = (
 		socket.on('message', async raw => {
 			const dispatchMessage = async (message: GuiMessage) => {
 				const {type} = message;
+				const repoRoot = project.repoRoot;
+
+				if (type === 'project:open') {
+					const result = resolveRecentProjectRoot(message.payload.root);
+
+					sendSocket(socket, {type: 'project:open:result', payload: result});
+
+					if (isFail(result)) return;
+
+					project.repoRoot = result.value;
+					return sendGuiState(socket, result.value);
+				}
 
 				// Echoed back rather than forwarded into the API: the client pairs
 				// the timeline and commit replies by it.

--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -15,7 +15,10 @@ import {CreateNodeModal} from './components/CreateNodeModal';
 import {AddSwimlaneColumn} from './components/AddSwimlaneColumn';
 import {ConfirmModal} from './components/ConfirmModal';
 import {DiffPanel} from './components/DiffPanel';
-import {InitProjectScreen} from './components/InitProjectScreen';
+import {
+	InitProjectScreen,
+	RecentProjectView,
+} from './components/InitProjectScreen';
 import {Dropdown} from './components/Dropdown';
 import {Header} from './components/Header';
 import {IssueDetails} from './components/IssueDetails';
@@ -125,6 +128,7 @@ export const App = () => {
 	const [noProject, setNoProject] = useState<{
 		message: string;
 		repoRoot: string;
+		recentProjects: RecentProjectView[];
 	} | null>(null);
 	// Assignable people for the board on screen, unlike state.contributors, which
 	// is the registry and stays empty until somebody is explicitly assigned.
@@ -1464,7 +1468,9 @@ export const App = () => {
 			<InitProjectScreen
 				repoRoot={noProject.repoRoot}
 				message={noProject.message}
+				recentProjects={noProject.recentProjects}
 				onRetry={requestState}
+				onOpen={root => send('project:open', {root})}
 			/>
 		);
 	}

--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -507,6 +507,16 @@ export const App = () => {
 				setNoProject(message.payload);
 			}
 
+			if (message.type === 'project:open:result') {
+				const result = message.payload as {status: string; message: string};
+
+				if (result.status !== 'success') {
+					setNoProject(current =>
+						current ? {...current, message: result.message} : current,
+					);
+				}
+			}
+
 			if (message.type === 'issue') {
 				const detail = getResultValue<{
 					issueId: string;

--- a/source/gui/client/components/InitProjectScreen.tsx
+++ b/source/gui/client/components/InitProjectScreen.tsx
@@ -2,10 +2,21 @@ import {Button} from './Button';
 import {Panel} from './Panel';
 import {GUI_THEME} from '../lib/gui-theme';
 
+// Mirrors the server's view of the recent-projects registry; the client cannot
+// import the Node-side module that defines it.
+export type RecentProjectView = {
+	projectId: string;
+	name: string;
+	root: string;
+	lastOpenedAt: number;
+};
+
 type Props = {
 	repoRoot: string;
 	message: string;
+	recentProjects?: RecentProjectView[];
 	onRetry: () => void;
+	onOpen: (root: string) => void;
 };
 
 const codeStyle = {
@@ -16,7 +27,13 @@ const codeStyle = {
 	color: GUI_THEME.primary,
 };
 
-export const InitProjectScreen = ({repoRoot, message, onRetry}: Props) => (
+export const InitProjectScreen = ({
+	repoRoot,
+	message,
+	recentProjects = [],
+	onRetry,
+	onOpen,
+}: Props) => (
 	<div
 		data-testid="init-project-screen"
 		style={{
@@ -85,6 +102,62 @@ export const InitProjectScreen = ({repoRoot, message, onRetry}: Props) => (
 					<span style={codeStyle}>.epiq/project.json</span>. Then come back and
 					reload.
 				</div>
+
+				{recentProjects.length > 0 && (
+					<div
+						data-testid="recent-projects"
+						style={{display: 'flex', flexDirection: 'column', gap: 8}}
+					>
+						<div
+							style={{
+								color: GUI_THEME.accent,
+								fontSize: 10,
+								letterSpacing: 1,
+								textTransform: 'uppercase',
+							}}
+						>
+							Or open a recent project
+						</div>
+
+						{recentProjects.map(project => (
+							<div
+								key={project.projectId}
+								data-testid="recent-project"
+								style={{
+									display: 'flex',
+									alignItems: 'center',
+									justifyContent: 'space-between',
+									gap: 12,
+									fontSize: 12,
+								}}
+							>
+								<div style={{minWidth: 0}}>
+									<div style={{fontWeight: 700}}>{project.name}</div>
+									<div
+										style={{
+											color: GUI_THEME.dim,
+											fontSize: 10,
+											overflow: 'hidden',
+											textOverflow: 'ellipsis',
+											whiteSpace: 'nowrap',
+										}}
+										title={project.root}
+									>
+										{project.root}
+									</div>
+								</div>
+
+								<Button
+									variant="primary"
+									onClick={() => onOpen(project.root)}
+									data-testid="open-recent-project"
+								>
+									open
+								</Button>
+							</div>
+						))}
+					</div>
+				)}
 
 				<div
 					style={{

--- a/source/lib/boot/load-project.ts
+++ b/source/lib/boot/load-project.ts
@@ -1,0 +1,75 @@
+import {getStateBranchRoot} from '../../git/git-storage.js';
+import {execGit} from '../../git/git-utils.js';
+import {ensureStateBranchWorktree} from '../../git/git.js';
+import {recordRecentProject} from '../config/recent-projects.js';
+import {bootStateFromEventLog} from '../event/event-boot.js';
+import {loadMergedEventsWithUnreadable} from '../event/event-load.js';
+import {Result, isFail, succeeded} from '../model/result-types.js';
+import {getProjectFileContents} from '../project-setup/project-setup.js';
+import {patchState} from '../state/state.js';
+import {failAt} from '../utils/logger.utils.js';
+
+/**
+ * Boots the app state from the project at `repoRoot`: ensures its state
+ * worktree, pulls what it can, and materialises the event log. Shared by the
+ * initial TUI boot and by `:open`, which switches into another project.
+ */
+export const loadProject = async (repoRoot: string): Promise<Result<void>> => {
+	const stateBranchRootResult = getStateBranchRoot({repoRoot});
+	if (isFail(stateBranchRootResult)) {
+		return failAt(3, stateBranchRootResult.message);
+	}
+
+	const ensureWorktreeResult = await ensureStateBranchWorktree({
+		repoRoot,
+		stateBranchRoot: stateBranchRootResult.value,
+		stateBranchName: getProjectFileContents().stateBranch,
+	});
+
+	if (isFail(ensureWorktreeResult)) {
+		return failAt(3, ensureWorktreeResult.message);
+	}
+
+	const pullResult = await execGit({
+		cwd: stateBranchRootResult.value,
+		args: ['pull', '--ff-only'],
+	});
+
+	if (isFail(pullResult)) {
+		logger.info(3, pullResult.message);
+	}
+
+	const eventsResult = loadMergedEventsWithUnreadable(
+		stateBranchRootResult.value,
+	);
+	if (isFail(eventsResult)) return failAt(3, eventsResult.message);
+
+	const {events, unreadable} = eventsResult.value;
+
+	const bootStateResult = bootStateFromEventLog(events, unreadable);
+	if (isFail(bootStateResult)) return failAt(4, bootStateResult.message);
+
+	patchState({
+		hasProjectDefinition: true,
+		hasInitializingEvents: Boolean(events.length),
+	});
+
+	// A convenience for the next boot outside a project; not worth failing
+	// this one over.
+	const recordResult = recordRecentProject({root: repoRoot});
+	if (isFail(recordResult)) logger.info(recordResult.message);
+
+	return succeeded('Loaded project', undefined);
+};
+
+export const loadWithoutProject = (): Result<void> => {
+	const bootStateResult = bootStateFromEventLog([]);
+	if (isFail(bootStateResult)) return failAt(4, bootStateResult.message);
+
+	patchState({
+		hasProjectDefinition: false,
+		hasInitializingEvents: false,
+	});
+
+	return succeeded('Booted without a project', undefined);
+};

--- a/source/lib/command-line/cmd-keywords.ts
+++ b/source/lib/command-line/cmd-keywords.ts
@@ -3,6 +3,7 @@ export const CmdKeywords = {
 
 	EXIT: 'exit',
 	INIT: 'init',
+	OPEN: 'open',
 	HELP: 'help',
 	NEW: 'new',
 	TAG: 'tag',

--- a/source/lib/command-line/command-intent.ts
+++ b/source/lib/command-line/command-intent.ts
@@ -20,6 +20,9 @@ export const getCommandIntent = (command: string): CommandIntent => {
 		case CmdKeywords.INIT:
 			return CmdIntent.Init;
 
+		case CmdKeywords.OPEN:
+			return CmdIntent.OpenProject;
+
 		case CmdKeywords.DELETE:
 			return CmdIntent.Delete;
 
@@ -83,6 +86,7 @@ export const CmdIntent = {
 	// Fundamentals (tight coupling to scope)
 	Exit: 'exit',
 	Init: 'init',
+	OpenProject: 'open-project',
 	None: 'none',
 	ViewHelp: 'view-help',
 	Rename: 'rename',

--- a/source/lib/command-line/command-modifiers.ts
+++ b/source/lib/command-line/command-modifiers.ts
@@ -329,7 +329,9 @@ export const getCmdModifiers = (
 		[CmdKeywords.EXPORT]: [],
 		[CmdKeywords.SYNC]: [],
 		[CmdKeywords.INIT]: [],
-		[CmdKeywords.OPEN]: getOpenProjectModifiers(),
+		// Reads the registry, so only when this is the command being completed.
+		[CmdKeywords.OPEN]:
+			keyword === CmdKeywords.OPEN ? getOpenProjectModifiers() : [],
 		[CmdKeywords.HELP]: [],
 
 		[CmdKeywords.PEEK]: [...generatePeekOffsetHints(), 'now', 'prev', 'next'],

--- a/source/lib/command-line/command-modifiers.ts
+++ b/source/lib/command-line/command-modifiers.ts
@@ -1,4 +1,6 @@
 import {MIN_AUTOSYNC_DURATION_MS} from '../../git/auto-sync.js';
+import {listRecentProjects} from '../config/recent-projects.js';
+import {isFail} from '../model/result-types.js';
 import {
 	getUserSetupStatus,
 	isRepositoryInitialized,
@@ -208,6 +210,17 @@ const getYankModifiers = ({
 	];
 };
 
+// Numbers first: they are what the init screen tells the user to type.
+export const getOpenProjectModifiers = (): string[] => {
+	const recentResult = listRecentProjects({exclude: process.cwd()});
+	if (isFail(recentResult)) return [];
+
+	return [
+		...recentResult.value.map((_, index) => String(index + 1)),
+		...recentResult.value.map(entry => entry.root),
+	];
+};
+
 const getAvailableBaseCommands = ({
 	selectedNode,
 	readOnly,
@@ -222,7 +235,7 @@ const getAvailableBaseCommands = ({
 	}
 
 	if (!isRepositoryInitialized()) {
-		return [CmdKeywords.HELP, CmdKeywords.INIT];
+		return [CmdKeywords.HELP, CmdKeywords.INIT, CmdKeywords.OPEN];
 	}
 
 	if (readOnly) {
@@ -316,6 +329,7 @@ export const getCmdModifiers = (
 		[CmdKeywords.EXPORT]: [],
 		[CmdKeywords.SYNC]: [],
 		[CmdKeywords.INIT]: [],
+		[CmdKeywords.OPEN]: getOpenProjectModifiers(),
 		[CmdKeywords.HELP]: [],
 
 		[CmdKeywords.PEEK]: [...generatePeekOffsetHints(), 'now', 'prev', 'next'],

--- a/source/lib/command-line/command-validation.ts
+++ b/source/lib/command-line/command-validation.ts
@@ -208,10 +208,12 @@ const requireModifierOrInputStr =
 			? invalid({message: hint, completionWordList: []})
 			: valid(onOk ?? CONFIRM_MSG);
 
-const validateOpenProjectCommand: Validator = ({modifier}) => {
+// A list number lands in `modifier`; a path (or a number the list does not
+// have) is not a known modifier, so the parser leaves it in `inputString`.
+const validateOpenProjectCommand: Validator = ({modifier, inputString}) => {
 	const choices = getOpenProjectModifiers();
 
-	if (!isBlank(modifier)) return valid(CONFIRM_MSG);
+	if (!isBlank(modifier) || !isBlank(inputString)) return valid(CONFIRM_MSG);
 
 	return invalid({
 		message: choices.length

--- a/source/lib/command-line/command-validation.ts
+++ b/source/lib/command-line/command-validation.ts
@@ -37,6 +37,7 @@ import {
 	ConfigModifiers,
 	EditModifiers,
 	getCmdModifiers,
+	getOpenProjectModifiers,
 	REPLAY_DURATION_HINTS,
 } from './command-modifiers.js';
 import {
@@ -206,6 +207,19 @@ const requireModifierOrInputStr =
 		isBlank(modifier) && isBlank(inputString)
 			? invalid({message: hint, completionWordList: []})
 			: valid(onOk ?? CONFIRM_MSG);
+
+const validateOpenProjectCommand: Validator = ({modifier}) => {
+	const choices = getOpenProjectModifiers();
+
+	if (!isBlank(modifier)) return valid(CONFIRM_MSG);
+
+	return invalid({
+		message: choices.length
+			? hintDefault('number from the list, or a path')
+			: hintDefault('path to an epiq project'),
+		completionWordList: choices,
+	});
+};
 
 const validateConfigCommand: Validator = ({modifier, inputString}) => {
 	const configModifiers = getCmdModifiers(CmdKeywords.CONFIG);
@@ -543,6 +557,7 @@ const validators: Record<CmdKeyword, Validator> = {
 	[CmdKeywords.EXIT]: () =>
 		valid(CONFIRM_MSG + hintDefault(' and exit the application')),
 	[CmdKeywords.INIT]: () => valid(CONFIRM_MSG),
+	[CmdKeywords.OPEN]: validateOpenProjectCommand,
 	[CmdKeywords.PALETTE]: () => valid(CONFIRM_MSG),
 
 	[CmdKeywords.FILTER]: args => {

--- a/source/lib/command-line/commands.ts
+++ b/source/lib/command-line/commands.ts
@@ -37,6 +37,7 @@ import {editCommand} from './commands/edit.cmd.js';
 import {initCommand} from './commands/init.cmd.js';
 import {moveCommand} from './commands/move.cmd.js';
 import {newCommand} from './commands/new.cmd.js';
+import {openProjectCommand} from './commands/open.cmd.js';
 import {peekCommand} from './commands/peek.cmd.js';
 import {replayCommand} from './commands/replay.cmd.js';
 import {setAutoSyncDurationCommand} from './commands/set-auto-sync-duration.cmd.js';
@@ -369,6 +370,13 @@ export const commands: CommandLineActionEntry[] = [
 		description: 'Initialize Epiq in the current git repository',
 		mode: Mode.COMMAND_LINE,
 		action: initCommand,
+	},
+	{
+		intent: CmdIntent.OpenProject,
+		description: 'Open a recently used epiq project, by number or path',
+		mode: Mode.COMMAND_LINE,
+		action: openProjectCommand,
+		onSuccess: () => patchState({mode: Mode.DEFAULT}),
 	},
 	{
 		intent: CmdIntent.NewItem,

--- a/source/lib/command-line/commands/open.cmd.ts
+++ b/source/lib/command-line/commands/open.cmd.ts
@@ -1,0 +1,83 @@
+import os from 'node:os';
+import path from 'node:path';
+import {loadProject} from '../../boot/load-project.js';
+import {
+	listRecentProjects,
+	RecentProject,
+	recentProjectName,
+} from '../../config/recent-projects.js';
+import {failed, isFail, Result, succeeded} from '../../model/result-types.js';
+import {getCmdArg, replaceCmdInput} from '../../state/cmd.state.js';
+import {resolveClosestEpiqProjectRoot} from '../../storage/paths.js';
+
+const expandHome = (input: string): string =>
+	input === '~' || input.startsWith('~/')
+		? path.join(os.homedir(), input.slice(1))
+		: input;
+
+/**
+ * `:open 2` picks from the recent list; anything else is a path, taken from
+ * the shell's point of view (relative to cwd, `~` expanded) and allowed to sit
+ * inside the project rather than at its root.
+ */
+export const resolveOpenTarget = (
+	arg: string,
+	recent: RecentProject[],
+): Result<string> => {
+	const trimmed = arg.trim();
+
+	if (!trimmed) {
+		return failed('Provide a number from the list or a path to a project');
+	}
+
+	if (/^\d+$/.test(trimmed)) {
+		const entry = recent[Number(trimmed) - 1];
+		if (!entry) return failed(`No recent project #${trimmed}`);
+
+		return succeeded('Resolved recent project', entry.root);
+	}
+
+	const rootResult = resolveClosestEpiqProjectRoot(
+		path.resolve(expandHome(trimmed)),
+	);
+	if (isFail(rootResult)) {
+		return failed(`No epiq project at ${trimmed}`);
+	}
+
+	return succeeded('Resolved project path', rootResult.value);
+};
+
+export const openProjectCommand = async (): Promise<Result<null>> => {
+	const arg = getCmdArg();
+	replaceCmdInput('');
+
+	const recentResult = listRecentProjects({exclude: process.cwd()});
+	const recent = isFail(recentResult) ? [] : recentResult.value;
+
+	const targetResult = resolveOpenTarget(arg, recent);
+	if (isFail(targetResult)) return failed(targetResult.message);
+
+	const root = targetResult.value;
+	const previousCwd = process.cwd();
+
+	// Everything downstream resolves the project from cwd, so switching means
+	// moving there. Undone if the project does not load, so a failed open
+	// leaves the screen describing the directory it still stands in.
+	try {
+		process.chdir(root);
+	} catch (error) {
+		return failed(
+			`Unable to enter ${root}: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+	}
+
+	const loadResult = await loadProject(root);
+	if (isFail(loadResult)) {
+		process.chdir(previousCwd);
+		return failed(loadResult.message);
+	}
+
+	return succeeded(`Opened ${recentProjectName(root)}`, null);
+};

--- a/source/lib/command-line/commands/open.cmd.ts
+++ b/source/lib/command-line/commands/open.cmd.ts
@@ -8,6 +8,7 @@ import {
 } from '../../config/recent-projects.js';
 import {failed, isFail, Result, succeeded} from '../../model/result-types.js';
 import {getCmdArg, replaceCmdInput} from '../../state/cmd.state.js';
+import {getState} from '../../state/state.js';
 import {resolveClosestEpiqProjectRoot} from '../../storage/paths.js';
 
 const expandHome = (input: string): string =>
@@ -50,6 +51,12 @@ export const resolveOpenTarget = (
 export const openProjectCommand = async (): Promise<Result<null>> => {
 	const arg = getCmdArg();
 	replaceCmdInput('');
+
+	// Loading materialises onto whatever state is live, and nothing upstream
+	// stops a keyword the init screen did not offer from being typed.
+	if (getState().hasProjectDefinition) {
+		return failed('Already in a project; run epiq from another directory');
+	}
 
 	const recentResult = listRecentProjects({exclude: process.cwd()});
 	const recent = isFail(recentResult) ? [] : recentResult.value;

--- a/source/lib/components/InitProjectUI.tsx
+++ b/source/lib/components/InitProjectUI.tsx
@@ -1,6 +1,12 @@
 import chalk from 'chalk';
 import {Box, Text} from 'ink';
 import React from 'react';
+import {
+	listRecentProjects,
+	RecentProject,
+	recentProjectName,
+} from '../config/recent-projects.js';
+import {isFail} from '../model/result-types.js';
 import {theme} from '../theme/themes.js';
 
 type InitProjectUIProps = {
@@ -8,10 +14,20 @@ type InitProjectUIProps = {
 	height: number;
 };
 
+const MAX_LISTED = 8;
+
+const getRecentProjects = (): RecentProject[] => {
+	const result = listRecentProjects({exclude: process.cwd()});
+
+	return isFail(result) ? [] : result.value.slice(0, MAX_LISTED);
+};
+
 export const InitProjectUI: React.FC<InitProjectUIProps> = ({
 	width,
 	height,
 }) => {
+	const recent = getRecentProjects();
+
 	return (
 		<Box
 			height={height - 4}
@@ -53,6 +69,30 @@ export const InitProjectUI: React.FC<InitProjectUIProps> = ({
 					{' .epiq/project.json '}
 				</Text>
 			</Box>
+
+			{recent.length > 0 && (
+				<Box marginTop={1} flexDirection="column">
+					<Text color={theme.accent} bold>
+						Or open a recent project
+					</Text>
+
+					{recent.map((entry, index) => (
+						<Box key={entry.projectId}>
+							<Text color={theme.accent}>{`   ${index + 1}  `}</Text>
+							<Text color={theme.primary}>{recentProjectName(entry.root)}</Text>
+							<Text color={theme.secondary2}>{`  ${entry.root}`}</Text>
+						</Box>
+					))}
+
+					<Box marginTop={1}>
+						<Text color={theme.accent}>{'   '}</Text>
+						<Text color={theme.primary}>Type </Text>
+						<Text backgroundColor={theme.secondary}>{' :open 1 '}</Text>
+						<Text color={theme.secondary2}> or </Text>
+						<Text backgroundColor={theme.secondary}>{' :open <path> '}</Text>
+					</Box>
+				</Box>
+			)}
 		</Box>
 	);
 };

--- a/source/lib/config/recent-projects.ts
+++ b/source/lib/config/recent-projects.ts
@@ -1,0 +1,164 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import {z} from 'zod';
+import {failed, isFail, Result, succeeded} from '../model/result-types.js';
+import {readProjectId} from '../project-setup/project-setup.js';
+import {getGlobalConfigDir} from '../storage/global-config-dir.js';
+import {hasLocalProjectFile} from '../storage/paths.js';
+
+export const RECENT_PROJECTS_FILE_NAME = 'recent-projects.json';
+export const MAX_RECENT_PROJECTS = 20;
+
+const RecentProjectSchema = z.object({
+	projectId: z.string().min(1),
+	root: z.string().min(1),
+	lastOpenedAt: z.number().finite(),
+});
+
+const RecentProjectsFileSchema = z.object({
+	projects: z.array(RecentProjectSchema),
+});
+
+export type RecentProject = z.infer<typeof RecentProjectSchema>;
+
+export const getRecentProjectsPath = (): string =>
+	path.join(getGlobalConfigDir(), RECENT_PROJECTS_FILE_NAME);
+
+export const recentProjectName = (root: string): string =>
+	path.basename(root) || root;
+
+// `process.cwd()` reports symlinks resolved (macOS's /var → /private/var), so
+// comparing a stored root to it has to see through them too.
+const canonical = (dir: string): string => {
+	const resolved = path.resolve(dir);
+
+	try {
+		return fs.realpathSync(resolved);
+	} catch {
+		return resolved;
+	}
+};
+
+const byMostRecent = (a: RecentProject, b: RecentProject) =>
+	b.lastOpenedAt - a.lastOpenedAt;
+
+// An entry is only worth offering while its directory still hosts the project
+// it was recorded for. A re-initialised directory carries a new id and gets
+// its own entry the next time it boots.
+const isLive = (entry: RecentProject): boolean => {
+	if (!hasLocalProjectFile(entry.root)) return false;
+
+	const idResult = readProjectId(entry.root);
+
+	return !isFail(idResult) && idResult.value === entry.projectId;
+};
+
+export const readRecentProjects = (): Result<RecentProject[]> => {
+	const filePath = getRecentProjectsPath();
+
+	if (!fs.existsSync(filePath)) {
+		return succeeded('No recent projects recorded', []);
+	}
+
+	let parsed: unknown;
+
+	try {
+		parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+	} catch (error) {
+		return failed(
+			`Invalid ${RECENT_PROJECTS_FILE_NAME}: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+	}
+
+	const result = RecentProjectsFileSchema.safeParse(parsed);
+
+	if (!result.success) {
+		return failed(
+			`Invalid ${RECENT_PROJECTS_FILE_NAME} shape: ${result.error.issues
+				.map(issue => issue.path.join('.') || issue.message)
+				.join(', ')}`,
+		);
+	}
+
+	return succeeded('Read recent projects', result.data.projects);
+};
+
+const writeRecentProjects = (
+	projects: RecentProject[],
+): Result<RecentProject[]> => {
+	const filePath = getRecentProjectsPath();
+
+	try {
+		fs.mkdirSync(path.dirname(filePath), {recursive: true});
+		fs.writeFileSync(
+			filePath,
+			JSON.stringify({projects}, null, 2) + '\n',
+			'utf8',
+		);
+	} catch (error) {
+		return failed(
+			`Unable to write ${RECENT_PROJECTS_FILE_NAME}: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+	}
+
+	return succeeded('Recorded recent project', projects);
+};
+
+/**
+ * Lists the projects still worth offering, most recently opened first. `exclude`
+ * drops the project the caller is already in.
+ */
+export const listRecentProjects = ({exclude}: {exclude?: string} = {}): Result<
+	RecentProject[]
+> => {
+	const readResult = readRecentProjects();
+	if (isFail(readResult)) return readResult;
+
+	const excluded = exclude === undefined ? null : canonical(exclude);
+
+	return succeeded(
+		'Listed recent projects',
+		readResult.value
+			.filter(entry => excluded === null || canonical(entry.root) !== excluded)
+			.filter(isLive)
+			.sort(byMostRecent),
+	);
+};
+
+/**
+ * Upserts `root` as the most recently opened project. The registry is a
+ * convenience, so a corrupt file is replaced rather than allowed to block the
+ * boot that is recording into it.
+ */
+export const recordRecentProject = ({
+	root,
+	now = Date.now(),
+}: {
+	root: string;
+	now?: number;
+}): Result<RecentProject[]> => {
+	const resolvedRoot = path.resolve(root);
+
+	const projectIdResult = readProjectId(resolvedRoot);
+	if (isFail(projectIdResult)) return failed(projectIdResult.message);
+
+	const projectId = projectIdResult.value;
+	const readResult = readRecentProjects();
+	const existing = isFail(readResult) ? [] : readResult.value;
+
+	const projects = [
+		{projectId, root: resolvedRoot, lastOpenedAt: now},
+		...existing.filter(
+			entry => entry.projectId !== projectId && entry.root !== resolvedRoot,
+		),
+	]
+		.filter(isLive)
+		.sort(byMostRecent)
+		.slice(0, MAX_RECENT_PROJECTS);
+
+	return writeRecentProjects(projects);
+};

--- a/source/mcp/epiq-api.ts
+++ b/source/mcp/epiq-api.ts
@@ -33,6 +33,7 @@ import {
 } from '../lib/repository/rank.js';
 import {getSafeState} from '../lib/state/state.js';
 import {setSynced, setSyncFailed, setSyncing} from '../lib/state/sync-state.js';
+import {recordRecentProject} from '../lib/config/recent-projects.js';
 import {resolveClosestEpiqProjectRoot} from '../lib/storage/paths.js';
 import {
 	Contributor,
@@ -1238,6 +1239,22 @@ export const deriveGuiState = (): Result<ApiState> => {
 	} satisfies ApiState);
 };
 
+// The GUI asks for state after every mutation; the registry only needs to hear
+// about a project once per session.
+let lastRememberedRoot: string | null = null;
+
+const rememberOpenedProject = (repoRoot: string): void => {
+	if (repoRoot === lastRememberedRoot) return;
+
+	const result = recordRecentProject({root: repoRoot});
+	if (isFail(result)) {
+		logger.info(result.message);
+		return;
+	}
+
+	lastRememberedRoot = repoRoot;
+};
+
 export const getGuiState = async (
 	input: ToolInput = {},
 ): Promise<Result<ApiState>> => {
@@ -1251,6 +1268,8 @@ export const getGuiState = async (
 	// is an explicit periodic sync's job.
 	const bootResult = await boot(input.repoRoot, {pull: false});
 	if (isFail(bootResult)) return bootResult;
+
+	rememberOpenedProject(bootResult.value.repoRoot);
 
 	return deriveGuiState();
 };

--- a/source/test/e2e-gui/init-project.pw.ts
+++ b/source/test/e2e-gui/init-project.pw.ts
@@ -32,3 +32,27 @@ test('leaves the board alone in a repo that does have a project', async ({
 	await expect(page.getByTestId('board-switcher')).toContainText('Default');
 	await expect(page.getByTestId('init-project-screen')).toHaveCount(0);
 });
+
+// The worker's seeded project was booted by the same process that serves the
+// bare directory, so it is the one recent project the bare screen can offer.
+test('offers the recently opened project and boots into it', async ({
+	page,
+	bareAppUrl,
+	repoRoot,
+	pageErrors,
+}) => {
+	await page.goto(bareAppUrl);
+
+	const screen = page.getByTestId('init-project-screen');
+	await expect(screen).toBeVisible();
+
+	const recent = page.getByTestId('recent-project');
+	await expect(recent).toHaveCount(1);
+	await expect(recent).toContainText(repoRoot);
+
+	await page.getByTestId('open-recent-project').click();
+
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+	await expect(page.getByTestId('init-project-screen')).toHaveCount(0);
+	expect(pageErrors).toEqual([]);
+});

--- a/source/test/load-project.test.ts
+++ b/source/test/load-project.test.ts
@@ -1,0 +1,129 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {ensureLocalStateBranch} from '../git/git.js';
+import {execGit} from '../git/git-utils.js';
+import {loadProject, loadWithoutProject} from '../lib/boot/load-project.js';
+import {
+	listRecentProjects,
+	readRecentProjects,
+} from '../lib/config/recent-projects.js';
+import {isFail} from '../lib/model/result-types.js';
+import {DEFAULT_STATE_BRANCH} from '../lib/project-setup/project-setup.js';
+import {getState} from '../lib/state/state.js';
+import {makeTempDir, useTempHome} from './helpers/git-repo.js';
+
+const git = async (cwd: string, args: string[]) => {
+	const result = await execGit({cwd, args});
+	if (isFail(result)) throw new Error(result.message);
+	return result.value;
+};
+
+const makeRepo = async (projectId: string): Promise<string> => {
+	const repoRoot = path.join(makeTempDir(), projectId);
+	fs.mkdirSync(repoRoot, {recursive: true});
+
+	await git(repoRoot, ['init', '-q', '-b', 'main', '.']);
+	await git(repoRoot, ['config', 'user.name', 'Test']);
+	await git(repoRoot, ['config', 'user.email', 't@test']);
+	fs.writeFileSync(path.join(repoRoot, 'README.md'), 'x\n');
+	await git(repoRoot, ['add', '-A']);
+	await git(repoRoot, ['commit', '-qm', 'init', '--no-verify']);
+
+	fs.mkdirSync(path.join(repoRoot, '.epiq'), {recursive: true});
+	fs.writeFileSync(
+		path.join(repoRoot, '.epiq', 'project.json'),
+		JSON.stringify({
+			projectId,
+			stateBranch: DEFAULT_STATE_BRANCH,
+			createdAt: new Date().toISOString(),
+		}),
+	);
+
+	const branch = await ensureLocalStateBranch({
+		repoRoot,
+		stateBranchName: DEFAULT_STATE_BRANCH,
+	});
+	if (isFail(branch)) throw new Error(branch.message);
+
+	return repoRoot;
+};
+
+useTempHome();
+
+let originalGlobalDir: string | undefined;
+
+beforeEach(() => {
+	(globalThis as {logger?: unknown}).logger = {
+		info: vi.fn(),
+		debug: vi.fn(),
+		error: vi.fn(),
+	};
+
+	originalGlobalDir = process.env['EPIQ_GLOBAL_DIR'];
+	process.env['EPIQ_GLOBAL_DIR'] = path.join(makeTempDir(), '.epiq-global');
+});
+
+afterEach(() => {
+	if (originalGlobalDir === undefined) delete process.env['EPIQ_GLOBAL_DIR'];
+	else process.env['EPIQ_GLOBAL_DIR'] = originalGlobalDir;
+});
+
+describe('loadProject', () => {
+	it('records the project it booted as the most recent', async () => {
+		const repoRoot = await makeRepo('01LOADPROJECT0000000000001');
+
+		const result = await loadProject(repoRoot);
+
+		expect(isFail(result)).toBe(false);
+		const recent = listRecentProjects();
+		expect(!isFail(recent) && recent.value.map(entry => entry.root)).toEqual([
+			repoRoot,
+		]);
+		expect(getState().hasProjectDefinition).toBe(true);
+	});
+
+	it('keeps earlier projects behind the one just booted', async () => {
+		const first = await makeRepo('01LOADPROJECT0000000000002');
+		const second = await makeRepo('01LOADPROJECT0000000000003');
+
+		await loadProject(first);
+		await loadProject(second);
+
+		const recent = listRecentProjects();
+		expect(!isFail(recent) && recent.value.map(entry => entry.root)).toEqual([
+			second,
+			first,
+		]);
+	});
+
+	it('does not record a project that failed to load', async () => {
+		const notARepo = path.join(makeTempDir(), 'plain');
+		fs.mkdirSync(path.join(notARepo, '.epiq'), {recursive: true});
+		fs.writeFileSync(
+			path.join(notARepo, '.epiq', 'project.json'),
+			JSON.stringify({
+				projectId: '01LOADPROJECT0000000000004',
+				stateBranch: DEFAULT_STATE_BRANCH,
+				createdAt: new Date().toISOString(),
+			}),
+		);
+
+		const result = await loadProject(notARepo);
+
+		expect(isFail(result)).toBe(true);
+		const recorded = readRecentProjects();
+		expect(!isFail(recorded) && recorded.value).toEqual([]);
+	});
+});
+
+describe('loadWithoutProject', () => {
+	it('boots the placeholder workspace and records nothing', () => {
+		const result = loadWithoutProject();
+
+		expect(isFail(result)).toBe(false);
+		expect(getState().hasProjectDefinition).toBe(false);
+		const recorded = readRecentProjects();
+		expect(!isFail(recorded) && recorded.value).toEqual([]);
+	});
+});

--- a/source/test/open-project-validation.test.ts
+++ b/source/test/open-project-validation.test.ts
@@ -120,6 +120,23 @@ describe(':open completions', () => {
 		expect(getCmdModifiers(CmdKeywords.OPEN)).toEqual(['1', '2', newer, older]);
 	});
 
+	it('is only read when completing the open command itself', () => {
+		const root = makeProject('p');
+		recordRecentProject({root, now: 1});
+		const globalDir = process.env['EPIQ_GLOBAL_DIR']!;
+		fs.chmodSync(globalDir, 0o000);
+
+		try {
+			// Other commands must not stall or fail on an unreadable registry.
+			expect(() => getCmdModifiers(CmdKeywords.HELP)).not.toThrow();
+			expect(getCmdModifiers(CmdKeywords.INIT)).toEqual([]);
+		} finally {
+			fs.chmodSync(globalDir, 0o755);
+		}
+
+		expect(getCmdModifiers(CmdKeywords.OPEN)).toEqual(['1', root]);
+	});
+
 	it('offers nothing from a corrupt registry', () => {
 		const globalDir = process.env['EPIQ_GLOBAL_DIR']!;
 		fs.mkdirSync(globalDir, {recursive: true});

--- a/source/test/open-project-validation.test.ts
+++ b/source/test/open-project-validation.test.ts
@@ -1,0 +1,172 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+vi.mock('../lib/state/state.js', () => ({
+	getState: () => ({
+		contextNode: {id: 'ws', title: 'Workspace', context: 'WORKSPACE'},
+		selectedNode: undefined,
+		contributors: {},
+		tags: {},
+		breadCrumb: [],
+		readOnly: false,
+	}),
+}));
+
+vi.mock('../lib/state/settings.state.js', () => ({
+	getSettingsState: () => ({
+		preferredEditor: 'vim',
+		autoSync: true,
+		userName: 'jola',
+	}),
+}));
+
+let initialized = false;
+
+vi.mock('../lib/config/setup-utils.js', async importOriginal => {
+	const actual = await importOriginal<
+		typeof import('../lib/config/setup-utils.js')
+	>();
+
+	return {
+		...actual,
+		isRepositoryInitialized: () => initialized,
+	};
+});
+
+import {CmdKeywords} from '../lib/command-line/cmd-keywords.js';
+import {cmdValidity} from '../lib/command-line/cmd-validity.js';
+import {
+	getCmdModifiers,
+	getOpenProjectModifiers,
+} from '../lib/command-line/command-modifiers.js';
+import {cmdValidation} from '../lib/command-line/command-validation.js';
+import {getCommandIntent} from '../lib/command-line/command-intent.js';
+import {CmdIntent} from '../lib/command-line/command-intent.js';
+import {recordRecentProject} from '../lib/config/recent-projects.js';
+
+const tempDirs: string[] = [];
+
+const makeTempDir = (): string => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'epiq-open-val-'));
+	tempDirs.push(dir);
+	return dir;
+};
+
+const makeProject = (projectId: string): string => {
+	const root = path.join(makeTempDir(), projectId);
+	fs.mkdirSync(path.join(root, '.epiq'), {recursive: true});
+	fs.writeFileSync(
+		path.join(root, '.epiq', 'project.json'),
+		JSON.stringify({
+			projectId,
+			stateBranch: '__epiq_state__',
+			createdAt: new Date().toISOString(),
+		}),
+	);
+	return root;
+};
+
+let originalGlobalDir: string | undefined;
+
+beforeEach(() => {
+	initialized = false;
+	originalGlobalDir = process.env['EPIQ_GLOBAL_DIR'];
+	process.env['EPIQ_GLOBAL_DIR'] = path.join(makeTempDir(), '.epiq-global');
+});
+
+afterEach(() => {
+	if (originalGlobalDir === undefined) delete process.env['EPIQ_GLOBAL_DIR'];
+	else process.env['EPIQ_GLOBAL_DIR'] = originalGlobalDir;
+
+	for (const dir of tempDirs.splice(0)) {
+		fs.rmSync(dir, {recursive: true, force: true});
+	}
+});
+
+describe(':open availability', () => {
+	it('is offered outside a project, next to init', () => {
+		expect(getCmdModifiers(CmdKeywords.NONE)).toEqual([
+			CmdKeywords.HELP,
+			CmdKeywords.INIT,
+			CmdKeywords.OPEN,
+		]);
+	});
+
+	it('is not offered inside a project', () => {
+		initialized = true;
+
+		expect(getCmdModifiers(CmdKeywords.NONE)).not.toContain(CmdKeywords.OPEN);
+	});
+
+	it('maps the keyword to its intent', () => {
+		expect(getCommandIntent(CmdKeywords.OPEN)).toBe(CmdIntent.OpenProject);
+	});
+});
+
+describe(':open completions', () => {
+	it('offers nothing when no project was recorded', () => {
+		expect(getOpenProjectModifiers()).toEqual([]);
+		expect(getCmdModifiers(CmdKeywords.OPEN)).toEqual([]);
+	});
+
+	it('offers list numbers first, then the roots, most recent first', () => {
+		const older = makeProject('older');
+		const newer = makeProject('newer');
+		recordRecentProject({root: older, now: 1});
+		recordRecentProject({root: newer, now: 2});
+
+		expect(getCmdModifiers(CmdKeywords.OPEN)).toEqual(['1', '2', newer, older]);
+	});
+
+	it('offers nothing from a corrupt registry', () => {
+		const globalDir = process.env['EPIQ_GLOBAL_DIR']!;
+		fs.mkdirSync(globalDir, {recursive: true});
+		fs.writeFileSync(path.join(globalDir, 'recent-projects.json'), 'nope');
+
+		expect(getOpenProjectModifiers()).toEqual([]);
+	});
+});
+
+describe(':open validation', () => {
+	it('asks for a target and completes against the list', () => {
+		const root = makeProject('p');
+		recordRecentProject({root, now: 1});
+
+		const result = cmdValidation[CmdKeywords.OPEN].validate(
+			CmdKeywords.OPEN,
+			'',
+			'',
+		);
+
+		expect(result.validity).toBe(cmdValidity.Invalid);
+		expect(result.message).toContain('number from the list');
+		expect(result.completionWordList).toEqual(['1', root]);
+	});
+
+	it('asks for a path when there is no list', () => {
+		const result = cmdValidation[CmdKeywords.OPEN].validate(
+			CmdKeywords.OPEN,
+			'',
+			'',
+		);
+
+		expect(result.validity).toBe(cmdValidity.Invalid);
+		expect(result.message).toContain('path');
+		expect(result.completionWordList).toEqual([]);
+	});
+
+	it.each(['1', '/some/where', '~/dev/x'])(
+		'is confirmable once %s is typed',
+		modifier => {
+			const result = cmdValidation[CmdKeywords.OPEN].validate(
+				CmdKeywords.OPEN,
+				modifier,
+				'',
+			);
+
+			expect(result.validity).toBe(cmdValidity.Valid);
+		},
+	);
+});

--- a/source/test/open-project-validation.test.ts
+++ b/source/test/open-project-validation.test.ts
@@ -157,13 +157,25 @@ describe(':open validation', () => {
 		expect(result.completionWordList).toEqual([]);
 	});
 
-	it.each(['1', '/some/where', '~/dev/x'])(
-		'is confirmable once %s is typed',
-		modifier => {
+	it('is confirmable once a listed number is typed', () => {
+		const result = cmdValidation[CmdKeywords.OPEN].validate(
+			CmdKeywords.OPEN,
+			'1',
+			'',
+		);
+
+		expect(result.validity).toBe(cmdValidity.Valid);
+	});
+
+	// The parser only promotes a word to `modifier` when it is in the completion
+	// list, so a path or an unlisted number arrives as `inputString`.
+	it.each(['7', '/some/where', '~/dev/x'])(
+		'is confirmable once %s is typed as free input',
+		inputString => {
 			const result = cmdValidation[CmdKeywords.OPEN].validate(
 				CmdKeywords.OPEN,
-				modifier,
 				'',
+				inputString,
 			);
 
 			expect(result.validity).toBe(cmdValidity.Valid);

--- a/source/test/open-project.cmd.test.ts
+++ b/source/test/open-project.cmd.test.ts
@@ -1,0 +1,256 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+vi.mock('../lib/boot/load-project.js', () => ({
+	loadProject: vi.fn(),
+}));
+
+vi.mock('../lib/state/cmd.state.js', () => ({
+	getCmdArg: vi.fn(() => ''),
+	replaceCmdInput: vi.fn(),
+}));
+
+import {loadProject} from '../lib/boot/load-project.js';
+import {
+	openProjectCommand,
+	resolveOpenTarget,
+} from '../lib/command-line/commands/open.cmd.js';
+import {
+	RecentProject,
+	recordRecentProject,
+} from '../lib/config/recent-projects.js';
+import {failed, isFail, succeeded} from '../lib/model/result-types.js';
+import {getCmdArg, replaceCmdInput} from '../lib/state/cmd.state.js';
+
+const tempDirs: string[] = [];
+
+const makeTempDir = (): string => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'epiq-open-'));
+	tempDirs.push(dir);
+	return dir;
+};
+
+const makeProject = (projectId: string): string => {
+	const root = path.join(makeTempDir(), projectId);
+	fs.mkdirSync(path.join(root, '.epiq'), {recursive: true});
+	fs.writeFileSync(
+		path.join(root, '.epiq', 'project.json'),
+		JSON.stringify({
+			projectId,
+			stateBranch: '__epiq_state__',
+			createdAt: new Date().toISOString(),
+		}),
+	);
+	return root;
+};
+
+const entry = (projectId: string, root: string): RecentProject => ({
+	projectId,
+	root,
+	lastOpenedAt: 1,
+});
+
+let originalGlobalDir: string | undefined;
+let originalCwd: string;
+let originalHome: string | undefined;
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	originalCwd = process.cwd();
+	originalHome = process.env['HOME'];
+	originalGlobalDir = process.env['EPIQ_GLOBAL_DIR'];
+	process.env['EPIQ_GLOBAL_DIR'] = path.join(makeTempDir(), '.epiq-global');
+	vi.mocked(loadProject).mockResolvedValue(succeeded('Loaded', undefined));
+});
+
+afterEach(() => {
+	process.chdir(originalCwd);
+
+	if (originalHome === undefined) delete process.env['HOME'];
+	else process.env['HOME'] = originalHome;
+
+	if (originalGlobalDir === undefined) delete process.env['EPIQ_GLOBAL_DIR'];
+	else process.env['EPIQ_GLOBAL_DIR'] = originalGlobalDir;
+
+	for (const dir of tempDirs.splice(0)) {
+		fs.rmSync(dir, {recursive: true, force: true});
+	}
+});
+
+describe('resolveOpenTarget', () => {
+	it('needs an argument', () => {
+		const result = resolveOpenTarget('   ', []);
+
+		expect(isFail(result)).toBe(true);
+		expect(result.message).toContain('Provide');
+	});
+
+	it('picks a recent project by its 1-based number', () => {
+		const first = makeProject('first');
+		const second = makeProject('second');
+
+		const result = resolveOpenTarget('2', [
+			entry('first', first),
+			entry('second', second),
+		]);
+
+		expect(result).toEqual(succeeded('Resolved recent project', second));
+	});
+
+	it.each(['0', '3', '99'])('rejects number %s outside the list', arg => {
+		const result = resolveOpenTarget(arg, [
+			entry('a', makeProject('a')),
+			entry('b', makeProject('b')),
+		]);
+
+		expect(isFail(result)).toBe(true);
+		expect(result.message).toContain(`#${arg}`);
+	});
+
+	it('accepts the root of a project by path', () => {
+		const root = makeProject('p');
+
+		expect(resolveOpenTarget(root, [])).toEqual(
+			succeeded('Resolved project path', root),
+		);
+	});
+
+	it('resolves a path inside a project to its root', () => {
+		const root = makeProject('p');
+		const nested = path.join(root, 'src', 'deep');
+		fs.mkdirSync(nested, {recursive: true});
+
+		const result = resolveOpenTarget(nested, []);
+
+		expect(!isFail(result) && result.value).toBe(root);
+	});
+
+	it('resolves a relative path against cwd', () => {
+		const root = makeProject('p');
+		process.chdir(path.dirname(root));
+
+		const result = resolveOpenTarget('p', []);
+
+		expect(!isFail(result) && fs.realpathSync(result.value)).toBe(
+			fs.realpathSync(root),
+		);
+	});
+
+	it('expands a leading ~', () => {
+		const home = makeTempDir();
+		process.env['HOME'] = home;
+		const root = path.join(home, 'proj');
+		fs.mkdirSync(path.join(root, '.epiq'), {recursive: true});
+		fs.writeFileSync(
+			path.join(root, '.epiq', 'project.json'),
+			JSON.stringify({
+				projectId: 'home-proj',
+				stateBranch: '__epiq_state__',
+				createdAt: new Date().toISOString(),
+			}),
+		);
+
+		const result = resolveOpenTarget('~/proj', []);
+
+		expect(!isFail(result) && result.value).toBe(root);
+	});
+
+	it('rejects a path with no project at or above it', () => {
+		const dir = makeTempDir();
+
+		const result = resolveOpenTarget(dir, []);
+
+		expect(isFail(result)).toBe(true);
+		expect(result.message).toContain('No epiq project');
+	});
+
+	it('does not treat a number-like path as a list index', () => {
+		const root = makeProject('p');
+		const numbered = path.join(root, '1');
+		fs.mkdirSync(numbered);
+
+		const result = resolveOpenTarget(numbered, []);
+
+		expect(!isFail(result) && result.value).toBe(root);
+	});
+});
+
+describe('openProjectCommand', () => {
+	it('moves into the project and loads it', async () => {
+		const root = makeProject('target');
+		vi.mocked(getCmdArg).mockReturnValue(root);
+
+		const result = await openProjectCommand();
+
+		expect(result).toEqual(succeeded('Opened target', null));
+		expect(fs.realpathSync(process.cwd())).toBe(fs.realpathSync(root));
+		expect(loadProject).toHaveBeenCalledWith(root);
+		expect(replaceCmdInput).toHaveBeenCalledWith('');
+	});
+
+	it('numbers the list the way the init screen shows it', async () => {
+		const older = makeProject('older');
+		const newer = makeProject('newer');
+		recordRecentProject({root: older, now: 1});
+		recordRecentProject({root: newer, now: 2});
+		vi.mocked(getCmdArg).mockReturnValue('2');
+
+		const result = await openProjectCommand();
+
+		expect(result.message).toBe('Opened older');
+		expect(loadProject).toHaveBeenCalledWith(older);
+	});
+
+	it('leaves the current project out of the numbering', async () => {
+		const here = makeProject('here');
+		const there = makeProject('there');
+		recordRecentProject({root: here, now: 2});
+		recordRecentProject({root: there, now: 1});
+		process.chdir(here);
+		vi.mocked(getCmdArg).mockReturnValue('1');
+
+		const result = await openProjectCommand();
+
+		expect(result.message).toBe('Opened there');
+		expect(loadProject).toHaveBeenCalledWith(there);
+	});
+
+	it('fails without touching cwd when the target is not a project', async () => {
+		vi.mocked(getCmdArg).mockReturnValue(makeTempDir());
+		const cwdBefore = process.cwd();
+
+		const result = await openProjectCommand();
+
+		expect(isFail(result)).toBe(true);
+		expect(process.cwd()).toBe(cwdBefore);
+		expect(loadProject).not.toHaveBeenCalled();
+	});
+
+	it('returns to the previous directory when the project fails to load', async () => {
+		const root = makeProject('broken');
+		vi.mocked(getCmdArg).mockReturnValue(root);
+		vi.mocked(loadProject).mockResolvedValue(failed('[boot:3] no worktree'));
+		const cwdBefore = process.cwd();
+
+		const result = await openProjectCommand();
+
+		expect(isFail(result)).toBe(true);
+		expect(result.message).toContain('no worktree');
+		expect(process.cwd()).toBe(cwdBefore);
+	});
+
+	it('still opens by path when the registry is corrupt', async () => {
+		const globalDir = process.env['EPIQ_GLOBAL_DIR']!;
+		fs.mkdirSync(globalDir, {recursive: true});
+		fs.writeFileSync(path.join(globalDir, 'recent-projects.json'), '{oops');
+		const root = makeProject('p');
+		vi.mocked(getCmdArg).mockReturnValue(root);
+
+		const result = await openProjectCommand();
+
+		expect(isFail(result)).toBe(false);
+		expect(loadProject).toHaveBeenCalledWith(root);
+	});
+});

--- a/source/test/open-project.cmd.test.ts
+++ b/source/test/open-project.cmd.test.ts
@@ -12,6 +12,12 @@ vi.mock('../lib/state/cmd.state.js', () => ({
 	replaceCmdInput: vi.fn(),
 }));
 
+let hasProjectDefinition = false;
+
+vi.mock('../lib/state/state.js', () => ({
+	getState: () => ({hasProjectDefinition}),
+}));
+
 import {loadProject} from '../lib/boot/load-project.js';
 import {
 	openProjectCommand,
@@ -58,6 +64,7 @@ let originalHome: string | undefined;
 
 beforeEach(() => {
 	vi.clearAllMocks();
+	hasProjectDefinition = false;
 	originalCwd = process.cwd();
 	originalHome = process.env['HOME'];
 	originalGlobalDir = process.env['EPIQ_GLOBAL_DIR'];
@@ -215,6 +222,20 @@ describe('openProjectCommand', () => {
 
 		expect(result.message).toBe('Opened there');
 		expect(loadProject).toHaveBeenCalledWith(there);
+	});
+
+	it('refuses to switch away from a project that is already loaded', async () => {
+		hasProjectDefinition = true;
+		const root = makeProject('elsewhere');
+		vi.mocked(getCmdArg).mockReturnValue(root);
+		const cwdBefore = process.cwd();
+
+		const result = await openProjectCommand();
+
+		expect(isFail(result)).toBe(true);
+		expect(result.message).toContain('Already in a project');
+		expect(process.cwd()).toBe(cwdBefore);
+		expect(loadProject).not.toHaveBeenCalled();
 	});
 
 	it('fails without touching cwd when the target is not a project', async () => {

--- a/source/test/recent-projects.test.ts
+++ b/source/test/recent-projects.test.ts
@@ -1,0 +1,326 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {
+	getRecentProjectsPath,
+	listRecentProjects,
+	MAX_RECENT_PROJECTS,
+	readRecentProjects,
+	RECENT_PROJECTS_FILE_NAME,
+	recentProjectName,
+	recordRecentProject,
+} from '../lib/config/recent-projects.js';
+import {isFail, Result} from '../lib/model/result-types.js';
+
+const tempDirs: string[] = [];
+
+const makeTempDir = (prefix = 'epiq-recent-'): string => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+	tempDirs.push(dir);
+	return dir;
+};
+
+const makeProject = (projectId: string, name = projectId): string => {
+	const root = path.join(makeTempDir(), name);
+	fs.mkdirSync(path.join(root, '.epiq'), {recursive: true});
+	fs.writeFileSync(
+		path.join(root, '.epiq', 'project.json'),
+		JSON.stringify({
+			projectId,
+			stateBranch: '__epiq_state__',
+			createdAt: new Date().toISOString(),
+		}),
+	);
+	return root;
+};
+
+const unwrap = <T>(result: Result<T>): T => {
+	if (isFail(result)) throw new Error(result.message);
+	return result.value;
+};
+
+let originalGlobalDir: string | undefined;
+
+beforeEach(() => {
+	originalGlobalDir = process.env['EPIQ_GLOBAL_DIR'];
+	process.env['EPIQ_GLOBAL_DIR'] = path.join(makeTempDir(), '.epiq-global');
+});
+
+afterEach(() => {
+	if (originalGlobalDir === undefined) {
+		delete process.env['EPIQ_GLOBAL_DIR'];
+	} else {
+		process.env['EPIQ_GLOBAL_DIR'] = originalGlobalDir;
+	}
+
+	for (const dir of tempDirs.splice(0)) {
+		fs.rmSync(dir, {recursive: true, force: true});
+	}
+});
+
+describe('getRecentProjectsPath', () => {
+	it('lives next to config.json in the global dir', () => {
+		expect(getRecentProjectsPath()).toBe(
+			path.join(process.env['EPIQ_GLOBAL_DIR']!, RECENT_PROJECTS_FILE_NAME),
+		);
+	});
+});
+
+describe('recentProjectName', () => {
+	it('is the directory name', () => {
+		expect(recentProjectName('/home/me/dev/epiq')).toBe('epiq');
+	});
+
+	it('falls back to the root itself when there is no basename', () => {
+		expect(recentProjectName('/')).toBe('/');
+	});
+});
+
+describe('readRecentProjects', () => {
+	it('is empty before anything was recorded, without creating the file', () => {
+		expect(unwrap(readRecentProjects())).toEqual([]);
+		expect(fs.existsSync(getRecentProjectsPath())).toBe(false);
+	});
+
+	it('fails on malformed JSON', () => {
+		fs.mkdirSync(path.dirname(getRecentProjectsPath()), {recursive: true});
+		fs.writeFileSync(getRecentProjectsPath(), '{not json');
+
+		const result = readRecentProjects();
+
+		expect(isFail(result)).toBe(true);
+		expect(result.message).toContain(RECENT_PROJECTS_FILE_NAME);
+	});
+
+	it('fails on a well-formed file of the wrong shape', () => {
+		fs.mkdirSync(path.dirname(getRecentProjectsPath()), {recursive: true});
+		fs.writeFileSync(
+			getRecentProjectsPath(),
+			JSON.stringify({projects: [{root: '/x'}]}),
+		);
+
+		const result = readRecentProjects();
+
+		expect(isFail(result)).toBe(true);
+		expect(result.message).toContain('shape');
+	});
+});
+
+describe('recordRecentProject', () => {
+	it('creates the global dir and file on first record', () => {
+		const root = makeProject('p1');
+
+		const recorded = unwrap(recordRecentProject({root, now: 100}));
+
+		expect(recorded).toEqual([{projectId: 'p1', root, lastOpenedAt: 100}]);
+		expect(
+			JSON.parse(fs.readFileSync(getRecentProjectsPath(), 'utf8')),
+		).toEqual({projects: recorded});
+	});
+
+	it('refuses a directory that is not a project', () => {
+		const result = recordRecentProject({root: makeTempDir()});
+
+		expect(isFail(result)).toBe(true);
+		expect(fs.existsSync(getRecentProjectsPath())).toBe(false);
+	});
+
+	it('stores the resolved absolute root', () => {
+		const root = makeProject('p1');
+		const relative = path.relative(process.cwd(), root);
+
+		const recorded = unwrap(recordRecentProject({root: relative, now: 1}));
+
+		expect(recorded[0]?.root).toBe(root);
+	});
+
+	it('moves a re-opened project to the top instead of duplicating it', () => {
+		const first = makeProject('p1');
+		const second = makeProject('p2');
+
+		recordRecentProject({root: first, now: 1});
+		recordRecentProject({root: second, now: 2});
+		const recorded = unwrap(recordRecentProject({root: first, now: 3}));
+
+		expect(recorded.map(entry => entry.root)).toEqual([first, second]);
+		expect(recorded[0]?.lastOpenedAt).toBe(3);
+	});
+
+	it('keys on the project id, so a moved checkout updates its entry', () => {
+		const before = makeProject('p1', 'before');
+		recordRecentProject({root: before, now: 1});
+
+		const after = path.join(path.dirname(before), 'after');
+		fs.renameSync(before, after);
+
+		const recorded = unwrap(recordRecentProject({root: after, now: 2}));
+
+		expect(recorded).toEqual([{projectId: 'p1', root: after, lastOpenedAt: 2}]);
+	});
+
+	it('replaces the entry of a directory re-initialised as another project', () => {
+		const root = makeProject('p1');
+		recordRecentProject({root, now: 1});
+
+		fs.writeFileSync(
+			path.join(root, '.epiq', 'project.json'),
+			JSON.stringify({
+				projectId: 'p2',
+				stateBranch: '__epiq_state__',
+				createdAt: new Date().toISOString(),
+			}),
+		);
+
+		const recorded = unwrap(recordRecentProject({root, now: 2}));
+
+		expect(recorded).toEqual([{projectId: 'p2', root, lastOpenedAt: 2}]);
+	});
+
+	it('drops entries whose project has since disappeared', () => {
+		const gone = makeProject('gone');
+		const kept = makeProject('kept');
+		recordRecentProject({root: gone, now: 1});
+		fs.rmSync(gone, {recursive: true, force: true});
+
+		const recorded = unwrap(recordRecentProject({root: kept, now: 2}));
+
+		expect(recorded.map(entry => entry.projectId)).toEqual(['kept']);
+	});
+
+	it('keeps the newest entries when the registry is full', () => {
+		for (let index = 0; index < MAX_RECENT_PROJECTS; index += 1) {
+			recordRecentProject({root: makeProject(`p${index}`), now: index});
+		}
+
+		const recorded = unwrap(
+			recordRecentProject({root: makeProject('newest'), now: 1000}),
+		);
+
+		expect(recorded).toHaveLength(MAX_RECENT_PROJECTS);
+		expect(recorded[0]?.projectId).toBe('newest');
+		expect(recorded.some(entry => entry.projectId === 'p0')).toBe(false);
+	});
+
+	it('starts over from a corrupt registry rather than failing the boot', () => {
+		fs.mkdirSync(path.dirname(getRecentProjectsPath()), {recursive: true});
+		fs.writeFileSync(getRecentProjectsPath(), '{not json');
+		const root = makeProject('p1');
+
+		const recorded = unwrap(recordRecentProject({root, now: 1}));
+
+		expect(recorded).toEqual([{projectId: 'p1', root, lastOpenedAt: 1}]);
+		expect(unwrap(readRecentProjects())).toEqual(recorded);
+	});
+
+	it('fails when the registry cannot be written', () => {
+		const blocker = path.join(makeTempDir(), 'file');
+		fs.writeFileSync(blocker, '');
+		process.env['EPIQ_GLOBAL_DIR'] = path.join(blocker, 'nested');
+
+		const result = recordRecentProject({root: makeProject('p1')});
+
+		expect(isFail(result)).toBe(true);
+		expect(result.message).toContain('Unable to write');
+	});
+});
+
+describe('listRecentProjects', () => {
+	it('is empty before anything was recorded', () => {
+		expect(unwrap(listRecentProjects())).toEqual([]);
+	});
+
+	it('orders by most recently opened, whatever order the file holds', () => {
+		const older = makeProject('older');
+		const newer = makeProject('newer');
+		fs.mkdirSync(path.dirname(getRecentProjectsPath()), {recursive: true});
+		fs.writeFileSync(
+			getRecentProjectsPath(),
+			JSON.stringify({
+				projects: [
+					{projectId: 'older', root: older, lastOpenedAt: 1},
+					{projectId: 'newer', root: newer, lastOpenedAt: 2},
+				],
+			}),
+		);
+
+		expect(unwrap(listRecentProjects()).map(entry => entry.root)).toEqual([
+			newer,
+			older,
+		]);
+	});
+
+	it('hides a project whose directory no longer exists', () => {
+		const gone = makeProject('gone');
+		const kept = makeProject('kept');
+		recordRecentProject({root: gone, now: 2});
+		recordRecentProject({root: kept, now: 1});
+		fs.rmSync(gone, {recursive: true, force: true});
+
+		expect(unwrap(listRecentProjects()).map(entry => entry.projectId)).toEqual([
+			'kept',
+		]);
+	});
+
+	it('hides a project whose directory lost its project file', () => {
+		const root = makeProject('p1');
+		recordRecentProject({root, now: 1});
+		fs.rmSync(path.join(root, '.epiq'), {recursive: true, force: true});
+
+		expect(unwrap(listRecentProjects())).toEqual([]);
+	});
+
+	it('hides an entry whose directory now hosts a different project', () => {
+		const root = makeProject('p1');
+		recordRecentProject({root, now: 1});
+		fs.writeFileSync(
+			path.join(root, '.epiq', 'project.json'),
+			JSON.stringify({
+				projectId: 'p2',
+				stateBranch: '__epiq_state__',
+				createdAt: new Date().toISOString(),
+			}),
+		);
+
+		expect(unwrap(listRecentProjects())).toEqual([]);
+	});
+
+	it('leaves the file alone when hiding stale entries', () => {
+		const gone = makeProject('gone');
+		recordRecentProject({root: gone, now: 1});
+		fs.rmSync(gone, {recursive: true, force: true});
+
+		listRecentProjects();
+
+		expect(unwrap(readRecentProjects())).toHaveLength(1);
+	});
+
+	it('excludes the project the caller is already in', () => {
+		const here = makeProject('here');
+		const there = makeProject('there');
+		recordRecentProject({root: here, now: 2});
+		recordRecentProject({root: there, now: 1});
+
+		const listed = unwrap(listRecentProjects({exclude: here}));
+
+		expect(listed.map(entry => entry.projectId)).toEqual(['there']);
+	});
+
+	it('excludes by resolved path, so a relative cwd still matches', () => {
+		const here = makeProject('here');
+		recordRecentProject({root: here, now: 1});
+
+		const listed = unwrap(
+			listRecentProjects({exclude: path.relative(process.cwd(), here)}),
+		);
+
+		expect(listed).toEqual([]);
+	});
+
+	it('propagates a corrupt registry as a failure', () => {
+		fs.mkdirSync(path.dirname(getRecentProjectsPath()), {recursive: true});
+		fs.writeFileSync(getRecentProjectsPath(), '[]');
+
+		expect(isFail(listRecentProjects())).toBe(true);
+	});
+});

--- a/source/test/websocket-mutation-broadcast.test.ts
+++ b/source/test/websocket-mutation-broadcast.test.ts
@@ -97,10 +97,14 @@ describe('websocket post-mutation state refresh', () => {
 		server = http.createServer();
 
 		let boundPort = 0;
-		setupWebsocket(server, '/repo', {
-			onStateChanged: vi.fn(),
-			getPort: () => boundPort,
-		});
+		setupWebsocket(
+			server,
+			{repoRoot: '/repo'},
+			{
+				onStateChanged: vi.fn(),
+				getPort: () => boundPort,
+			},
+		);
 
 		await new Promise<void>(resolve => server.listen(0, resolve));
 

--- a/source/test/websocket-open-project.test.ts
+++ b/source/test/websocket-open-project.test.ts
@@ -1,0 +1,245 @@
+import fs from 'node:fs';
+import http from 'node:http';
+import {AddressInfo} from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {WebSocket} from 'ws';
+
+// Every imported entry point must exist on the mock or the import fails.
+vi.mock('../mcp/epiq-api.js', () => ({
+	addIssueAssignee: vi.fn(),
+	getBoardContributors: vi.fn(),
+	tombstoneContributor: vi.fn(),
+	addIssueComment: vi.fn(),
+	addIssueTag: vi.fn(),
+	closeIssue: vi.fn(),
+	createIssue: vi.fn(),
+	createSwimlane: vi.fn(),
+	deleteSwimlane: vi.fn(),
+	deleteIssueComment: vi.fn(),
+	deriveGuiState: vi.fn(),
+	editIssueDescription: vi.fn(),
+	editSwimlaneTitle: vi.fn(),
+	editIssueTitle: vi.fn(),
+	getGuiState: vi.fn(),
+	getIssueHistory: vi.fn(),
+	listIssues: vi.fn(),
+	moveIssue: vi.fn(),
+	moveSwimlane: vi.fn(),
+	removeIssueAssignee: vi.fn(),
+	removeIssueTag: vi.fn(),
+	reopenIssue: vi.fn(),
+	sync: vi.fn(),
+}));
+
+vi.mock('../mcp/epiq-time-travel.js', () => ({
+	checkoutStateAt: vi.fn(),
+	getCommitDiff: vi.fn(),
+	getCommitsForRef: vi.fn(),
+	getCommitTimeline: vi.fn(),
+	getEventTimeline: vi.fn(),
+	getTimeTravelStatus: vi.fn(() => ({mode: 'live', asOfTime: null})),
+	openCommitDiffInEditor: vi.fn(),
+	returnToLive: vi.fn(),
+	runExclusive: vi.fn(),
+}));
+
+import {getGuiState} from '../mcp/epiq-api.js';
+import {recordRecentProject} from '../lib/config/recent-projects.js';
+import {failed, succeeded} from '../lib/model/result-types.js';
+import {NO_PROJECT_MESSAGE} from '../lib/storage/paths.js';
+import {setupWebsocket} from '../gui/api/lib/websocket.js';
+
+type Received = {
+	type: string;
+	payload?: {
+		status?: string;
+		message?: string;
+		repoRoot?: string;
+		recentProjects?: Array<{name: string; root: string}>;
+		value?: unknown;
+	};
+};
+
+const tempDirs: string[] = [];
+
+const makeTempDir = (): string => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'epiq-ws-open-'));
+	tempDirs.push(dir);
+	return dir;
+};
+
+const makeProject = (projectId: string): string => {
+	const root = path.join(makeTempDir(), projectId);
+	fs.mkdirSync(path.join(root, '.epiq'), {recursive: true});
+	fs.writeFileSync(
+		path.join(root, '.epiq', 'project.json'),
+		JSON.stringify({
+			projectId,
+			stateBranch: '__epiq_state__',
+			createdAt: new Date().toISOString(),
+		}),
+	);
+	return root;
+};
+
+describe('websocket project:open', () => {
+	let server: http.Server;
+	let client: WebSocket;
+	let received: Received[] = [];
+	let bareRoot: string;
+	let projectRoot: string;
+	let originalGlobalDir: string | undefined;
+	const onStateChanged = vi.fn();
+
+	const waitFor = async (predicate: () => boolean, label: string) => {
+		const deadline = Date.now() + 2000;
+
+		while (!predicate()) {
+			if (Date.now() > deadline) throw new Error(`timed out waiting: ${label}`);
+			await new Promise(resolve => setTimeout(resolve, 5));
+		}
+	};
+
+	const send = (message: unknown) => client.send(JSON.stringify(message));
+	const ofType = (type: string) => received.filter(m => m.type === type);
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		received = [];
+
+		(globalThis as {logger?: unknown}).logger = {
+			info: vi.fn(),
+			debug: vi.fn(),
+			error: vi.fn(),
+		};
+
+		originalGlobalDir = process.env['EPIQ_GLOBAL_DIR'];
+		process.env['EPIQ_GLOBAL_DIR'] = path.join(makeTempDir(), '.epiq-global');
+
+		bareRoot = makeTempDir();
+		projectRoot = makeProject('01WSOPEN000000000000000001');
+		recordRecentProject({root: projectRoot, now: 1});
+
+		// A project answers with state; anywhere else is the init screen.
+		vi.mocked(getGuiState).mockImplementation(async ({repoRoot} = {}) =>
+			repoRoot === projectRoot
+				? succeeded('state', {marker: repoRoot} as never)
+				: failed(NO_PROJECT_MESSAGE),
+		);
+
+		server = http.createServer();
+
+		let boundPort = 0;
+		setupWebsocket(
+			server,
+			{repoRoot: bareRoot},
+			{onStateChanged, getPort: () => boundPort},
+		);
+
+		await new Promise<void>(resolve => server.listen(0, resolve));
+
+		const {port} = server.address() as AddressInfo;
+		boundPort = port;
+		client = new WebSocket(`ws://127.0.0.1:${port}/ws`);
+		client.on('message', raw => {
+			received.push(JSON.parse(raw.toString()) as Received);
+		});
+
+		await new Promise(resolve => client.once('open', resolve));
+	});
+
+	afterEach(async () => {
+		client.close();
+		await new Promise<void>(resolve => server.close(() => resolve()));
+
+		if (originalGlobalDir === undefined) delete process.env['EPIQ_GLOBAL_DIR'];
+		else process.env['EPIQ_GLOBAL_DIR'] = originalGlobalDir;
+
+		for (const dir of tempDirs.splice(0)) {
+			fs.rmSync(dir, {recursive: true, force: true});
+		}
+	});
+
+	it('lists recent projects alongside the init screen', async () => {
+		send({type: 'state:get'});
+
+		await waitFor(
+			() => ofType('state:unavailable').length === 1,
+			'the init screen',
+		);
+
+		const [unavailable] = ofType('state:unavailable');
+		expect(unavailable?.payload?.repoRoot).toBe(bareRoot);
+		expect(unavailable?.payload?.recentProjects).toEqual([
+			expect.objectContaining({
+				name: '01WSOPEN000000000000000001',
+				root: projectRoot,
+			}),
+		]);
+	});
+
+	it('switches the server to a listed project and answers with its state', async () => {
+		send({type: 'project:open', payload: {root: projectRoot}});
+
+		await waitFor(() => ofType('state').length === 1, 'the project state');
+
+		expect(ofType('project:open:result')[0]?.payload?.status).toBe('success');
+		expect(ofType('state')[0]?.payload?.value).toEqual(
+			expect.objectContaining({marker: projectRoot}),
+		);
+
+		// Every later request goes to the opened project, not the bare root.
+		send({type: 'state:get'});
+		await waitFor(() => ofType('state').length === 2, 'a second state');
+		expect(ofType('state')[1]?.payload?.value).toEqual(
+			expect.objectContaining({marker: projectRoot}),
+		);
+		expect(ofType('state:unavailable')).toHaveLength(0);
+	});
+
+	it('refuses a root the registry does not list, and stays put', async () => {
+		const elsewhere = makeProject('01WSOPEN000000000000000002');
+
+		send({type: 'project:open', payload: {root: elsewhere}});
+
+		await waitFor(
+			() => ofType('project:open:result').length === 1,
+			'the refusal',
+		);
+
+		const [result] = ofType('project:open:result');
+		expect(result?.payload?.status).not.toBe('success');
+		expect(result?.payload?.message).toContain('Not a recent project');
+
+		send({type: 'state:get'});
+		await waitFor(() => ofType('state:unavailable').length === 1, 'init');
+		expect(ofType('state:unavailable')[0]?.payload?.repoRoot).toBe(bareRoot);
+		expect(getGuiState).not.toHaveBeenCalledWith({repoRoot: elsewhere});
+	});
+
+	it('refuses a listed project whose directory has since gone', async () => {
+		fs.rmSync(projectRoot, {recursive: true, force: true});
+
+		send({type: 'project:open', payload: {root: projectRoot}});
+
+		await waitFor(
+			() => ofType('project:open:result').length === 1,
+			'the refusal',
+		);
+
+		expect(ofType('project:open:result')[0]?.payload?.status).not.toBe(
+			'success',
+		);
+		expect(ofType('state')).toHaveLength(0);
+	});
+
+	it('does not treat opening as a mutation worth syncing', async () => {
+		send({type: 'project:open', payload: {root: projectRoot}});
+
+		await waitFor(() => ofType('state').length === 1, 'the project state');
+
+		expect(onStateChanged).not.toHaveBeenCalled();
+	});
+});

--- a/source/test/websocket-origin.test.ts
+++ b/source/test/websocket-origin.test.ts
@@ -11,10 +11,14 @@ beforeEach(async () => {
 	server = http.createServer();
 
 	let boundPort = 0;
-	setupWebsocket(server, '/repo', {
-		onStateChanged: vi.fn(),
-		getPort: () => boundPort,
-	});
+	setupWebsocket(
+		server,
+		{repoRoot: '/repo'},
+		{
+			onStateChanged: vi.fn(),
+			getPort: () => boundPort,
+		},
+	);
 
 	await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
 	port = (server.address() as AddressInfo).port;

--- a/source/test/websocket-schema.test.ts
+++ b/source/test/websocket-schema.test.ts
@@ -13,6 +13,18 @@ describe('parseGuiMessage', () => {
 		});
 	});
 
+	it('accepts an open request naming a root', () => {
+		const parsed = parseGuiMessage({
+			type: 'project:open',
+			payload: {root: '/home/me/dev/epiq'},
+		});
+
+		expect(parsed).toEqual({
+			ok: true,
+			message: {type: 'project:open', payload: {root: '/home/me/dev/epiq'}},
+		});
+	});
+
 	it('accepts a message whose payload is optional', () => {
 		expect(parseGuiMessage({type: 'state:get'}).ok).toBe(true);
 		expect(parseGuiMessage({type: 'timeline:get'}).ok).toBe(true);
@@ -78,6 +90,8 @@ describe('parseGuiMessage', () => {
 			{type: 'issue:edit:title', payload: {issueId, title: 42}},
 		],
 		['an empty id', {type: 'issue:close', payload: {issueId: ''}}],
+		['an empty root', {type: 'project:open', payload: {root: ''}}],
+		['an open with no root', {type: 'project:open', payload: {}}],
 		[
 			'a non-finite time',
 			{type: 'time-travel:scrub', payload: {targetTime: Infinity}},


### PR DESCRIPTION
Ticket M7SERD9.

Running `epiq` / `epiq gui` outside a project showed the init screen with no way to reach a project elsewhere.

- `~/.epiq-global/recent-projects.json`: registry keyed by projectId → {root, lastOpenedAt}, written on every successful TUI/GUI boot of a project (`loadProject`, `getGuiState`). Stale entries — directory gone, project file gone, or re-initialised as another project — are hidden on read and dropped on write. Capped at 20.
- TUI: init screen lists recent projects; `:open <n|path>` chdirs into the target and reboots the state from it, restoring cwd if the load fails. `~` and paths inside a project are accepted.
- GUI: `state:unavailable` carries the recent list; the init screen shows them with an open button; `project:open` switches the server's root (only to a root the registry lists) and answers with that project's state. Autosync follows the switch.
- The TUI boot's project-loading half moved out of `boot-tui.tsx` into `lib/boot/load-project.ts` so `:open` can reuse it without pulling in the CLI entry point.

Tests: registry (25), `:open` resolution/command (17), command availability/completion/validation (10), loader against a real repo (4), websocket schema (+3) and `project:open` handling (5), GUI e2e opening the seeded project from the bare screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nf2Lo2aeq4UVyQBVZGjHK7