### PR TITLE
0P8ZXS5 attribute tag deletion and restore to the tag on the timeline

### DIFF
--- a/source/lib/event/event.model.ts
+++ b/source/lib/event/event.model.ts
@@ -82,7 +82,10 @@ export type AppEventMap = {
 		result: Tag;
 	};
 
-	/** Undoes a `tombstone.tag`. Carries the name so replay never reads it back off earlier events. */
+	/**
+	 * Undoes a `tombstone.tag`. Carries the name so replay never has to read
+	 * it back off earlier events.
+	 */
 	'restore.tag': {
 		payload: PayloadBase & {name: string};
 		result: Tag;

--- a/source/mcp/epiq-time-travel.ts
+++ b/source/mcp/epiq-time-travel.ts
@@ -130,21 +130,32 @@ const buildNameIndex = (events: AppEvent[]): Map<string, string> => {
 	return names;
 };
 
+// Which tag an event is about. Tagging a ticket names it as `tag`; deleting or
+// restoring the tag itself names it as the event's own `id`.
+const tagOf = (event: AppEvent): string | undefined => {
+	// Optional like filterEventsForBoard's: a malformed log entry must not take
+	// the whole timeline down with it.
+	const payload = event.payload as {id?: string; tag?: string} | undefined;
+
+	return event.action === 'tombstone.tag' || event.action === 'restore.tag'
+		? payload?.id
+		: payload?.tag;
+};
+
 // The TUI's phrasing minus the details that need state. A renamed tag reads
 // under its original name, which is what the log itself says happened.
 const describeTimelineEvent = (
 	event: AppEvent,
 	names: Map<string, string>,
 ): string => {
-	// Optional like filterEventsForBoard's: a malformed log entry must not take
-	// the whole timeline down with it.
 	const payload = event.payload as
-		| {name?: string; tag?: string; assignee?: string}
+		| {name?: string; assignee?: string}
 		| undefined;
+	const tag = tagOf(event);
 
 	const detail =
-		payload?.tag !== undefined
-			? names.get(payload.tag) ?? ''
+		tag !== undefined
+			? names.get(tag) ?? ''
 			: payload?.assignee !== undefined
 			? names.get(payload.assignee) ?? ''
 			: payload?.name !== undefined
@@ -173,9 +184,7 @@ const identitiesFor = (
 	event: AppEvent,
 	names: Map<string, string>,
 ): Pick<EventTimelineEntry, 'actor' | 'tag' | 'assignee'> => {
-	const payload = event.payload as
-		| {tag?: string; assignee?: string}
-		| undefined;
+	const payload = event.payload as {assignee?: string} | undefined;
 
 	return {
 		actor: event.userId
@@ -185,7 +194,7 @@ const identitiesFor = (
 					color: getStringColor(event.userName ?? event.userId),
 			  }
 			: null,
-		tag: identityFor(payload?.tag, names),
+		tag: identityFor(tagOf(event), names),
 		assignee: identityFor(payload?.assignee, names),
 	};
 };

--- a/source/test/epiq-time-travel.test.ts
+++ b/source/test/epiq-time-travel.test.ts
@@ -367,6 +367,44 @@ describe('epiq-time-travel', () => {
 			expect(result.value.events.at(-1)?.label).toBe('Tagged with bug');
 		});
 
+		// Deleting or restoring names the tag as the event's own id, so the Tags
+		// view can colour and untick those dots like any other tagging event.
+		it('attributes a tag deletion and restore to the tag itself', async () => {
+			const baseTime = 1_700_000_000_000;
+			const events = [
+				{
+					id: ulid(baseTime),
+					action: 'create.tag',
+					payload: {id: 'tag-1', name: 'bug'},
+				},
+				{
+					id: ulid(baseTime + 1_000),
+					action: 'tombstone.tag',
+					payload: {id: 'tag-1'},
+				},
+				{
+					id: ulid(baseTime + 2_000),
+					action: 'restore.tag',
+					payload: {id: 'tag-1', name: 'bug'},
+				},
+			];
+
+			vi.mocked(loadMergedEvents).mockReturnValue(
+				succeeded('events', events as never),
+			);
+
+			const result = await getEventTimeline();
+
+			expect(isSuccess(result)).toBe(true);
+			if (isFail(result)) return;
+
+			const [, deleted, restored] = result.value.events;
+			expect(deleted?.label).toBe('Deleted tag bug');
+			expect(deleted?.tag?.id).toBe('tag-1');
+			expect(restored?.label).toBe('Restored tag bug');
+			expect(restored?.tag?.id).toBe('tag-1');
+		});
+
 		it('sorts the entries by time regardless of log order', async () => {
 			const baseTime = 1_700_000_000_000;
 			const events = [

--- a/source/test/filter.test.ts
+++ b/source/test/filter.test.ts
@@ -1,0 +1,36 @@
+import {describe, expect, it, vi} from 'vitest';
+import {Filter} from '../lib/model/app-state.model.js';
+import {nodes} from '../lib/state/node-builder.js';
+import {ticketMatchesFilter} from '../lib/utils/filter.js';
+
+vi.mock('../lib/state/state.js', () => ({
+	getState: () => ({
+		tags: {
+			live: {id: 'live', name: 'bug'},
+			gone: {id: 'gone', name: 'urgent', tombstoned: true},
+		},
+		contributors: {},
+	}),
+}));
+
+describe('tag filter', () => {
+	const ticket = {
+		...nodes.ticket('01KS22YK9AXCMATZXTR5JZCS5M', 'Fix bug', 'lane', 'a0'),
+	};
+	ticket.props.tags = ['live', 'gone'];
+
+	const byTag = (value: string): Filter => ({
+		target: 'tag',
+		operator: '=',
+		value,
+	});
+
+	it('matches a live tag on the ticket', () => {
+		expect(ticketMatchesFilter(ticket, byTag('bug'))).toBe(true);
+	});
+
+	// The reference is still on the ticket; only the tag has been deleted.
+	it('ignores a deleted tag the ticket still references', () => {
+		expect(ticketMatchesFilter(ticket, byTag('urgent'))).toBe(false);
+	});
+});


### PR DESCRIPTION
Follow-up to #137 from a post-merge review of the tag tombstone work.

- On the scrubber's Tags view, `tombstone.tag` / `restore.tag` dots carried no tag identity (the tag is the event's own `id`, not `tag`), so they drew in the plain accent colour, couldn't be unticked, and the label read as a bare "Deleted tag". They are now attributed to the tag, with its name in the label.
- Wraps an over-long doc comment on `restore.tag`.
- Tests: timeline attribution for both events (red without the fix), and the TUI filter ignoring a deleted tag a ticket still references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KubtnkwMMd99upedNUf2Ut