### PR TITLE
0P8ZXS5 delete tags by tombstoning

### DIFF
--- a/source/gui/api/lib/websocket.model.ts
+++ b/source/gui/api/lib/websocket.model.ts
@@ -23,6 +23,7 @@ export type GuiMessage =
 			type: 'contributor:remove';
 			payload: {contributorId: string};
 	  }
+	| {type: 'tag:remove'; payload: {tagId: string}}
 	| {
 			type: 'contributors:get';
 			// Optional board scope: omit for everyone in the workspace.

--- a/source/gui/api/lib/websocket.schema.ts
+++ b/source/gui/api/lib/websocket.schema.ts
@@ -59,6 +59,7 @@ export const GuiMessageSchema = z.discriminatedUnion('type', [
 	message('issue:tag:add', z.object({issueId: id, tagName: z.string()})),
 	message('issue:tag:remove', z.object({issueId: id, tagId: id})),
 	message('contributor:remove', z.object({contributorId: id})),
+	message('tag:remove', z.object({tagId: id})),
 	z.object({
 		type: z.literal('contributors:get'),
 		payload: z.object({boardId: id.optional()}).optional(),

--- a/source/gui/api/lib/websocket.ts
+++ b/source/gui/api/lib/websocket.ts
@@ -4,6 +4,7 @@ import {
 	addIssueAssignee,
 	getBoardContributors,
 	tombstoneContributor,
+	tombstoneTag,
 	addIssueComment,
 	addIssueTag,
 	closeIssue,
@@ -382,6 +383,21 @@ export const setupWebsocket = (
 						repoRoot,
 						onStateChanged,
 						'contributor:remove:result',
+						result,
+					);
+				}
+
+				if (type === 'tag:remove') {
+					const result = await tombstoneTag({
+						repoRoot,
+						...message.payload,
+					});
+
+					return sendMutationResult(
+						socket,
+						repoRoot,
+						onStateChanged,
+						'tag:remove:result',
 						result,
 					);
 				}

--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -593,6 +593,13 @@ export const App = () => {
 				);
 			}
 
+			if (
+				message.type === 'tag:remove:result' &&
+				message.payload?.status === 'fail'
+			) {
+				setRemoveError(`Couldn't delete a tag: ${message.payload.message}`);
+			}
+
 			if (message.type === 'contributors') {
 				const next = getResultValue<GuiContributor[]>(message.payload);
 				if (next) setContributors(next);
@@ -938,6 +945,12 @@ export const App = () => {
 	// Clears the display name only; the id and every assignment survive.
 	const removeContributor = (contributorId: string) => {
 		send('contributor:remove', {contributorId});
+	};
+
+	// Hides the tag everywhere; the id and every ticket reference survive. The
+	// state broadcast that follows drops it from every card at once.
+	const removeTag = (tagId: string) => {
+		send('tag:remove', {tagId});
 	};
 
 	// Invent a person who has no record at all in the in the event logs.
@@ -1712,6 +1725,7 @@ export const App = () => {
 								onAddAssignee={addIssueAssignee}
 								onAddExternalAssignee={addExternalIssueAssignee}
 								onRemoveContributor={removeContributor}
+								onDeleteTag={removeTag}
 								onRemoveAssignee={removeIssueAssignee}
 								onAddComment={addIssueComment}
 								onDeleteComment={deleteIssueComment}

--- a/source/gui/client/components/IssueDetails.tsx
+++ b/source/gui/client/components/IssueDetails.tsx
@@ -18,6 +18,7 @@ import {
 } from './Aside';
 import {Button} from './Button';
 import {ManageContributorsModal} from './ManageContributorsModal';
+import {ManageTagsModal} from './ManageTagsModal';
 import {CopyRef} from './CopyRef';
 import {FormHeader} from './FormHeader';
 import {FullscreenToggleButton} from './FullscreenToggleButton';
@@ -103,6 +104,7 @@ export const IssueDetails = ({
 	onAddAssignee,
 	onAddExternalAssignee,
 	onRemoveContributor,
+	onDeleteTag,
 	onRemoveAssignee,
 	onCloseIssue,
 	onReopenIssue,
@@ -139,6 +141,7 @@ export const IssueDetails = ({
 	onAddAssignee: (issueId: string, assigneeId: string) => void;
 	onAddExternalAssignee: (issueId: string, assigneeName: string) => void;
 	onRemoveContributor: (contributorId: string) => void;
+	onDeleteTag: (tagId: string) => void;
 	onRemoveAssignee: (issueId: string, assigneeId: string) => void;
 	onCloseIssue: (issueId: string) => void;
 	onReopenIssue: (issueId: string) => void;
@@ -172,6 +175,7 @@ export const IssueDetails = ({
 	const [tagName, setTagName] = useState('');
 	const [assigneeName, setAssigneeName] = useState('');
 	const [managingContributors, setManagingContributors] = useState(false);
+	const [managingTags, setManagingTags] = useState(false);
 	const [editingTitle, setEditingTitle] = useState(false);
 	const [editingDescription, setEditingDescription] = useState(false);
 	const [addingTag, setAddingTag] = useState(false);
@@ -433,6 +437,19 @@ export const IssueDetails = ({
 											+ {tag.name}
 										</Button>
 									))}
+								</ChipRow>
+							)}
+
+							{addingTag && tags.length > 0 && (
+								<ChipRow>
+									<Button
+										variant="ghost"
+										disabled={issue.readonly}
+										onClick={() => setManagingTags(true)}
+										title="Review and delete tags across the whole workspace"
+									>
+										manage tags…
+									</Button>
 								</ChipRow>
 							)}
 
@@ -771,6 +788,14 @@ export const IssueDetails = ({
 								contributors={assignees}
 								onRemove={onRemoveContributor}
 								onClose={() => setManagingContributors(false)}
+							/>
+						)}
+
+						{managingTags && (
+							<ManageTagsModal
+								tags={tags}
+								onDelete={onDeleteTag}
+								onClose={() => setManagingTags(false)}
 							/>
 						)}
 					</>

--- a/source/gui/client/components/ManageTagsModal.tsx
+++ b/source/gui/client/components/ManageTagsModal.tsx
@@ -1,0 +1,127 @@
+import {useState} from 'react';
+import {GuiTag} from '../lib/gui-state.model';
+import {GUI_THEME} from '../lib/gui-theme';
+import {Button} from './Button';
+import {IconTrash} from './IconTrash';
+
+type Props = {
+	tags: GuiTag[];
+	onDelete: (tagId: string) => void;
+	onClose: () => void;
+};
+
+export const ManageTagsModal = ({tags, onDelete, onClose}: Props) => {
+	// Two-step: the first click arms one row, the second commits it. Arming by
+	// id rather than a boolean so moving to another row cancels the first.
+	const [armedId, setArmedId] = useState<string | null>(null);
+
+	const sorted = [...tags].sort((a, b) => a.name.localeCompare(b.name));
+
+	return (
+		<div
+			style={{
+				position: 'fixed',
+				inset: 0,
+				background: 'rgba(0, 0, 0, 0.25)',
+				backdropFilter: 'blur(.5px)',
+				display: 'flex',
+				alignItems: 'center',
+				justifyContent: 'center',
+				zIndex: 1000,
+			}}
+			onMouseDown={onClose}
+		>
+			<div
+				onMouseDown={event => event.stopPropagation()}
+				style={{
+					marginTop: '-100px',
+					width: 460,
+					background: GUI_THEME.panel,
+					border: `1px solid ${GUI_THEME.line}`,
+					borderRadius: 12,
+					padding: 20,
+					display: 'flex',
+					flexDirection: 'column',
+					gap: 14,
+				}}
+			>
+				<div
+					style={{
+						color: GUI_THEME.secondary,
+						fontSize: 10,
+						letterSpacing: 1,
+						textTransform: 'uppercase',
+					}}
+				>
+					Manage tags
+				</div>
+
+				<div style={{fontSize: 12, color: GUI_THEME.secondary}}>
+					Delete tags across the whole workspace. A deleted tag comes off every
+					ticket at once; its history stays in the log.
+				</div>
+
+				<div
+					style={{
+						display: 'flex',
+						flexDirection: 'column',
+						gap: 2,
+						maxHeight: 260,
+						overflowY: 'auto',
+					}}
+				>
+					{sorted.map(tag => {
+						const armed = armedId === tag.id;
+
+						return (
+							<div
+								key={tag.id}
+								style={{
+									display: 'flex',
+									alignItems: 'center',
+									justifyContent: 'space-between',
+									gap: 8,
+									padding: '6px 8px',
+									borderRadius: 6,
+								}}
+							>
+								<span style={{fontSize: 12, color: tag.color}}>{tag.name}</span>
+
+								<Button
+									variant="ghost"
+									title={
+										armed
+											? `Click again to delete "${tag.name}" everywhere`
+											: `Delete "${tag.name}"`
+									}
+									onClick={() => {
+										if (!armed) return setArmedId(tag.id);
+
+										onDelete(tag.id);
+										setArmedId(null);
+									}}
+									style={{
+										display: 'flex',
+										alignItems: 'center',
+										gap: 6,
+										color: armed ? GUI_THEME.red : GUI_THEME.dim,
+										borderColor: armed ? GUI_THEME.red : undefined,
+									}}
+								>
+									{armed && <span style={{fontSize: 10}}>confirm</span>}
+									<IconTrash />
+								</Button>
+							</div>
+						);
+					})}
+				</div>
+
+				<div style={{display: 'flex', justifyContent: 'flex-end'}}>
+					<Button variant="ghost" onClick={onClose}>
+						close
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+};

--- a/source/gui/client/lib/gui-mutations.ts
+++ b/source/gui/client/lib/gui-mutations.ts
@@ -15,6 +15,7 @@ export const MUTATING_MESSAGE_TYPES = new Set<string>([
 	'issue:tag:add',
 	'issue:tag:remove',
 	'contributor:remove',
+	'tag:remove',
 	'issue:assignee:add',
 	'issue:assignee:remove',
 	'issue:comment:add',

--- a/source/gui/client/lib/scrubber.ts
+++ b/source/gui/client/lib/scrubber.ts
@@ -228,6 +228,8 @@ const CATEGORY_BY_ACTION: Record<string, EventCategory> = {
 	'add.issue.tag': 'tagging',
 	'remove.issue.tag': 'tagging',
 	'create.tag': 'tagging',
+	'tombstone.tag': 'tagging',
+	'restore.tag': 'tagging',
 	'add.issue.assignee': 'assigning',
 	'remove.issue.assignee': 'assigning',
 	'create.contributor': 'assigning',

--- a/source/lib/command-line/commands.ts
+++ b/source/lib/command-line/commands.ts
@@ -1,4 +1,5 @@
 import {ulid} from 'ulid';
+import {nodeRepo} from '../repository/node-repo.js';
 import {exportBoardLayout} from '../../export/export.js';
 import {navigationUtils} from '../actions/default/navigation-action-utils.js';
 import {ACTOR_NAME_ENV} from '../config/actor-env.js';
@@ -57,9 +58,6 @@ const isAddIssueCommentEvent = (
 		md: string;
 	};
 } => event.action === 'add.issue.comment';
-
-const findTagByName = (name: string) =>
-	Object.values(getState().tags).find(tag => tag.name === name);
 
 // The registry only holds people explicitly created or assigned, so it is often
 // empty even of you; log authors are candidates too.
@@ -424,7 +422,7 @@ export const commands: CommandLineActionEntry[] = [
 			const name = (modifier || inputString).trim();
 			if (!name) return failed('Provide a tag');
 
-			const existingTag = findTagByName(name);
+			const existingTag = nodeRepo.findTagByName(name);
 			if (!existingTag) return failed(`Tag "${name}" does not exist`);
 
 			const {selectedNode} = getState();
@@ -490,7 +488,7 @@ export const commands: CommandLineActionEntry[] = [
 			const persistRootResult = await getPersistRootValue();
 			if (isFail(persistRootResult)) return persistRootResult;
 
-			const existingTag = findTagByName(name);
+			const existingTag = nodeRepo.findTagByName(name);
 			const tagId = existingTag?.id ?? ulid();
 
 			const tags = ticket.props.tags ?? [];

--- a/source/lib/components/BreadCrumb.tsx
+++ b/source/lib/components/BreadCrumb.tsx
@@ -51,7 +51,7 @@ export const Breadcrumb: React.FC<Props> = ({width}) => {
 	);
 	const ticket = isSuccess(ticketResult) ? ticketResult.value : undefined;
 
-	const tags = ticket?.props.tags ?? [];
+	const tags = (ticket?.props.tags ?? []).filter(tag => nodeRepo.getTag(tag));
 	const assignees = ticket?.props.assignees ?? [];
 
 	const showDetails = ticket?.parentNodeId

--- a/source/lib/components/FieldListUI.tsx
+++ b/source/lib/components/FieldListUI.tsx
@@ -33,7 +33,7 @@ export const FieldListUI: React.FC<Props> = ({
 			? title === FieldNames.ASSIGNEES
 				? ticket.props.assignees ?? []
 				: title === FieldNames.TAGS
-				? ticket.props.tags ?? []
+				? (ticket.props.tags ?? []).filter(tag => nodeRepo.getTag(tag))
 				: []
 			: [];
 

--- a/source/lib/event/event-materialize.ts
+++ b/source/lib/event/event-materialize.ts
@@ -176,6 +176,8 @@ export const getAffectedNodeIds = (event: AppEvent): string[] => {
 			return Object.keys(event.payload.ranks);
 
 		case 'create.tag':
+		case 'tombstone.tag':
+		case 'restore.tag':
 		case 'create.contributor':
 		case 'rename.contributor':
 		case 'link.contributor.user':
@@ -456,6 +458,34 @@ const materializeHandlers: MaterializeHandlers = {
 		}
 
 		return succeeded('Tag added', {
+			action: event.action,
+			result: result.value,
+		});
+	},
+
+	'tombstone.tag': event => {
+		const {id} = event.payload;
+		const result = nodeRepo.tombstoneTag(id);
+
+		if (isFail(result)) {
+			return materializeSkip(result.message ?? 'Unable to delete tag', event);
+		}
+
+		return succeeded('Tag tombstoned', {
+			action: event.action,
+			result: result.value,
+		});
+	},
+
+	'restore.tag': event => {
+		const {id, name} = event.payload;
+		const result = nodeRepo.restoreTag(id, name);
+
+		if (isFail(result)) {
+			return materializeSkip(result.message ?? 'Unable to restore tag', event);
+		}
+
+		return succeeded('Tag restored', {
 			action: event.action,
 			result: result.value,
 		});

--- a/source/lib/event/event.model.ts
+++ b/source/lib/event/event.model.ts
@@ -73,6 +73,21 @@ export type AppEventMap = {
 		result: Tag;
 	};
 
+	/**
+	 * Hides a tag everywhere, keeping the id and every ticket reference. A
+	 * forward event: earlier tag events still replay unchanged.
+	 */
+	'tombstone.tag': {
+		payload: PayloadBase;
+		result: Tag;
+	};
+
+	/** Undoes a `tombstone.tag`. Carries the name so replay never reads it back off earlier events. */
+	'restore.tag': {
+		payload: PayloadBase & {name: string};
+		result: Tag;
+	};
+
 	'create.contributor': {
 		payload: PayloadBase & {name: string};
 		result: Contributor;
@@ -280,6 +295,8 @@ export const EVENT_ACTIONS = [
 	'edit.title',
 	'delete.node',
 	'create.tag',
+	'tombstone.tag',
+	'restore.tag',
 	'create.contributor',
 	'rename.contributor',
 	'tombstone.contributor',

--- a/source/lib/event/format-log-utils.ts
+++ b/source/lib/event/format-log-utils.ts
@@ -45,6 +45,8 @@ export const formatLogAction = (action: string): string => {
 		'add.swimlane': 'Created swimlane',
 		'add.field': 'Added field',
 		'create.tag': 'Created tag',
+		'tombstone.tag': 'Deleted tag',
+		'restore.tag': 'Restored tag',
 		'create.contributor': 'Added contributor',
 		'rename.contributor': 'Renamed contributor',
 		'link.contributor.user': 'Linked contributor',
@@ -119,6 +121,11 @@ const formatEventDetails = (event: AppEvent): string => {
 				: 'unknown tag';
 		}
 
+		case 'tombstone.tag': {
+			const tag = getState().tags[event.payload.id];
+			return tag ? `"${tag.name}"` : '';
+		}
+
 		case 'add.issue.assignee': {
 			const contributor = getState().contributors[event.payload.assignee];
 			return contributor
@@ -138,6 +145,7 @@ const formatEventDetails = (event: AppEvent): string => {
 		case 'add.issue':
 		case 'add.field':
 		case 'create.tag':
+		case 'restore.tag':
 		case 'create.contributor':
 		case 'rename.contributor':
 		case 'edit.title': {
@@ -186,11 +194,17 @@ const formatEventDetailsPlain = (event: AppEvent): string => {
 			return contributor ? contributor.name : '';
 		}
 
+		case 'tombstone.tag': {
+			const tag = getState().tags[event.payload.id];
+			return tag ? `"${tag.name}"` : '';
+		}
+
 		case 'add.board':
 		case 'add.swimlane':
 		case 'add.issue':
 		case 'add.field':
 		case 'create.tag':
+		case 'restore.tag':
 		case 'create.contributor':
 		case 'rename.contributor':
 		case 'edit.title':

--- a/source/lib/model/app-state.model.ts
+++ b/source/lib/model/app-state.model.ts
@@ -24,7 +24,9 @@ export type BreadCrumb =
 
 export type ViewMode = 'wide' | 'dense';
 
-export type Tag = {id: string; name: string};
+// A tombstoned tag keeps its id and record but reads as absent everywhere, and
+// its name is free for a fresh tag.
+export type Tag = {id: string; name: string; tombstoned?: boolean};
 // A placeholder, not an empty name, so a tombstoned assignee still reads as one.
 export const REMOVED_CONTRIBUTOR_NAME = 'removed';
 

--- a/source/lib/repository/node-repo.ts
+++ b/source/lib/repository/node-repo.ts
@@ -581,7 +581,8 @@ export const nodeRepo = {
 	},
 
 	untag(targetId: string, tagId: string): Result<{tag: string}> {
-		const tag = this.getTag(tagId);
+		// The raw record: a reference to a deleted tag may still be cleared.
+		const tag = this.getTagRecord(tagId);
 		const target = this.getNode(targetId);
 
 		if (!tag) return failed('Unable to remove tag, missing tag');
@@ -608,6 +609,36 @@ export const nodeRepo = {
 		this.updateNode(updatedNode);
 
 		return succeeded('Tag removed', {tag: tagId});
+	},
+
+	tombstoneTag(tagId: string): Result<Tag> {
+		const tag = this.getTagRecord(tagId);
+		if (!tag) return failed('Tag not found');
+
+		const tombstoned: Tag = {...tag, tombstoned: true};
+
+		const result = updateState(s => ({
+			...s,
+			tags: {...s.tags, [tagId]: tombstoned},
+		}));
+
+		if (isFail(result)) return failed('Unable to delete tag');
+		return succeeded('Tombstoned tag', tombstoned);
+	},
+
+	restoreTag(tagId: string, name: string): Result<Tag> {
+		const tag = this.getTagRecord(tagId);
+		if (!tag) return failed('Tag not found');
+
+		const restored: Tag = {...tag, name, tombstoned: false};
+
+		const result = updateState(s => ({
+			...s,
+			tags: {...s.tags, [tagId]: restored},
+		}));
+
+		if (isFail(result)) return failed('Unable to restore tag');
+		return succeeded('Restored tag', restored);
 	},
 
 	createTag(tag: Tag): Result<Tag> {
@@ -678,8 +709,23 @@ export const nodeRepo = {
 		return getState().contributors[id];
 	},
 
+	// A tombstoned tag reads as absent, which is what hides it from every chip,
+	// picker and filter at once. `getTagRecord` is the raw read.
 	getTag(id: string): Tag | undefined {
+		const tag = getState().tags[id];
+		return tag?.tombstoned ? undefined : tag;
+	},
+
+	getTagRecord(id: string): Tag | undefined {
 		return getState().tags[id];
+	},
+
+	getTags(): Tag[] {
+		return Object.values(getState().tags).filter(tag => !tag.tombstoned);
+	},
+
+	findTagByName(name: string): Tag | undefined {
+		return this.getTags().find(tag => tag.name === name);
 	},
 
 	getNode<T extends AnyContext>(id: string) {

--- a/source/lib/utils/filter.ts
+++ b/source/lib/utils/filter.ts
@@ -1,4 +1,4 @@
-import {Filter} from '../model/app-state.model.js';
+import {Filter, Tag} from '../model/app-state.model.js';
 import {NavNode} from '../model/navigation-node.model.js';
 import {getState} from '../state/state.js';
 import {nodeRefMatches} from './node-ref.js';
@@ -17,8 +17,9 @@ const getTagNames = (ticket: NavNode<'TICKET'>): string[] => {
 	const {tags} = getState();
 
 	return (ticket.props.tags ?? [])
-		.map(tag => tags[tag]?.name)
-		.filter((name): name is string => Boolean(name));
+		.map(tag => tags[tag])
+		.filter((tag): tag is Tag => tag !== undefined && !tag.tombstoned)
+		.map(tag => tag.name);
 };
 
 const getAssigneeNames = (ticket: NavNode<'TICKET'>): string[] => {

--- a/source/mcp/epiq-api.ts
+++ b/source/mcp/epiq-api.ts
@@ -564,9 +564,7 @@ export const createIssue = async (input: CreateIssueInput) => {
 		const overLongTag = tooLong('Tag name', tagName, MAX_TAG_NAME_LENGTH);
 		if (overLongTag) return failed(overLongTag);
 
-		const existingTag = Object.values(stateResult.value.tags).find(
-			tag => tag.name === tagName,
-		);
+		const existingTag = nodeRepo.findTagByName(tagName);
 		const tagId = existingTag?.id ?? ulid();
 
 		if (!existingTag) {
@@ -1215,7 +1213,7 @@ export const deriveGuiState = (): Result<ApiState> => {
 							} satisfies ApiSwimlane),
 					),
 			})),
-		tags: Object.values(stateResult.value.tags).map(x => ({
+		tags: nodeRepo.getTags().map(x => ({
 			...x,
 			color: getStringColor(x.name),
 		})),
@@ -1390,9 +1388,7 @@ export const addIssueTag = async (input: AddIssueTagInput) => {
 	const overLongTag = tooLong('Tag name', tagName, MAX_TAG_NAME_LENGTH);
 	if (overLongTag) return failed(overLongTag);
 
-	const existingTag = Object.values(stateResult.value.tags).find(
-		tag => tag.name === tagName,
-	);
+	const existingTag = nodeRepo.findTagByName(tagName);
 
 	const tagId = existingTag?.id ?? ulid();
 
@@ -1433,6 +1429,84 @@ export const addIssueTag = async (input: AddIssueTagInput) => {
 		ref: nodeRef(input.issueId),
 		tag: {id: tagId, name: tagName},
 	});
+};
+
+// Tombstone, not deletion: the id and every ticket reference survive in the
+// log; the tag just stops rendering anywhere, and its name is free again.
+export const tombstoneTag = async (
+	input: ToolInput & {tagId: string},
+): Promise<Result<{id: string; name: string}>> => {
+	const bootResult = await boot(input.repoRoot, {pull: false});
+	if (isFail(bootResult)) return bootResult;
+
+	const actorResult = getActor();
+	if (isFail(actorResult)) return actorResult;
+
+	const stateResult = getStateResult();
+	if (isFail(stateResult)) return stateResult;
+
+	const tag = stateResult.value.tags[input.tagId];
+	if (!tag) return failed('Tag not found');
+	if (tag.tombstoned) return failed('Tag is already deleted');
+
+	const events = [
+		{
+			id: ulid(),
+			...actorResult.value,
+			action: 'tombstone.tag',
+			payload: {id: input.tagId},
+		} satisfies AppEvent<'tombstone.tag'>,
+	];
+
+	const results = materializeAndPersistAll(
+		events,
+		bootResult.value.stateBranchRoot,
+	);
+
+	if (isFail(results)) return failed(results.message);
+
+	return succeeded('Deleted tag', {id: tag.id, name: tag.name});
+};
+
+export const restoreTag = async (
+	input: ToolInput & {tagId: string},
+): Promise<Result<{id: string; name: string}>> => {
+	const bootResult = await boot(input.repoRoot, {pull: false});
+	if (isFail(bootResult)) return bootResult;
+
+	const actorResult = getActor();
+	if (isFail(actorResult)) return actorResult;
+
+	const stateResult = getStateResult();
+	if (isFail(stateResult)) return stateResult;
+
+	const tag = stateResult.value.tags[input.tagId];
+	if (!tag) return failed('Tag not found');
+	if (!tag.tombstoned) return failed('Tag is not deleted');
+
+	// The name may have been taken by a fresh tag in the meantime; two live
+	// tags with one name would be indistinguishable everywhere they are picked.
+	if (nodeRepo.findTagByName(tag.name)) {
+		return failed(`Cannot restore: another tag is already named "${tag.name}"`);
+	}
+
+	const events = [
+		{
+			id: ulid(),
+			...actorResult.value,
+			action: 'restore.tag',
+			payload: {id: input.tagId, name: tag.name},
+		} satisfies AppEvent<'restore.tag'>,
+	];
+
+	const results = materializeAndPersistAll(
+		events,
+		bootResult.value.stateBranchRoot,
+	);
+
+	if (isFail(results)) return failed(results.message);
+
+	return succeeded('Restored tag', {id: tag.id, name: tag.name});
 };
 
 export const removeIssueTag = async (input: RemoveIssueTagInput) => {

--- a/source/mcp/server.ts
+++ b/source/mcp/server.ts
@@ -16,6 +16,8 @@ import {
 	getBoardContributors,
 	tombstoneContributor,
 	restoreContributor,
+	tombstoneTag,
+	restoreTag,
 	addIssueComment,
 	addIssueTag,
 	closeIssue,
@@ -283,6 +285,32 @@ export const createMcpServer = () => {
 			}),
 		},
 		async input => resultJson(await tombstoneContributor(input)),
+	);
+
+	server.registerTool(
+		'epiq_tag_remove',
+		{
+			description:
+				'Delete a tag from the whole workspace. It disappears from every ticket, picker and filter, but its id and history stay in the event log, and the name is free for a new tag.',
+			inputSchema: z.object({
+				tagId: z.string().min(1),
+				repoRoot: z.string().optional(),
+			}),
+		},
+		async input => resultJson(await tombstoneTag(input)),
+	);
+
+	server.registerTool(
+		'epiq_tag_restore',
+		{
+			description:
+				'Put back a tag deleted with epiq_tag_remove, on every ticket that still carried it.',
+			inputSchema: z.object({
+				tagId: z.string().min(1),
+				repoRoot: z.string().optional(),
+			}),
+		},
+		async input => resultJson(await restoreTag(input)),
 	);
 
 	server.registerTool(

--- a/source/mcp/test/epiq-api.test.ts
+++ b/source/mcp/test/epiq-api.test.ts
@@ -302,6 +302,17 @@ const DEFAULT_CONTRIBUTOR_REGISTRY = {
 	'contributor-1': {id: 'contributor-1', name: 'Alice'},
 };
 
+const tagRegistry: Record<
+	string,
+	{id: string; name: string; tombstoned?: boolean}
+> = {
+	'tag-1': {id: 'tag-1', name: 'bug'},
+};
+
+const DEFAULT_TAG_REGISTRY = {
+	'tag-1': {id: 'tag-1', name: 'bug'},
+};
+
 // The *state* event log, distinct from the merged on-disk log loadMergedEvents
 // supplies. Name resolution reads this one.
 const DEFAULT_STATE_EVENT_LOG = [
@@ -328,6 +339,8 @@ const resetContributorFixtures = () => {
 		contributorRegistry,
 		structuredClone(DEFAULT_CONTRIBUTOR_REGISTRY),
 	);
+	for (const key of Object.keys(tagRegistry)) delete tagRegistry[key];
+	Object.assign(tagRegistry, structuredClone(DEFAULT_TAG_REGISTRY));
 	stateEventLog = [...DEFAULT_STATE_EVENT_LOG];
 };
 
@@ -344,9 +357,7 @@ vi.mock('../../lib/state/state.js', async importOriginal => {
 				rootNodeId: 'workspace-1',
 				contextNode: nodes['swimlane-1'],
 				selectedIndex: 0,
-				tags: {
-					'tag-1': {id: 'tag-1', name: 'bug'},
-				},
+				tags: tagRegistry,
 				contributors: contributorRegistry,
 				eventLog: stateEventLog,
 				syncStatus: {
@@ -364,8 +375,18 @@ vi.mock('../../lib/state/state.js', async importOriginal => {
 vi.mock('../../lib/repository/node-repo.js', () => ({
 	nodeRepo: {
 		getNode: vi.fn((id: string) => nodes[id]),
+		// Mirrors the real repo: a tombstoned tag reads as absent.
 		getTag: vi.fn((id: string) =>
-			id === 'tag-1' ? {id: 'tag-1', name: 'bug'} : undefined,
+			tagRegistry[id]?.tombstoned ? undefined : tagRegistry[id],
+		),
+		getTagRecord: vi.fn((id: string) => tagRegistry[id]),
+		getTags: vi.fn(() =>
+			Object.values(tagRegistry).filter(tag => !tag.tombstoned),
+		),
+		findTagByName: vi.fn((name: string) =>
+			Object.values(tagRegistry).find(
+				tag => !tag.tombstoned && tag.name === name,
+			),
 		),
 		getContributor: vi.fn((id: string) => contributorRegistry[id]),
 		getCommentsByIssue: vi.fn(() => []),
@@ -1380,6 +1401,117 @@ describe('mcp tools', () => {
 				payload: {id: 'contributor-1'},
 			}),
 		]);
+	});
+
+	describe('tag tombstoning', () => {
+		const asDeleted = () => {
+			tagRegistry['tag-1'] = {id: 'tag-1', name: 'bug', tombstoned: true};
+		};
+
+		const persistedEvents = () =>
+			(persistModule.materializeAndPersistAll as ReturnType<typeof vi.fn>).mock
+				.calls[0]?.[0];
+
+		it('writes a tombstone for a live tag', async () => {
+			const result = await tools.tombstoneTag({
+				repoRoot: '/repo',
+				tagId: 'tag-1',
+			});
+
+			expect(isFail(result)).toBe(false);
+			if (!isFail(result)) {
+				expect(result.value).toEqual({id: 'tag-1', name: 'bug'});
+			}
+			expect(persistedEvents()).toEqual([
+				expect.objectContaining({
+					action: 'tombstone.tag',
+					payload: {id: 'tag-1'},
+				}),
+			]);
+		});
+
+		it('refuses an unknown or already deleted tag', async () => {
+			const missing = await tools.tombstoneTag({
+				repoRoot: '/repo',
+				tagId: 'tag-9',
+			});
+			expect(isFail(missing)).toBe(true);
+
+			asDeleted();
+			const twice = await tools.tombstoneTag({
+				repoRoot: '/repo',
+				tagId: 'tag-1',
+			});
+			expect(isFail(twice)).toBe(true);
+			if (isFail(twice)) expect(twice.message).toBe('Tag is already deleted');
+		});
+
+		it('drops a deleted tag from the state and from its issues', async () => {
+			asDeleted();
+
+			const result = await tools.getGuiState({repoRoot: '/repo'});
+
+			expect(isFail(result)).toBe(false);
+			if (!isFail(result)) {
+				expect(result.value.tags).toEqual([]);
+				const issue = result.value.boards
+					.flatMap(board => board.swimlanes)
+					.flatMap(swimlane => swimlane.issues)
+					.find(issue => issue.id === fixtureId('issue-1'));
+				expect(issue?.tags).toEqual([]);
+			}
+		});
+
+		it('frees the name: tagging with it again mints a fresh tag', async () => {
+			asDeleted();
+
+			const result = await tools.addIssueTag({
+				repoRoot: '/repo',
+				issueId: fixtureId('issue-1'),
+				tagName: 'bug',
+			});
+
+			expect(isFail(result)).toBe(false);
+			const events = persistedEvents();
+			expect(events?.map((event: {action: string}) => event.action)).toEqual([
+				'create.tag',
+				'add.issue.tag',
+			]);
+			expect(events?.[0]?.payload?.id).not.toBe('tag-1');
+		});
+
+		it('restores a deleted tag under its own name', async () => {
+			asDeleted();
+
+			const result = await tools.restoreTag({
+				repoRoot: '/repo',
+				tagId: 'tag-1',
+			});
+
+			expect(isFail(result)).toBe(false);
+			// The name rides in the payload, so replay never reads it back.
+			expect(persistedEvents()).toEqual([
+				expect.objectContaining({
+					action: 'restore.tag',
+					payload: {id: 'tag-1', name: 'bug'},
+				}),
+			]);
+		});
+
+		it('refuses to restore a live tag, or one whose name was reused', async () => {
+			const live = await tools.restoreTag({repoRoot: '/repo', tagId: 'tag-1'});
+			expect(isFail(live)).toBe(true);
+			if (isFail(live)) expect(live.message).toBe('Tag is not deleted');
+
+			asDeleted();
+			tagRegistry['tag-2'] = {id: 'tag-2', name: 'bug'};
+			const taken = await tools.restoreTag({
+				repoRoot: '/repo',
+				tagId: 'tag-1',
+			});
+			expect(isFail(taken)).toBe(true);
+			if (isFail(taken)) expect(taken.message).toContain('already named');
+		});
 	});
 
 	describe('restoreContributor', () => {

--- a/source/test/commands.test.ts
+++ b/source/test/commands.test.ts
@@ -28,7 +28,10 @@ vi.mock('../lib/storage/paths.js', () => ({
 	getGlobalConfigDir: vi.fn(() => '/home/test/.epiq-global'),
 }));
 
-vi.mock('../lib/repository/node-repo.js', () => ({
+// Only the ancestor walk is stubbed; the repo itself reads the real state
+// these tests build.
+vi.mock('../lib/repository/node-repo.js', async importOriginal => ({
+	...(await importOriginal<typeof import('../lib/repository/node-repo.js')>()),
 	findAncestor: vi.fn(),
 }));
 

--- a/source/test/event-materialize.test.ts
+++ b/source/test/event-materialize.test.ts
@@ -422,3 +422,66 @@ describe('contributor tombstone round-trip', () => {
 		expect(isFail(result)).toBe(true);
 	});
 });
+
+describe('tag tombstone round-trip', () => {
+	const TAG = '01H00000000000000000000200';
+
+	it('hides the tag on tombstone and shows it again on restore', () => {
+		setupWorkspace();
+
+		expectOk(materialize(event('create.tag', {id: TAG, name: 'bug'})));
+		expectOk(materialize(event('add.issue.tag', {id: IDS.issue, tag: TAG})));
+		expect(nodeRepo.getTag(TAG)?.name).toBe('bug');
+
+		expectOk(materialize(event('tombstone.tag', {id: TAG})));
+		// Absent to every reader, present as a record.
+		expect(nodeRepo.getTag(TAG)).toBeUndefined();
+		expect(nodeRepo.getTagRecord(TAG)?.tombstoned).toBe(true);
+		expect(nodeRepo.findTagByName('bug')).toBeUndefined();
+		expect(nodeRepo.getTags()).toEqual([]);
+
+		expectOk(materialize(event('restore.tag', {id: TAG, name: 'bug'})));
+		expect(nodeRepo.getTag(TAG)?.name).toBe('bug');
+		expect(nodeRepo.getTagRecord(TAG)?.tombstoned).toBe(false);
+	});
+
+	// The id is why this is a tombstone and not a deletion.
+	it('keeps the ticket reference across the whole sequence', () => {
+		setupWorkspace();
+
+		materializeAll([
+			event('create.tag', {id: TAG, name: 'bug'}),
+			event('add.issue.tag', {id: IDS.issue, tag: TAG}),
+			event('tombstone.tag', {id: TAG}),
+		] as const);
+
+		const issue = nodeRepo.getNode(IDS.issue);
+		expect(isTicketNode(issue!) ? issue.props.tags : undefined).toContain(TAG);
+	});
+
+	it('skips tagging with a deleted tag but still allows untagging', () => {
+		setupWorkspace();
+
+		materializeAll([
+			event('create.tag', {id: TAG, name: 'bug'}),
+			event('add.issue.tag', {id: IDS.issue, tag: TAG}),
+			event('tombstone.tag', {id: TAG}),
+		] as const);
+
+		expect(
+			isFail(materialize(event('add.issue.tag', {id: IDS.issue, tag: TAG}))),
+		).toBe(true);
+		expectOk(materialize(event('remove.issue.tag', {id: IDS.issue, tag: TAG})));
+	});
+
+	it('fails for a tag that does not exist', () => {
+		setupWorkspace();
+
+		expect(isFail(materialize(event('tombstone.tag', {id: IDS.missing})))).toBe(
+			true,
+		);
+		expect(
+			isFail(materialize(event('restore.tag', {id: IDS.missing, name: 'x'}))),
+		).toBe(true);
+	});
+});


### PR DESCRIPTION
Closes nothing on the board automatically — ticket 0P8ZXS5.

## What
- `tombstone.tag` / `restore.tag` events. Ids and ticket references are permanent; a tombstoned tag keeps its record but reads as absent everywhere (`nodeRepo.getTag`), which hides it from ticket chips, pickers, filters, TUI badges and the GUI state at once. `getTagRecord` is the raw read.
- Replay: `add.issue.tag` against a deleted tag is a `materializeSkip`; `remove.issue.tag` still clears the reference.
- A deleted tag's name is free again: tagging with it mints a fresh tag. Restore refuses while another live tag holds the name.
- MCP: `epiq_tag_remove`, `epiq_tag_restore`.
- GUI: "manage tags…" modal next to the tag picker, arm-then-confirm delete, same shape as "manage contributors…".
- Log labels: "Deleted tag" / "Restored tag"; scrubber buckets both under tagging.

## Tests
- Materialize round-trip, ticket reference survival, skip-on-tag/allow-untag, missing ids.
- MCP: remove/refuse-twice, hidden from GUI state and issues, name freed on re-tag, restore payload carries the name, restore refused when live or name reused.
- Pre-push gate green (lint, typecheck, unit incl. replay equivalence, containers, collab, GUI e2e).
- Manually verified in a scratch project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KubtnkwMMd99upedNUf2Ut