### PR TITLE
MNJVG4S diff-linked bodies render their own lead text

### DIFF
--- a/source/gui/client/components/IssueComments.tsx
+++ b/source/gui/client/components/IssueComments.tsx
@@ -9,6 +9,7 @@ import {timeAgo} from '../lib/gui-format.helper';
 import {
 	DiffLocation,
 	diffLocationFromMeta,
+	extractCommentLead,
 	extractCommentSnippet,
 	formatSelectionLabel,
 	parseDiffCommentMeta,
@@ -41,6 +42,7 @@ export const CommentBody = ({
 	}
 
 	const location = diffLocationFromMeta(meta);
+	const lead = extractCommentLead(body);
 	const caption = `${meta.issueRef ? `${meta.issueRef} · ` : ''}${
 		meta.filePath
 	} ${formatSelectionLabel(meta)}`;
@@ -49,7 +51,7 @@ export const CommentBody = ({
 		// A flex column: sibling margins don't collapse here, so the gap between
 		// note and snippet is the gap it says it is.
 		<div style={{display: 'flex', flexDirection: 'column', gap: 12}}>
-			{meta.note && <MarkdownContent content={meta.note} softBreaks />}
+			{lead && <MarkdownContent content={lead} softBreaks />}
 
 			{/* Only clickable when the marker recorded which commit the selection
 			    came from — a file can appear in several of a ticket's commits, so
@@ -103,7 +105,10 @@ export const IssueComments = ({
 
 	const startEditing = (comment: GuiComment) => {
 		const meta = parseDiffCommentMeta(comment.body);
-		setEditing({id: comment.id, text: meta ? meta.note : comment.body});
+		setEditing({
+			id: comment.id,
+			text: meta ? extractCommentLead(comment.body) : comment.body,
+		});
 	};
 
 	const saveEdit = (comment: GuiComment) => {

--- a/source/gui/client/components/IssueCommits.test.ts
+++ b/source/gui/client/components/IssueCommits.test.ts
@@ -4,6 +4,7 @@ import {
 	dedent,
 	diffLocationFromMeta,
 	encodeDiffCommentMarker,
+	extractCommentLead,
 	extractCommentSnippet,
 	extractSnippet,
 	findDiffCommentsForFile,
@@ -423,5 +424,41 @@ describe('findDiffCommentsForFile', () => {
 		expect(
 			findDiffCommentsForFile([{...comment, isDeleted: true}], 'source/a.ts'),
 		).toHaveLength(0);
+	});
+});
+
+describe('extractCommentLead', () => {
+	const marker = encodeDiffCommentMarker({
+		filePath: 'source/a.ts',
+		start: 2,
+		side: 'additions',
+		end: 3,
+		endSide: 'additions',
+		note: 'as written',
+	});
+	const tail = ['`source/a.ts` lines 2–3 (added)', '```', 'code', '```'];
+
+	it('is the text before the caption and snippet, not the marker copy', () => {
+		const body = ['as written', '', marker, ...tail].join('\n');
+		expect(extractCommentLead(body)).toBe('as written');
+
+		const edited = [
+			'as written',
+			'',
+			'and more, by hand',
+			'',
+			marker,
+			...tail,
+		].join('\n');
+		expect(extractCommentLead(edited)).toBe('as written\n\nand more, by hand');
+	});
+
+	it('is empty for a body that is only the quote', () => {
+		expect(extractCommentLead([marker, ...tail].join('\n'))).toBe('');
+	});
+
+	it('keeps a caption-shaped line that is part of the text', () => {
+		const body = ['see `source/b.ts` too', '', marker, ...tail].join('\n');
+		expect(extractCommentLead(body)).toBe('see `source/b.ts` too');
 	});
 });

--- a/source/gui/client/components/IssueCommits.tsx
+++ b/source/gui/client/components/IssueCommits.tsx
@@ -206,6 +206,20 @@ const SNIPPET_FENCE = /```\n([\s\S]*?)\n?```\s*$/;
 export const extractCommentSnippet = (body: string): string | null =>
 	SNIPPET_FENCE.exec(body)?.[1] ?? null;
 
+// The caption line the GUI writes right above the fence: the quoted file in
+// backticks, then the line range.
+const CAPTION_LINE = /`[^`\n]+`[^\n]*\n?$/;
+
+// What a diff-linked body says in its own words: everything before the
+// marker's caption and quoted snippet. Read off the body rather than the
+// marker's `note` copy, so text typed into the body by hand (a description
+// edited in the Overview, a comment edited from the TUI) still shows.
+export const extractCommentLead = (body: string): string =>
+	stripDiffCommentMarker(body)
+		.replace(SNIPPET_FENCE, '')
+		.replace(CAPTION_LINE, '')
+		.trim();
+
 // What a "File ticket" submission carries up to the caller that owns the
 // actual issues:create call and the origin-ticket back-comment — everything
 // needed to build both without the caller re-deriving any of it.


### PR DESCRIPTION
Review finding on #133–#136 (ticket MNJVG4S).

`CommentBody` rendered `meta.note` from the marker JSON and ignored the body's own leading text. Identical when the GUI wrote the body, but a filed ticket's description can be edited by hand in the Overview (the editor shows the raw marker) and a comment can be edited from the TUI/MCP — anything typed outside the marker's note then never rendered. Now `extractCommentLead` reads the text before the caption line and snippet fence, and both the rendered body and the inline editor's prefill use it. Unit-tested; e2e and unit suites green.