### PR TITLE
Q2H8QTG add a text filter that narrows the GUI board by ref or title

### DIFF
--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -38,6 +38,7 @@ import {reconnectDelayMs} from './lib/reconnect';
 import {moveSwimlane} from './lib/gui-move-swimlane';
 import {DropTarget} from './lib/gui-result.model';
 import {nodeRef} from '../../lib/utils/node-ref.js';
+import {issueMatchesText} from '../../lib/utils/text-match.js';
 import {
 	findBoard,
 	findIssue,
@@ -60,6 +61,7 @@ import {
 	GuiUser,
 } from './lib/gui-state.model';
 import {buildBoardFilter, issuePassesBoardFilter} from './lib/scrubber';
+import {Input} from './components/FormPrimitives';
 import {useBoardSelection} from './lib/use-board-selection';
 import {sendSocketJson} from './lib/socket-send';
 import {createHistoryBuffer} from './lib/history-buffer';
@@ -316,6 +318,10 @@ export const App = () => {
 		comments: GuiComment[];
 		history: GuiIssueHistoryEntry[];
 	} | null>(null);
+	// Typed into the box beside the board switcher; hides cards whose ref and
+	// title both miss it. Not part of the URL selection: it is a passing
+	// narrowing, not a view worth linking to.
+	const [textFilter, setTextFilter] = useState('');
 	// Null unless the selection has been narrowed to particular tags or people.
 	const boardFilter = useMemo(
 		() => buildBoardFilter(selection.view, selection.only),
@@ -350,17 +356,22 @@ export const App = () => {
 	// new identity every time and undo its memoization.
 	const {visibleSwimlanes, hiddenIssueCount} = useMemo(() => {
 		const swimlanes = selectedBoard?.swimlanes ?? [];
-		if (!boardFilter) return {visibleSwimlanes: swimlanes, hiddenIssueCount: 0};
+		const query = textFilter.trim();
+		if (!boardFilter && !query)
+			return {visibleSwimlanes: swimlanes, hiddenIssueCount: 0};
 
 		let hidden = 0;
 
 		const visible = swimlanes.map(swimlane => {
-			const issues = swimlane.issues.filter(issue =>
-				issuePassesBoardFilter(
-					issue,
-					(commentsByIssueId[issue.id] ?? []).map(comment => comment.author.id),
-					boardFilter,
-				),
+			const issues = swimlane.issues.filter(
+				issue =>
+					issuePassesBoardFilter(
+						issue,
+						(commentsByIssueId[issue.id] ?? []).map(
+							comment => comment.author.id,
+						),
+						boardFilter,
+					) && issueMatchesText(issue, query),
 			);
 
 			hidden += swimlane.issues.length - issues.length;
@@ -369,7 +380,7 @@ export const App = () => {
 		});
 
 		return {visibleSwimlanes: visible, hiddenIssueCount: hidden};
-	}, [selectedBoard, boardFilter, commentsByIssueId]);
+	}, [selectedBoard, boardFilter, textFilter, commentsByIssueId]);
 	const attachmentsByIssueId = state?.attachmentsByIssueId ?? {};
 	const [attachmentUploadStatus, setAttachmentUploadStatus] =
 		useState<AttachmentUploadStatus>({state: 'idle'});
@@ -1528,6 +1539,23 @@ export const App = () => {
 								}
 								placeholder="Loading..."
 								onSelect={selectBoard}
+							/>
+
+							<Input
+								data-testid="text-filter"
+								type="search"
+								value={textFilter}
+								placeholder="filter by ref or title"
+								aria-label="Filter tickets by ref or title"
+								spellCheck={false}
+								onChange={event => setTextFilter(event.target.value)}
+								onKeyDown={event => {
+									if (event.key === 'Escape') {
+										setTextFilter('');
+										event.currentTarget.blur();
+									}
+								}}
+								style={{width: 220, padding: '5px 10px', fontSize: 12}}
 							/>
 						</div>
 

--- a/source/lib/utils/filter.ts
+++ b/source/lib/utils/filter.ts
@@ -2,6 +2,7 @@ import {Filter} from '../model/app-state.model.js';
 import {NavNode} from '../model/navigation-node.model.js';
 import {getState} from '../state/state.js';
 import {nodeRefMatches} from './node-ref.js';
+import {normalizeText, textIncludes} from './text-match.js';
 
 export type FilterField =
 	| 'all'
@@ -10,8 +11,6 @@ export type FilterField =
 	| 'tag'
 	| 'assignee'
 	| 'ref';
-
-const normalize = (value: string) => value.trim().toLocaleLowerCase();
 
 const getTagNames = (ticket: NavNode<'TICKET'>): string[] => {
 	const {tags} = getState();
@@ -36,27 +35,23 @@ export const ticketMatchesFilter = (
 	ticket: NavNode<'TICKET'>,
 	filter: Filter,
 ): boolean => {
-	const query = normalize(filter.value);
+	const query = normalizeText(filter.value);
 	if (!query) return true;
 
 	switch (filter.target) {
-		case 'title': {
-			const title = normalize(ticket.title ?? '');
-			return title.includes(query);
-		}
+		case 'title':
+			return textIncludes(ticket.title ?? '', query);
 
-		case 'description': {
-			const description = normalize(ticket.props.description ?? '');
-			return description.includes(query);
-		}
+		case 'description':
+			return textIncludes(ticket.props.description ?? '', query);
 
 		case 'tag': {
-			const tagNames = getTagNames(ticket).map(normalize);
+			const tagNames = getTagNames(ticket).map(normalizeText);
 			return tagNames.some(tag => tag.includes(query));
 		}
 
 		case 'assignee': {
-			const assigneeNames = getAssigneeNames(ticket).map(normalize);
+			const assigneeNames = getAssigneeNames(ticket).map(normalizeText);
 			return assigneeNames.some(name => name.includes(query));
 		}
 
@@ -65,10 +60,10 @@ export const ticketMatchesFilter = (
 		}
 
 		// case 'all': {
-		// 	const title = normalize(ticket.title ?? '');
-		// 	const description = normalize(ticket.props.description ?? '');
-		// 	const tagNames = getTagNames(ticket).map(normalize);
-		// 	const assigneeNames = getAssigneeNames(ticket).map(normalize);
+		// 	const title = normalizeText(ticket.title ?? '');
+		// 	const description = normalizeText(ticket.props.description ?? '');
+		// 	const tagNames = getTagNames(ticket).map(normalizeText);
+		// 	const assigneeNames = getAssigneeNames(ticket).map(normalizeText);
 
 		// 	return (
 		// 		title.includes(query) ||

--- a/source/lib/utils/text-match.ts
+++ b/source/lib/utils/text-match.ts
@@ -1,0 +1,20 @@
+import {nodeRefMatches} from './node-ref.js';
+
+// Shared by the TUI's `:filter` and the GUI's text filter, so the two agree on
+// what a query matches.
+export const normalizeText = (value: string): string =>
+	value.trim().toLocaleLowerCase();
+
+export const textIncludes = (haystack: string, query: string): boolean =>
+	normalizeText(haystack).includes(normalizeText(query));
+
+// A ticket matches on its ref (same rules as `nodeRefMatches`) or its title.
+// An empty query matches everything.
+export const issueMatchesText = (
+	issue: {id: string; title: string},
+	query: string,
+): boolean => {
+	if (!normalizeText(query)) return true;
+
+	return nodeRefMatches(issue.id, query) || textIncludes(issue.title, query);
+};

--- a/source/test/e2e-gui/text-filter.pw.ts
+++ b/source/test/e2e-gui/text-filter.pw.ts
@@ -1,0 +1,58 @@
+import type {Page} from '@playwright/test';
+import {expect, test} from './fixtures.js';
+
+const card = (page: Page, title: string) =>
+	page.locator('[draggable="true"]').filter({hasText: title});
+
+const addTicket = async (page: Page, title: string) => {
+	await page.getByTitle('Add issue').first().click();
+	await page.getByPlaceholder('issue name').fill(title);
+	await page.getByPlaceholder('issue name').press('Enter');
+	await expect(page.locator('aside')).toContainText(title);
+};
+
+test('typing in the text filter narrows the board by title or ref, and Escape clears it', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+	const boardUrl = page.url();
+
+	const stamp = Date.now();
+	const apple = `Apple ${stamp}`;
+	const banana = `Banana ${stamp}`;
+
+	await addTicket(page, apple);
+	await addTicket(page, banana);
+
+	await page.goto(boardUrl);
+	await expect(card(page, apple)).toBeVisible();
+	await expect(card(page, banana)).toBeVisible();
+
+	const bananaRef = (
+		await card(page, banana).locator('button[title^="Copy "]').textContent()
+	)?.trim();
+	expect(bananaRef).toMatch(/^[A-Z0-9]{7}$/);
+
+	const filter = page.getByTestId('text-filter');
+
+	// By title, ignoring case.
+	await filter.fill(`apple ${stamp}`);
+	await expect(card(page, banana)).toHaveCount(0);
+	await expect(card(page, apple)).toBeVisible();
+
+	// By ref, ignoring case.
+	await filter.fill(bananaRef!.toLowerCase());
+	await expect(card(page, apple)).toHaveCount(0);
+	await expect(card(page, banana)).toBeVisible();
+
+	// Escape empties the box and brings everything back.
+	await filter.press('Escape');
+	await expect(filter).toHaveValue('');
+	await expect(card(page, apple)).toBeVisible();
+	await expect(card(page, banana)).toBeVisible();
+
+	expect(pageErrors).toEqual([]);
+});

--- a/source/test/text-match.test.ts
+++ b/source/test/text-match.test.ts
@@ -1,0 +1,35 @@
+import {describe, expect, it} from 'vitest';
+import {issueMatchesText, textIncludes} from '../lib/utils/text-match.js';
+
+const issue = {id: '01KS22YK9AXCMATZXTR5JZCS5M', title: 'Fix the Login bug'};
+
+describe('textIncludes', () => {
+	it('ignores case and surrounding whitespace', () => {
+		expect(textIncludes('Fix the Login bug', '  login ')).toBe(true);
+		expect(textIncludes('Fix the Login bug', 'logout')).toBe(false);
+	});
+});
+
+describe('issueMatchesText', () => {
+	it('matches everything on an empty or blank query', () => {
+		expect(issueMatchesText(issue, '')).toBe(true);
+		expect(issueMatchesText(issue, '   ')).toBe(true);
+	});
+
+	it('matches the title case-insensitively', () => {
+		expect(issueMatchesText(issue, 'login')).toBe(true);
+		expect(issueMatchesText(issue, 'LOGIN BUG')).toBe(true);
+		expect(issueMatchesText(issue, 'signup')).toBe(false);
+	});
+
+	it('matches the ref like nodeRefMatches does', () => {
+		expect(issueMatchesText(issue, '5JZCS5M')).toBe(true);
+		expect(issueMatchesText(issue, '5jz-cs5m')).toBe(true);
+		expect(issueMatchesText(issue, 'zcs5')).toBe(true);
+		expect(issueMatchesText(issue, '5JZCS5X')).toBe(false);
+	});
+
+	it('does not match on the rest of the id', () => {
+		expect(issueMatchesText(issue, '01KS22')).toBe(false);
+	});
+});


### PR DESCRIPTION
Ticket Q2H8QTG.

- Text box beside the board switcher; a card stays when its ref (same rules as \`nodeRefMatches\`) or title matches, case-insensitively. Escape clears.
- Composes with the scrubber's tag/assignee/author filter with AND, inside the same \`visibleSwimlanes\` memo; an empty query still returns the lanes untouched.
- Match core lifted into \`source/lib/utils/text-match.ts\`; the TUI's \`:filter title|description\` now goes through it too.
- Descriptions are out of scope on purpose — they are stripped from the client broadcast (\`slim-state.ts\`).

Tests: \`text-match.test.ts\` (unit), \`e2e-gui/text-filter.pw.ts\` (browser: title, ref, Escape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm6V5Piof6nGkKdVEDrSwQ