### PR TITLE
N7A4XSG comment editing, working delete, refused-frame toasts, accordion hover

### DIFF
--- a/source/gui/api/lib/websocket.model.ts
+++ b/source/gui/api/lib/websocket.model.ts
@@ -59,6 +59,10 @@ export type GuiMessage =
 			payload: {issueId: string; commentId: string};
 	  }
 	| {
+			type: 'issue:comment:edit';
+			payload: {issueId: string; commentId: string; body: string};
+	  }
+	| {
 			// The description and comment bodies the board's state leaves out.
 			type: 'issue:get';
 			payload: {issueId: string};

--- a/source/gui/api/lib/websocket.schema.ts
+++ b/source/gui/api/lib/websocket.schema.ts
@@ -86,6 +86,10 @@ export const GuiMessageSchema = z.discriminatedUnion('type', [
 	message('issue:reopen', z.object({issueId: id})),
 	message('issue:comment:add', z.object({issueId: id, body: z.string()})),
 	message('issue:comment:delete', z.object({issueId: id, commentId: id})),
+	message(
+		'issue:comment:edit',
+		z.object({issueId: id, commentId: id, body: z.string()}),
+	),
 	message('issue:get', z.object({issueId: id})),
 	z.object({
 		type: z.literal('timeline:get'),

--- a/source/gui/api/lib/websocket.ts
+++ b/source/gui/api/lib/websocket.ts
@@ -12,6 +12,7 @@ import {
 	createSwimlane,
 	deleteSwimlane,
 	deleteIssueComment,
+	editIssueComment,
 	deriveGuiState,
 	editIssueDescription,
 	editSwimlaneTitle,
@@ -286,6 +287,21 @@ export const setupWebsocket = (
 						repoRoot,
 						onStateChanged,
 						'issue:comment:add:result',
+						result,
+					);
+				}
+
+				if (type === 'issue:comment:edit') {
+					const result = await editIssueComment({
+						repoRoot,
+						...message.payload,
+					});
+
+					return sendMutationResult(
+						socket,
+						repoRoot,
+						onStateChanged,
+						'issue:comment:edit:result',
 						result,
 					);
 				}

--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -559,6 +559,17 @@ export const App = () => {
 				requestState();
 			}
 
+			// A frame the server could not parse is refused the same way, and
+			// was otherwise invisible — the optimistic change just quietly held.
+			if (message.type === 'error') {
+				setActionError(
+					typeof message.message === 'string'
+						? message.message
+						: 'The board could not read that change',
+				);
+				requestState();
+			}
+
 			if (message.type === 'timeline') {
 				const nextTimeline = getResultValue<GuiEventTimeline>(message.payload);
 				if (nextTimeline) {
@@ -1042,12 +1053,14 @@ export const App = () => {
 
 			const requestId = historyBuffer.open();
 			// The board scopes the timeline but not the commit log, which is
-			// repository-wide. Omitting boardId is how the API says "every board".
+			// repository-wide. Omitting boardId is how the API says "every board"
+			// — which is also the right ask before any board is known, and the
+			// only one the schema accepts (null is refused).
 			sendSocketJson(socketRef.current, {
 				type: 'timeline:get',
 				payload: {
 					...window,
-					boardId: allBoards ? undefined : selectedBoardId,
+					boardId: allBoards ? undefined : selectedBoardId ?? undefined,
 					requestId,
 				},
 			});
@@ -1409,24 +1422,39 @@ export const App = () => {
 		}
 	};
 
-	const deleteIssueComment = (_issueId: string, commentId: string) => {
-		setState(prev => {
-			if (!prev) return prev;
+	// The panel renders issueDetail's comments, not the board state's, so an
+	// optimistic change has to land there to be seen before the server's reply.
+	const updateDetailComments = (
+		issueId: string,
+		update: (comments: GuiComment[]) => GuiComment[],
+	) => {
+		setIssueDetail(prev =>
+			prev && prev.issueId === issueId
+				? {...prev, comments: update(prev.comments)}
+				: prev,
+		);
+	};
 
-			return {
-				...prev,
-				commentsByIssueId: Object.fromEntries(
-					Object.entries(prev.commentsByIssueId).map(
-						([nextIssueId, comments]) => [
-							nextIssueId,
-							comments.filter(comment => comment.id !== commentId),
-						],
-					),
-				),
-			};
-		});
+	const deleteIssueComment = (issueId: string, commentId: string) => {
+		updateDetailComments(issueId, comments =>
+			comments.filter(comment => comment.id !== commentId),
+		);
 
-		send('issue:comment:delete', {commentId});
+		send('issue:comment:delete', {issueId, commentId});
+	};
+
+	const editIssueComment = (
+		issueId: string,
+		commentId: string,
+		body: string,
+	) => {
+		updateDetailComments(issueId, comments =>
+			comments.map(comment =>
+				comment.id === commentId ? {...comment, body} : comment,
+			),
+		);
+
+		send('issue:comment:edit', {issueId, commentId, body});
 	};
 
 	// Ahead of the board: without a project there are no boards, no history and
@@ -1763,6 +1791,7 @@ export const App = () => {
 								onRemoveAssignee={removeIssueAssignee}
 								onAddComment={addIssueComment}
 								onDeleteComment={deleteIssueComment}
+								onEditComment={editIssueComment}
 								onFileTicket={fileTicketFromSelection}
 								onOpenDiffLocation={openDiffLocation}
 								diffFocus={diffFocus}

--- a/source/gui/client/components/IssueComments.tsx
+++ b/source/gui/client/components/IssueComments.tsx
@@ -13,6 +13,7 @@ import {
 	formatSelectionLabel,
 	parseDiffCommentMeta,
 	stripDiffCommentMarker,
+	withDiffCommentNote,
 } from './IssueCommits';
 import {MarkdownContent} from './MarkdownContent';
 import {MAX_COMMENT_LENGTH} from '../../../lib/utils/text.limits.js';
@@ -79,6 +80,7 @@ type Props = {
 	whoAmI: GuiUser;
 	onAddComment?: (issueId: string, body: string) => void;
 	onDeleteComment?: (issueId: string, commentId: string) => void;
+	onEditComment?: (issueId: string, commentId: string, body: string) => void;
 	onOpenDiffLocation?: (location: DiffLocation) => void;
 };
 
@@ -89,9 +91,30 @@ export const IssueComments = ({
 	comments = [],
 	onAddComment,
 	onDeleteComment,
+	onEditComment,
 	onOpenDiffLocation,
 }: Props) => {
 	const [body, setBody] = useState('');
+	// The comment being rewritten, if any. A diff-linked comment only exposes
+	// its note here; the marker and quoted snippet ride along untouched.
+	const [editing, setEditing] = useState<{id: string; text: string} | null>(
+		null,
+	);
+
+	const startEditing = (comment: GuiComment) => {
+		const meta = parseDiffCommentMeta(comment.body);
+		setEditing({id: comment.id, text: meta ? meta.note : comment.body});
+	};
+
+	const saveEdit = (comment: GuiComment) => {
+		if (!editing || !onEditComment) return;
+
+		const next =
+			withDiffCommentNote(comment.body, editing.text) ?? editing.text.trim();
+		if (next && next !== comment.body) onEditComment(issueId, comment.id, next);
+
+		setEditing(null);
+	};
 
 	// Trimmed, because that is what the server stores and measures.
 	const length = body.trim().length;
@@ -168,9 +191,22 @@ export const IssueComments = ({
 
 								{!readonly &&
 									comment.author.id === whoAmI.id &&
+									onEditComment &&
+									editing?.id !== comment.id && (
+										<Button
+											variant="ghost"
+											title="Edit comment"
+											onClick={() => startEditing(comment)}
+										>
+											edit
+										</Button>
+									)}
+								{!readonly &&
+									comment.author.id === whoAmI.id &&
 									onDeleteComment && (
 										<Button
 											variant="ghost"
+											title="Delete comment"
 											onClick={event => {
 												event.preventDefault();
 												event.stopPropagation();
@@ -182,10 +218,45 @@ export const IssueComments = ({
 									)}
 							</div>
 
-							<CommentBody
-								body={comment.body}
-								onOpenDiffLocation={onOpenDiffLocation}
-							/>
+							{editing?.id === comment.id ? (
+								<>
+									<Textarea
+										autoFocus
+										maxLength={Number.MAX_SAFE_INTEGER}
+										value={editing.text}
+										placeholder="write a comment"
+										onChange={event =>
+											setEditing({id: comment.id, text: event.target.value})
+										}
+										onKeyDown={event => {
+											if (event.key === 'Escape') setEditing(null);
+											if (
+												(event.metaKey || event.ctrlKey) &&
+												event.key === 'Enter'
+											) {
+												saveEdit(comment);
+											}
+										}}
+										style={{
+											minHeight: 45,
+											font: 'inherit',
+											fontFamily: CONTENT_FONT,
+											fontSize: TEXT.prose,
+										}}
+									/>
+									<ActionRow>
+										<Button variant="ghost" onClick={() => setEditing(null)}>
+											cancel
+										</Button>
+										<Button onClick={() => saveEdit(comment)}>save</Button>
+									</ActionRow>
+								</>
+							) : (
+								<CommentBody
+									body={comment.body}
+									onOpenDiffLocation={onOpenDiffLocation}
+								/>
+							)}
 						</div>
 					))}
 				</div>

--- a/source/gui/client/components/IssueCommits.test.ts
+++ b/source/gui/client/components/IssueCommits.test.ts
@@ -11,6 +11,7 @@ import {
 	parseDiffCommentMeta,
 	readDiffLocationParams,
 	stripDiffCommentMarker,
+	withDiffCommentNote,
 	writeDiffLocationParams,
 } from './IssueCommits';
 import {GuiComment, GuiCommitDiffFile} from '../lib/gui-state.model';
@@ -354,5 +355,73 @@ describe('issueRef', () => {
 				`<!-- epiq-diff-comment:${JSON.stringify({...meta, issueRef: 7})} -->`,
 			),
 		).toBeNull();
+	});
+});
+
+describe('withDiffCommentNote', () => {
+	const meta = {
+		filePath: 'source/a.ts',
+		start: 2,
+		side: 'additions' as const,
+		end: 3,
+		endSide: 'additions' as const,
+		note: 'old note',
+		sha: 'abc123',
+	};
+	const body = [
+		'old note',
+		'',
+		encodeDiffCommentMarker(meta),
+		'`source/a.ts` lines 2–3 (added)',
+		'```',
+		'after two\nafter three',
+		'```',
+	].join('\n');
+
+	it('replaces the note in both the text and the marker, keeping the rest', () => {
+		const next = withDiffCommentNote(body, 'new note');
+
+		expect(next).not.toBeNull();
+		expect(next!.startsWith('new note\n\n')).toBe(true);
+		expect(parseDiffCommentMeta(next!)).toEqual({...meta, note: 'new note'});
+		expect(extractCommentSnippet(next!)).toBe('after two\nafter three');
+		expect(next).not.toContain('old note');
+	});
+
+	it('drops the leading text when the note is emptied', () => {
+		const next = withDiffCommentNote(body, '  ');
+
+		expect(next!.startsWith('<!-- epiq-diff-comment:')).toBe(true);
+		expect(parseDiffCommentMeta(next!)?.note).toBe('');
+		expect(extractCommentSnippet(next!)).toBe('after two\nafter three');
+	});
+
+	it('is null for a body without a marker', () => {
+		expect(withDiffCommentNote('just words', 'note')).toBeNull();
+	});
+});
+
+describe('findDiffCommentsForFile', () => {
+	it('leaves out a deleted comment, so its annotation goes with it', () => {
+		const marker = encodeDiffCommentMarker({
+			filePath: 'source/a.ts',
+			start: 1,
+			side: 'additions',
+			end: 1,
+			endSide: 'additions',
+			note: '',
+		});
+		const comment = {
+			id: 'c1',
+			issueId: 'i1',
+			body: marker,
+			author: {id: 'u', name: 'u'},
+			createdAt: 0,
+		} as GuiComment;
+
+		expect(findDiffCommentsForFile([comment], 'source/a.ts')).toHaveLength(1);
+		expect(
+			findDiffCommentsForFile([{...comment, isDeleted: true}], 'source/a.ts'),
+		).toHaveLength(0);
 	});
 });

--- a/source/gui/client/components/IssueCommits.tsx
+++ b/source/gui/client/components/IssueCommits.tsx
@@ -164,6 +164,27 @@ export const parseDiffCommentMeta = (body: string): DiffCommentMeta | null => {
 	return meta as DiffCommentMeta;
 };
 
+// The body of a diff-selection comment with its note replaced and everything
+// else — marker location, caption, quoted snippet — kept as it was. Null for a
+// body that carries no marker.
+export const withDiffCommentNote = (
+	body: string,
+	note: string,
+): string | null => {
+	const meta = parseDiffCommentMeta(body);
+	const match = DIFF_COMMENT_MARKER.exec(body);
+	if (!meta || !match) return null;
+
+	const trimmed = note.trim();
+	const rest = body.slice(match.index + match[0].length);
+
+	return [
+		...(trimmed ? [trimmed, ''] : []),
+		encodeDiffCommentMarker({...meta, note: trimmed}),
+		rest,
+	].join('\n');
+};
+
 export type DiffComment = {comment: GuiComment; meta: DiffCommentMeta};
 
 export const findDiffCommentsForFile = (
@@ -171,6 +192,7 @@ export const findDiffCommentsForFile = (
 	filePath: string,
 ): DiffComment[] =>
 	comments.flatMap(comment => {
+		if (comment.isDeleted) return [];
 		const meta = parseDiffCommentMeta(comment.body);
 		return meta && meta.filePath === filePath ? [{comment, meta}] : [];
 	});
@@ -290,11 +312,16 @@ const disclosureStyle: React.CSSProperties = {
 	textAlign: 'left',
 	background: 'transparent',
 	border: 'none',
+	borderRadius: 6,
 	cursor: 'pointer',
 	color: GUI_THEME.primary,
 	font: 'inherit',
 	fontSize: TEXT.ui,
+	transition: 'background 120ms ease',
 };
+
+// Says "this opens" before it is clicked.
+const DISCLOSURE_HOVER_BG = 'rgba(255,255,255,0.04)';
 
 // A rounded pill rather than GitHub's five solid squares — matches the
 // rest of the app's soft, rounded chrome instead of copying its exact look.
@@ -546,6 +573,7 @@ const FileRow = ({
 	focusRange?: SelectedLineRange | null;
 }) => {
 	const [selection, setSelection] = useState<SelectedLineRange | null>(null);
+	const [headerLit, setHeaderLit] = useState(false);
 	// Held here rather than in the composer so re-dragging the range keeps
 	// what was typed.
 	const [note, setNote] = useState('');
@@ -621,10 +649,17 @@ const FileRow = ({
 			<button
 				onClick={onToggle}
 				aria-expanded={expanded}
+				onMouseEnter={() => setHeaderLit(true)}
+				onMouseLeave={() => setHeaderLit(false)}
+				onFocus={() => setHeaderLit(true)}
+				onBlur={() => setHeaderLit(false)}
 				style={{
 					...disclosureStyle,
 					color: GUI_THEME.secondary,
-					padding: '4px 0',
+					padding: '4px 6px',
+					margin: '0 -6px',
+					width: 'calc(100% + 12px)',
+					background: headerLit ? DISCLOSURE_HOVER_BG : 'transparent',
 				}}
 			>
 				{expanded ? (
@@ -782,7 +817,11 @@ const CommitRow = ({
 				onFocus={() => setFocused(true)}
 				onBlur={() => setFocused(false)}
 				aria-expanded={expanded}
-				style={{...disclosureStyle, padding: '13px 14px'}}
+				style={{
+					...disclosureStyle,
+					padding: '13px 14px',
+					background: revealed ? DISCLOSURE_HOVER_BG : 'transparent',
+				}}
 			>
 				{/* Subject leads the row with nothing before it — the sha and caret
 			    are lookup/navigation chrome, not part of reading the list, so

--- a/source/gui/client/components/IssueDetails.tsx
+++ b/source/gui/client/components/IssueDetails.tsx
@@ -111,6 +111,7 @@ export const IssueDetails = ({
 	onReopenIssue,
 	onAddComment,
 	onDeleteComment,
+	onEditComment,
 	onFileTicket,
 	onOpenDiffLocation,
 	diffFocus,
@@ -148,6 +149,7 @@ export const IssueDetails = ({
 	onReopenIssue: (issueId: string) => void;
 	onAddComment?: (issueId: string, body: string) => void;
 	onDeleteComment?: (issueId: string, commentId: string) => void;
+	onEditComment?: (issueId: string, commentId: string, body: string) => void;
 	onFileTicket?: (
 		originIssueId: string,
 		originRef: string,
@@ -635,6 +637,7 @@ export const IssueDetails = ({
 						comments={comments}
 						onAddComment={onAddComment}
 						onDeleteComment={onDeleteComment}
+						onEditComment={onEditComment}
 						onOpenDiffLocation={onOpenDiffLocation}
 					/>
 				);

--- a/source/mcp/epiq-api.ts
+++ b/source/mcp/epiq-api.ts
@@ -178,6 +178,11 @@ type DeleteIssueCommentInput = ToolInput & {
 	commentId: string;
 };
 
+type EditIssueCommentInput = ToolInput & {
+	commentId: string;
+	body: string;
+};
+
 type AddIssueAttachmentInput = ToolInput & {
 	issueId: string;
 	name: string;
@@ -2090,6 +2095,81 @@ export const deleteIssueComment = async (input: DeleteIssueCommentInput) => {
 	return succeeded('Deleted issue comment', {
 		id: input.commentId,
 		issueId: commentEvent.payload.issue,
+	});
+};
+
+export const editIssueComment = async (input: EditIssueCommentInput) => {
+	const bootResult = await boot(input.repoRoot, {pull: false});
+	if (isFail(bootResult)) return bootResult;
+
+	const actorResult = getActor();
+	if (isFail(actorResult)) return actorResult;
+
+	const stateResult = getStateResult();
+	if (isFail(stateResult)) return stateResult;
+
+	const commentEvent = stateResult.value.eventLog.find(
+		(event): event is AppEvent<'add.issue.comment'> =>
+			event.action === 'add.issue.comment' &&
+			event.payload.id === input.commentId,
+	);
+
+	if (!commentEvent) {
+		return failed('Unable to resolve comment');
+	}
+
+	if (commentEvent.payload.author !== actorResult.value.userId) {
+		return failed('You can only edit your own comments');
+	}
+
+	const issue = stateResult.value.nodes[commentEvent.payload.issue];
+
+	if (!issue) return failed('Issue not found');
+	if (!isTicketNode(issue)) return failed('Comment target must be an issue');
+	if (issue.readonly) return failed('Cannot edit comment on readonly issue');
+
+	const deleted = stateResult.value.eventLog.some(
+		event =>
+			event.action === 'delete.issue.comment' &&
+			event.payload.id === input.commentId,
+	);
+
+	if (deleted) return failed('Comment was deleted');
+
+	const body = input.body.trim();
+
+	if (!body) {
+		return failed('Comment cannot be empty');
+	}
+
+	if (body.length > MAX_COMMENT_LENGTH) {
+		return failed(
+			`Comment cannot exceed ${MAX_COMMENT_LENGTH} characters (got ${body.length})`,
+		);
+	}
+
+	const event = {
+		id: ulid(),
+		...actorResult.value,
+		action: 'edit.issue.comment',
+		payload: {
+			id: input.commentId,
+			issue: commentEvent.payload.issue,
+			md: body,
+		},
+	} satisfies AppEvent<'edit.issue.comment'>;
+
+	const results = materializeAndPersistAll(
+		[event],
+		bootResult.value.stateBranchRoot,
+	);
+
+	if (isFail(results)) return failed(results.message);
+
+	return succeeded('Edited issue comment', {
+		id: input.commentId,
+		issueId: commentEvent.payload.issue,
+		body,
 	});
 };
 

--- a/source/mcp/server.ts
+++ b/source/mcp/server.ts
@@ -24,6 +24,7 @@ import {
 	createIssue,
 	createSwimlane,
 	deleteIssueComment,
+	editIssueComment,
 	deleteSwimlane,
 	editIssueDescription,
 	editIssueTitle,
@@ -383,6 +384,20 @@ export const createMcpServer = () => {
 			}),
 		},
 		async input => resultJson(await deleteIssueComment(input)),
+	);
+
+	server.registerTool(
+		'epiq_issue_comment_edit',
+		{
+			description:
+				'Replace the body of one of your own comments on an Epiq issue',
+			inputSchema: z.object({
+				commentId: z.string().min(1),
+				body: z.string().min(1).max(MAX_COMMENT_LENGTH),
+				repoRoot: z.string().optional(),
+			}),
+		},
+		async input => resultJson(await editIssueComment(input)),
 	);
 
 	server.registerTool(

--- a/source/test/e2e-gui/comments.pw.ts
+++ b/source/test/e2e-gui/comments.pw.ts
@@ -1,0 +1,56 @@
+import type {Page} from '@playwright/test';
+import {expect, test} from './fixtures.js';
+
+const addTicket = async (page: Page, title: string) => {
+	await page.getByTitle('Add issue').first().click();
+	await page.getByPlaceholder('issue name').fill(title);
+	await page.getByPlaceholder('issue name').press('Enter');
+	await expect(page.locator('aside')).toContainText(title);
+};
+
+const postComment = async (page: Page, text: string) => {
+	await page.getByPlaceholder('write a comment').fill(text);
+	await page.getByRole('button', {name: 'comment', exact: true}).click();
+	await expect(page.locator('aside').getByText(text)).toBeVisible();
+};
+
+test.beforeEach(async ({page, appUrl}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+});
+
+test('your own comment can be edited and deleted', async ({
+	page,
+	pageErrors,
+}) => {
+	await addTicket(page, `Own comment ${Date.now()}`);
+	await page.getByRole('button', {name: /^Comments/}).click();
+	await postComment(page, 'first draft');
+	await expect(page.getByRole('button', {name: 'Comments (1)'})).toBeVisible();
+
+	// Edit: the body is prefilled, Escape backs out untouched.
+	await page.getByTitle('Edit comment').click();
+	const editor = page.locator('aside textarea').first();
+	await expect(editor).toHaveValue('first draft');
+	await editor.press('Escape');
+	await expect(page.locator('aside').getByText('first draft')).toBeVisible();
+
+	await page.getByTitle('Edit comment').click();
+	await editor.fill('second draft');
+	await page.getByRole('button', {name: 'save'}).click();
+	await expect(page.locator('aside').getByText('second draft')).toBeVisible();
+	await expect(page.locator('aside').getByText('first draft')).toHaveCount(0);
+
+	// Survives a reload: it reached the log, not just the screen.
+	await page.reload();
+	await expect(page.locator('aside').getByText('second draft')).toBeVisible();
+
+	// Delete.
+	await page.getByTitle('Delete comment').click();
+	await expect(page.locator('aside').getByText('second draft')).toHaveCount(0);
+	await expect(page.getByRole('button', {name: 'Comments (0)'})).toBeVisible();
+	await page.reload();
+	await expect(page.getByRole('button', {name: 'Comments (0)'})).toBeVisible();
+
+	expect(pageErrors).toEqual([]);
+});

--- a/source/test/e2e-gui/diff-composer.pw.ts
+++ b/source/test/e2e-gui/diff-composer.pw.ts
@@ -9,10 +9,19 @@ const addTicket = async (page: Page, title: string) => {
 	await expect(page.locator('aside')).toContainText(title);
 };
 
+// Opens the commit and its file if they aren't open already — once a diff
+// link has been followed the URL keeps pointing at the spot, and the tab then
+// opens both on its own.
 const expandDiff = async (page: Page, subject: string) => {
 	await page.getByRole('button', {name: /^Commits/}).click();
-	await page.getByRole('button', {name: subject}).click();
-	await page.getByRole('button', {name: 'notes.txt'}).click();
+	for (const name of [subject, 'notes.txt']) {
+		const toggle = page.getByRole('button', {name});
+		await expect(toggle).toBeVisible();
+		if ((await toggle.getAttribute('aria-expanded')) !== 'true') {
+			await toggle.click();
+		}
+		await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+	}
 };
 
 const openDiffAndSelectLine = async (page: Page, subject: string) => {
@@ -103,6 +112,34 @@ test('selecting lines opens one composer under them; write, then comment or file
 	await expect(page.getByTestId('snippet-gutter')).toHaveText('2');
 	await expect(page.getByTestId('code-snippet')).toContainText('beta');
 	await page.screenshot({path: testInfo.outputPath('comment-snippet.png')});
+
+	// Editing a diff comment edits its note; the link and snippet stay.
+	await page.getByTitle('Edit comment').click();
+	const editor = page.locator('aside textarea').first();
+	await expect(editor).toHaveValue('looks off');
+	await editor.fill('looks fine after all');
+	await page.getByRole('button', {name: 'save'}).click();
+	await expect(
+		page.locator('aside').getByText('looks fine after all'),
+	).toBeVisible();
+	await expect(
+		page.locator('aside').getByTitle('Open this in the diff'),
+	).toHaveText('notes.txt line 2 (added)');
+	await expect(page.getByTestId('code-snippet')).toContainText('beta');
+
+	// ...and the annotation in the diff follows the edit.
+	await expandDiff(page, 'add notes');
+	await expect(page.getByTestId('diff-comment')).toContainText(
+		'looks fine after all',
+	);
+
+	// Deleting it takes the annotation away too.
+	await page.getByRole('button', {name: 'Comments (1)'}).click();
+	await page.getByTitle('Delete comment').click();
+	await expect(page.getByRole('button', {name: 'Comments (0)'})).toBeVisible();
+	await expandDiff(page, 'add notes');
+	await expect(page.getByTestId('diff-comment')).toHaveCount(0);
+	await expect(page.locator('[data-line]')).toHaveCount(3);
 
 	// File a ticket: the note stays the note, the title is asked for.
 	await expandDiff(page, 'add notes');

--- a/source/test/websocket-mutation-broadcast.test.ts
+++ b/source/test/websocket-mutation-broadcast.test.ts
@@ -13,6 +13,7 @@ vi.mock('../mcp/epiq-api.js', () => ({
 	closeIssue: vi.fn(),
 	createIssue: vi.fn(),
 	deleteIssueComment: vi.fn(),
+	editIssueComment: vi.fn(),
 	deriveGuiState: vi.fn(),
 	editIssueDescription: vi.fn(),
 	editIssueTitle: vi.fn(),

--- a/source/test/websocket-schema.test.ts
+++ b/source/test/websocket-schema.test.ts
@@ -54,6 +54,18 @@ describe('parseGuiMessage', () => {
 		expect(parsed.message.payload).toEqual(payload);
 	});
 
+	it('accepts a comment edit', () => {
+		const payload = {issueId, commentId: issueId, body: 'again'};
+		const parsed = parseGuiMessage({type: 'issue:comment:edit', payload});
+
+		expect(parsed.ok).toBe(true);
+		if (!parsed.ok || parsed.message.type !== 'issue:comment:edit') {
+			throw new Error('expected an issue:comment:edit message');
+		}
+
+		expect(parsed.message.payload).toEqual(payload);
+	});
+
 	it.each([
 		['null', null],
 		['a number', 123],


### PR DESCRIPTION
Stacked on #134. Three tickets in one commit (they touch the same lines):

**ERXM4AZ — deleting a comment did nothing.** The client sent `{commentId}` while the schema requires `{issueId, commentId}`, so the frame was refused before the handler ran; the refusal came back as an `error` frame the client ignored; and the optimistic removal edited `state.commentsByIssueId` while the panel renders `issueDetail.comments`. Now: the frame carries `issueId`, optimistic changes land in `issueDetail`, and `error` frames get the same toast + refetch that `failed` frames do.

Fixing that surfaced a second pre-existing bug: every page load sent `timeline:get` with `boardId: null`, which the schema refuses. Omitting the board is the documented "every board" ask and the only shape accepted, so the client now omits it.

**N7A4XSG — edit your own comments.** `edit.issue.comment` already existed in the log (the TUI's `:edit` uses it); it's now exposed as `editIssueComment` (same author/readonly checks as delete, plus empty/length checks), the `epiq_issue_comment_edit` MCP tool, the `issue:comment:edit` websocket message, and an inline editor on your own comments in the panel (Cmd/Ctrl+Enter saves, Escape cancels). A diff-linked comment edits its note only — `withDiffCommentNote` re-encodes the marker and keeps the caption and quoted snippet — so the annotation in the diff follows the edit, and deleting the comment removes the annotation (`findDiffCommentsForFile` skips deleted comments).

Privileges: server-enforced own-comments-only, no time window — there is no shared clock to enforce one against (see the architecture rules), and the log keeps every edit.

**RDK1HGY — hover state** on the commit rows and file rows in the Commits tab.

Tests: `comments.pw.ts` (edit prefilled, Escape backs out, save, survives reload, delete, survives reload); `diff-composer.pw.ts` extended (edit a diff comment's note → link and snippet kept, annotation updates; delete → annotation gone); unit tests for `withDiffCommentNote`, deleted-comment filtering, the schema; `details-close` guards the timeline fix.