### PR TITLE
1J98GDN TUI comments wrap; 2STENR2 fenced code and diff captions in the TUI

### DIFF
--- a/source/gui/client/components/IssueCommits.tsx
+++ b/source/gui/client/components/IssueCommits.tsx
@@ -10,6 +10,15 @@ import {
 	GuiRefCommitEntry,
 } from '../lib/gui-state.model';
 import {CONTENT_FONT, GUI_THEME, TEXT} from '../lib/gui-theme';
+import {
+	DiffCommentMeta,
+	encodeDiffCommentMarker,
+	extractCommentSnippet,
+	formatSelectionLabel,
+	isSelectionSide,
+	parseDiffCommentMeta,
+	stripDiffCommentMarker,
+} from '../../../lib/utils/diff-comment.js';
 import {timeAgo} from '../lib/gui-format.helper';
 import {ActionRow, Textarea} from './FormPrimitives';
 import {Button} from './Button';
@@ -64,14 +73,7 @@ export const extractSnippet = (
 	return [...startHalf, ...endHalf].join('\n');
 };
 
-export const formatSelectionLabel = (range: SelectedLineRange): string => {
-	const endSide = range.endSide ?? range.side;
-	const sideLabel = endSide === 'deletions' ? 'removed' : 'added';
-
-	return range.start === range.end
-		? `line ${range.start} (${sideLabel})`
-		: `lines ${range.start}-${range.end} (${sideLabel})`;
-};
+export {formatSelectionLabel} from '../../../lib/utils/diff-comment.js';
 
 // Quoted lines keep their real source indentation (often several tabs deep
 // inside nested JSX) — fine in the wide diff, unreadable in a narrow comment
@@ -92,98 +94,17 @@ export const dedent = (snippet: string): string => {
 	return lines.map(line => line.slice(commonIndent)).join('\n');
 };
 
-// Metadata for a diff-selection comment, carried as an HTML-comment-shaped
-// marker in the posted body — round-trips through storage intact with no
-// separate field needed on GuiComment. react-markdown does *not* silently
-// drop `<!-- ... -->` without rehype-raw as might be assumed — it renders
-// the literal text — so every render path showing a comment body must strip
-// it via stripDiffCommentMarker below rather than relying on the markdown
-// renderer to hide it.
-export type DiffCommentMeta = {
-	filePath: string;
-	start: number;
-	side: SelectionSide;
-	end: number;
-	endSide: SelectionSide;
-	note: string;
-	// Which commit's diff the selection was made in — a file can appear in
-	// several of a ticket's commits, so linking back needs it. Optional
-	// because comments written before it was recorded should still render
-	// their inline annotation; they just aren't clickable.
-	sha?: string;
-	// The ticket whose Commits tab holds the diff, when it isn't the one the
-	// marker sits on — a ticket filed from a selection points back at its
-	// origin this way.
-	issueRef?: string;
-};
-
-const DIFF_COMMENT_MARKER = /<!--\s*epiq-diff-comment:(.+?)-->\n?/;
-
-export const stripDiffCommentMarker = (body: string): string =>
-	body.replace(DIFF_COMMENT_MARKER, '');
-
-// `>` is escaped so a note containing `-->` cannot terminate the marker early
-// — that truncated the JSON (losing the annotation) and left the remainder
-// visible as garbage in the rendered comment. JSON.parse decodes > back
-// to `>`, so the round trip is exact.
-export const encodeDiffCommentMarker = (meta: DiffCommentMeta): string =>
-	`<!-- epiq-diff-comment:${JSON.stringify(meta).replaceAll(
-		'>',
-		'\\u003e',
-	)} -->`;
-
-const isSelectionSide = (value: unknown): value is SelectionSide =>
-	value === 'additions' || value === 'deletions';
-
-export const parseDiffCommentMeta = (body: string): DiffCommentMeta | null => {
-	const match = DIFF_COMMENT_MARKER.exec(body);
-	if (!match?.[1]) return null;
-
-	let parsed: unknown;
-	try {
-		parsed = JSON.parse(match[1]);
-	} catch {
-		return null;
-	}
-
-	const meta = parsed as Partial<DiffCommentMeta> | null;
-
-	if (
-		typeof meta?.filePath !== 'string' ||
-		typeof meta.start !== 'number' ||
-		typeof meta.end !== 'number' ||
-		typeof meta.note !== 'string' ||
-		!isSelectionSide(meta.side) ||
-		!isSelectionSide(meta.endSide) ||
-		(meta.sha !== undefined && typeof meta.sha !== 'string') ||
-		(meta.issueRef !== undefined && typeof meta.issueRef !== 'string')
-	) {
-		return null;
-	}
-
-	return meta as DiffCommentMeta;
-};
-
-// The body of a diff-selection comment with its note replaced and everything
-// else — marker location, caption, quoted snippet — kept as it was. Null for a
-// body that carries no marker.
-export const withDiffCommentNote = (
-	body: string,
-	note: string,
-): string | null => {
-	const meta = parseDiffCommentMeta(body);
-	const match = DIFF_COMMENT_MARKER.exec(body);
-	if (!meta || !match) return null;
-
-	const trimmed = note.trim();
-	const rest = body.slice(match.index + match[0].length);
-
-	return [
-		...(trimmed ? [trimmed, ''] : []),
-		encodeDiffCommentMarker({...meta, note: trimmed}),
-		rest,
-	].join('\n');
-};
+// The marker codec lives in lib so the TUI renders the same bodies; the GUI
+// keeps reaching it through this module.
+export {
+	encodeDiffCommentMarker,
+	extractCommentLead,
+	extractCommentSnippet,
+	parseDiffCommentMeta,
+	stripDiffCommentMarker,
+	withDiffCommentNote,
+} from '../../../lib/utils/diff-comment.js';
+export type {DiffCommentMeta} from '../../../lib/utils/diff-comment.js';
 
 export type DiffComment = {comment: GuiComment; meta: DiffCommentMeta};
 
@@ -196,29 +117,6 @@ export const findDiffCommentsForFile = (
 		const meta = parseDiffCommentMeta(comment.body);
 		return meta && meta.filePath === filePath ? [{comment, meta}] : [];
 	});
-
-// The fenced block a diff-selection comment's body ends with. Pulled back out
-// so the snippet can be rendered as real highlighted code instead of markdown
-// text — the body keeps carrying it verbatim so the comment still reads
-// correctly anywhere that only knows how to render markdown.
-const SNIPPET_FENCE = /```\n([\s\S]*?)\n?```\s*$/;
-
-export const extractCommentSnippet = (body: string): string | null =>
-	SNIPPET_FENCE.exec(body)?.[1] ?? null;
-
-// The caption line the GUI writes right above the fence: the quoted file in
-// backticks, then the line range.
-const CAPTION_LINE = /`[^`\n]+`[^\n]*\n?$/;
-
-// What a diff-linked body says in its own words: everything before the
-// marker's caption and quoted snippet. Read off the body rather than the
-// marker's `note` copy, so text typed into the body by hand (a description
-// edited in the Overview, a comment edited from the TUI) still shows.
-export const extractCommentLead = (body: string): string =>
-	stripDiffCommentMarker(body)
-		.replace(SNIPPET_FENCE, '')
-		.replace(CAPTION_LINE, '')
-		.trim();
 
 // What a "File ticket" submission carries up to the caller that owns the
 // actual issues:create call and the origin-ticket back-comment — everything

--- a/source/lib/components/CommentListUI.tsx
+++ b/source/lib/components/CommentListUI.tsx
@@ -17,12 +17,17 @@ import {virtualNodeId} from '../virtual-nodes/virtual-ids.js';
 import {AssigneeUI} from './Assignee.js';
 import {ScrollBoxUI} from './ScrollBox.js';
 import {CommentItem, createCommentNode} from '../utils/comment.utils.js';
+import {renderMarkdownLines} from '../utils/markdown-lite.js';
+import {MarkdownLinesUI} from './MarkdownLinesUI.js';
 
 type Props = {
 	ticket: Ticket;
 	width: number;
 	height: number;
 };
+
+// Top border, two header rows, one row of padding under the body.
+const CARD_CHROME_ROWS = 4;
 
 const getCommentsRootNodeId = (ticketId: string) =>
 	virtualNodeId(ticketId, 'comments');
@@ -69,14 +74,6 @@ const attachCommentNodes = (
 	return nodes;
 };
 
-const renderCommentBody = (md: string, maxLength: number) => {
-	const normalized = md.replace(/\s+/g, ' ').trim();
-
-	if (normalized.length <= maxLength) return normalized;
-
-	return `${normalized.slice(0, Math.max(0, maxLength - 1))}…`;
-};
-
 export function CommentListUI({ticket, width, height}: Props) {
 	const comments = useMemo(() => getCommentItems(ticket), [ticket]);
 
@@ -97,6 +94,18 @@ export function CommentListUI({ticket, width, height}: Props) {
 	const padding = 4;
 	const scrollHeight = Math.max(1, height - padding);
 	const bodyWidth = Math.max(20, width - 8);
+
+	// Every row a comment needs, so nothing is cut: header, the wrapped body,
+	// and the card's own border and padding (CARD_CHROME_ROWS of them).
+	const bodies = useMemo(
+		() =>
+			comments.map(comment => {
+				const lines = renderMarkdownLines(comment.md, bodyWidth);
+				return lines.length > 0 ? lines : [{kind: 'blank' as const}];
+			}),
+		[comments, bodyWidth],
+	);
+	const itemHeights = bodies.map(lines => lines.length + CARD_CHROME_ROWS);
 
 	if (comments.length === 0) {
 		return (
@@ -128,7 +137,7 @@ export function CommentListUI({ticket, width, height}: Props) {
 
 			<ScrollBoxUI
 				height={scrollHeight}
-				itemHeight={4}
+				itemHeights={itemHeights}
 				selectedIndex={selectedIndex}
 			>
 				{comments.map((comment, index) => {
@@ -157,9 +166,10 @@ export function CommentListUI({ticket, width, height}: Props) {
 							</Box>
 
 							<Box paddingLeft={3} paddingBottom={1}>
-								<Text color={theme.primary}>
-									{renderCommentBody(comment.md, bodyWidth)}
-								</Text>
+								<MarkdownLinesUI
+									lines={bodies[index] ?? []}
+									width={bodyWidth}
+								/>
 							</Box>
 						</Box>
 					);

--- a/source/lib/components/InlineEditor.tsx
+++ b/source/lib/components/InlineEditor.tsx
@@ -8,6 +8,12 @@ import {theme} from '../theme/themes.js';
 import {truncateWithEllipsis} from '../utils/string.utils.js';
 import {CursorUI} from './Cursor.js';
 import {ScrollBoxUI} from './ScrollBox.js';
+import {RenderedLineUI} from './MarkdownLinesUI.js';
+import {
+	classifyRows,
+	inlineSpans,
+	RenderedLine,
+} from '../utils/markdown-lite.js';
 import {bigIntToHex} from '../utils/rank.js';
 
 type Props = {
@@ -89,9 +95,30 @@ export const InlineEditor: React.FC<Props> = ({
 		};
 	}, [id, rowKey]);
 
-	const renderMarkdownInline = (md: string) => String(md).replace(/\r?\n/g, '');
+	// Styled row for row, so the line numbers keep pointing at the text
+	// they name; a row wider than the box is cut, as before.
+	const rowWidth = maxWidth - 10;
+	const styledRows = useMemo(
+		() =>
+			classifyRows(rows).map((line): RenderedLine => {
+				if (line.kind === 'code') {
+					return {...line, text: truncateWithEllipsis(line.text, rowWidth)};
+				}
+				if (line.kind === 'text' || line.kind === 'heading') {
+					const text = line.spans
+						.map(span => (span.code ? `\`${span.text}\`` : span.text))
+						.join('');
+					return {
+						...line,
+						spans: inlineSpans(truncateWithEllipsis(text, rowWidth)),
+					};
+				}
+				return line;
+			}),
+		[rows, rowWidth],
+	);
 
-	const renderedItems = rows.map((row, i) => {
+	const renderedItems = styledRows.map((line, i) => {
 		const isSel = contextNode.id === id && selectedIndex === i;
 
 		return (
@@ -103,13 +130,18 @@ export const InlineEditor: React.FC<Props> = ({
 					{`${i + 1}   `.padStart(5, '\u00A0')}
 				</Text>
 
-				<Text backgroundColor={isSel ? 'gray' : undefined}>
-					{renderMarkdownInline(
-						row.length
-							? truncateWithEllipsis(row, maxWidth - 10)
-							: EMPTY_ROW_FALLBACK,
-					)}
-				</Text>
+				{line.kind === 'blank' ? (
+					<Text backgroundColor={isSel ? 'gray' : undefined}>
+						{EMPTY_ROW_FALLBACK}
+					</Text>
+				) : (
+					<Box>
+						<RenderedLineUI
+							line={line}
+							width={line.kind === 'code' ? rowWidth : 0}
+						/>
+					</Box>
+				)}
 			</Box>
 		);
 	});

--- a/source/lib/components/MarkdownLinesUI.tsx
+++ b/source/lib/components/MarkdownLinesUI.tsx
@@ -1,0 +1,81 @@
+import {Box, Text} from 'ink';
+import React from 'react';
+import {theme} from '../theme/themes.js';
+import {RenderedLine, Span} from '../utils/markdown-lite.js';
+
+const SpansUI = ({spans, bold}: {spans: Span[]; bold?: boolean}) => (
+	<Text color={theme.primary} bold={bold}>
+		{spans.map((span, index) =>
+			span.code ? (
+				<Text key={index} color={theme.yellow}>
+					{span.text}
+				</Text>
+			) : (
+				<Text key={index}>{span.text}</Text>
+			),
+		)}
+	</Text>
+);
+
+// One rendered line. `width` is what a code line is padded to, so a fenced
+// block reads as a block rather than a ragged right edge.
+export const RenderedLineUI = ({
+	line,
+	width,
+	gutter = 0,
+}: {
+	line: RenderedLine;
+	width: number;
+	gutter?: number;
+}) => {
+	switch (line.kind) {
+		case 'blank':
+			return <Text> </Text>;
+		case 'fence':
+			return <Text color={theme.secondary2}>```</Text>;
+		case 'caption':
+			return <Text color={theme.accent}>{line.text}</Text>;
+		case 'heading':
+			return <SpansUI spans={line.spans} bold />;
+		case 'text':
+			return <SpansUI spans={line.spans} />;
+		case 'code': {
+			const number =
+				gutter > 0
+					? `${line.number === undefined ? '' : String(line.number)}`.padStart(
+							gutter - 3,
+					  ) + ' │ '
+					: '';
+			return (
+				<Text backgroundColor={theme.secondary} color={theme.primary}>
+					{number}
+					{line.text.padEnd(Math.max(0, width - number.length))}
+				</Text>
+			);
+		}
+	}
+};
+
+export const MarkdownLinesUI = ({
+	lines,
+	width,
+}: {
+	lines: RenderedLine[];
+	width: number;
+}) => {
+	const numbers = lines.flatMap(line =>
+		line.kind === 'code' && line.number !== undefined ? [line.number] : [],
+	);
+	const gutter =
+		numbers.length > 0 ? String(Math.max(...numbers)).length + 3 : 0;
+
+	return (
+		<Box flexDirection="column">
+			{lines.map((line, index) => (
+				<Box key={index}>
+					<RenderedLineUI line={line} width={width} gutter={gutter} />
+				</Box>
+			))}
+		</Box>
+	);
+};

--- a/source/lib/components/ScrollBox.tsx
+++ b/source/lib/components/ScrollBox.tsx
@@ -7,7 +7,34 @@ type Props = {
 	height: number; // height in terminal rows
 	selectedIndex: number;
 	itemHeight?: number;
+	// Per-child heights, for children that are not all the same size. The
+	// window then holds whichever run of children fits around the selection.
+	itemHeights?: number[];
 	scrollByOne?: boolean;
+};
+
+const windowByHeights = (
+	heights: number[],
+	count: number,
+	selected: number,
+	height: number,
+): {start: number; end: number} => {
+	const heightAt = (index: number) => Math.max(1, heights[index] ?? 1);
+
+	let start = selected;
+	let end = selected + 1;
+	let used = heightAt(selected);
+
+	while (end < count && used + heightAt(end) <= height) {
+		used += heightAt(end);
+		end++;
+	}
+	while (start > 0 && used + heightAt(start - 1) <= height) {
+		start--;
+		used += heightAt(start);
+	}
+
+	return {start, end};
 };
 
 export const ScrollBoxUI: React.FC<Props> = ({
@@ -15,6 +42,7 @@ export const ScrollBoxUI: React.FC<Props> = ({
 	height,
 	selectedIndex,
 	itemHeight = 1,
+	itemHeights,
 	scrollByOne = false,
 }) => {
 	if (children.length === 0) {
@@ -24,26 +52,51 @@ export const ScrollBoxUI: React.FC<Props> = ({
 	const safeHeight = Math.max(1, Math.floor(height));
 	const safeItemHeight = Math.max(1, Math.ceil(itemHeight));
 
-	const visibleItemCount = Math.max(1, Math.floor(safeHeight / safeItemHeight));
-
 	const clampedSelectedIndex = Math.max(
 		0,
 		Math.min(selectedIndex, children.length - 1),
 	);
 
-	const maxStart = Math.max(0, children.length - visibleItemCount);
+	const uniformVisibleCount = Math.max(
+		1,
+		Math.floor(safeHeight / safeItemHeight),
+	);
+	const maxStart = Math.max(0, children.length - uniformVisibleCount);
 
-	const start = scrollByOne
-		? Math.min(
-				maxStart,
-				Math.max(0, clampedSelectedIndex - visibleItemCount + 1),
+	const {start, end} = itemHeights
+		? windowByHeights(
+				itemHeights,
+				children.length,
+				clampedSelectedIndex,
+				safeHeight,
 		  )
-		: Math.min(
-				maxStart,
-				Math.floor(clampedSelectedIndex / visibleItemCount) * visibleItemCount,
-		  );
+		: scrollByOne
+		? {
+				start: Math.min(
+					maxStart,
+					Math.max(0, clampedSelectedIndex - uniformVisibleCount + 1),
+				),
+				end:
+					Math.min(
+						maxStart,
+						Math.max(0, clampedSelectedIndex - uniformVisibleCount + 1),
+					) + uniformVisibleCount,
+		  }
+		: {
+				start: Math.min(
+					maxStart,
+					Math.floor(clampedSelectedIndex / uniformVisibleCount) *
+						uniformVisibleCount,
+				),
+				end:
+					Math.min(
+						maxStart,
+						Math.floor(clampedSelectedIndex / uniformVisibleCount) *
+							uniformVisibleCount,
+					) + uniformVisibleCount,
+		  };
 
-	const end = start + visibleItemCount;
+	const visibleItemCount = Math.max(1, end - start);
 	const visibleChildren = children.slice(start, end);
 
 	const showScrollbar = children.length > visibleItemCount;

--- a/source/lib/utils/diff-comment.ts
+++ b/source/lib/utils/diff-comment.ts
@@ -1,0 +1,138 @@
+// A comment made on a selection in a commit diff carries where it was made as
+// an HTML-comment-shaped marker in its body, followed by a caption line and
+// the quoted lines in a fence. The body stays readable anywhere that only
+// knows markdown; anything that knows the marker can do better.
+
+export type SelectionSide = 'additions' | 'deletions';
+
+export type SelectionRange = {
+	start: number;
+	end: number;
+	side?: SelectionSide;
+	endSide?: SelectionSide;
+};
+
+export type DiffCommentMeta = {
+	filePath: string;
+	start: number;
+	side: SelectionSide;
+	end: number;
+	endSide: SelectionSide;
+	note: string;
+	// Which commit's diff the selection was made in — a file can appear in
+	// several of a ticket's commits, so linking back needs it. Optional
+	// because comments written before it was recorded should still render
+	// their inline annotation; they just aren't clickable.
+	sha?: string;
+	// The ticket whose Commits tab holds the diff, when it isn't the one the
+	// marker sits on — a ticket filed from a selection points back at its
+	// origin this way.
+	issueRef?: string;
+};
+
+const DIFF_COMMENT_MARKER = /<!--\s*epiq-diff-comment:(.+?)-->\n?/;
+
+export const stripDiffCommentMarker = (body: string): string =>
+	body.replace(DIFF_COMMENT_MARKER, '');
+
+// `>` is escaped so a note containing `-->` cannot terminate the marker early
+// — that truncated the JSON (losing the annotation) and left the remainder
+// visible as garbage in the rendered comment. JSON.parse decodes > back
+// to `>`, so the round trip is exact.
+export const encodeDiffCommentMarker = (meta: DiffCommentMeta): string =>
+	`<!-- epiq-diff-comment:${JSON.stringify(meta).replaceAll(
+		'>',
+		'\\u003e',
+	)} -->`;
+
+export const isSelectionSide = (value: unknown): value is SelectionSide =>
+	value === 'additions' || value === 'deletions';
+
+export const parseDiffCommentMeta = (body: string): DiffCommentMeta | null => {
+	const match = DIFF_COMMENT_MARKER.exec(body);
+	if (!match?.[1]) return null;
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(match[1]);
+	} catch {
+		return null;
+	}
+
+	const meta = parsed as Partial<DiffCommentMeta> | null;
+
+	if (
+		typeof meta?.filePath !== 'string' ||
+		typeof meta.start !== 'number' ||
+		typeof meta.end !== 'number' ||
+		typeof meta.note !== 'string' ||
+		!isSelectionSide(meta.side) ||
+		!isSelectionSide(meta.endSide) ||
+		(meta.sha !== undefined && typeof meta.sha !== 'string') ||
+		(meta.issueRef !== undefined && typeof meta.issueRef !== 'string')
+	) {
+		return null;
+	}
+
+	return meta as DiffCommentMeta;
+};
+
+// The body of a diff-selection comment with its note replaced and everything
+// else — marker location, caption, quoted snippet — kept as it was. Null for a
+// body that carries no marker.
+export const withDiffCommentNote = (
+	body: string,
+	note: string,
+): string | null => {
+	const meta = parseDiffCommentMeta(body);
+	const match = DIFF_COMMENT_MARKER.exec(body);
+	if (!meta || !match) return null;
+
+	const trimmed = note.trim();
+	const rest = body.slice(match.index + match[0].length);
+
+	return [
+		...(trimmed ? [trimmed, ''] : []),
+		encodeDiffCommentMarker({...meta, note: trimmed}),
+		rest,
+	].join('\n');
+};
+
+// The fenced block a diff-selection comment's body ends with. Pulled back out
+// so the snippet can be rendered as real code instead of markdown text — the
+// body keeps carrying it verbatim so the comment still reads correctly
+// anywhere that only knows how to render markdown.
+const SNIPPET_FENCE = /```\n([\s\S]*?)\n?```\s*$/;
+
+export const extractCommentSnippet = (body: string): string | null =>
+	SNIPPET_FENCE.exec(body)?.[1] ?? null;
+
+// The caption line written right above the fence: the quoted file in
+// backticks, then the line range.
+const CAPTION_LINE = /`[^`\n]+`[^\n]*\n?$/;
+
+// What a diff-linked body says in its own words: everything before the
+// marker's caption and quoted snippet. Read off the body rather than the
+// marker's `note` copy, so text typed into the body by hand (a description
+// edited in the Overview, a comment edited from the TUI) still shows.
+export const extractCommentLead = (body: string): string =>
+	stripDiffCommentMarker(body)
+		.replace(SNIPPET_FENCE, '')
+		.replace(CAPTION_LINE, '')
+		.trim();
+
+export const formatSelectionLabel = (range: SelectionRange): string => {
+	const endSide = range.endSide ?? range.side;
+	const sideLabel = endSide === 'deletions' ? 'removed' : 'added';
+
+	return range.start === range.end
+		? `line ${range.start} (${sideLabel})`
+		: `lines ${range.start}-${range.end} (${sideLabel})`;
+};
+
+// What a diff-linked body is headed by wherever it is shown: the origin
+// ticket when there is one, the file, the line range.
+export const formatDiffCaption = (meta: DiffCommentMeta): string =>
+	`${meta.issueRef ? `${meta.issueRef} · ` : ''}${
+		meta.filePath
+	} ${formatSelectionLabel(meta)}`;

--- a/source/lib/utils/markdown-lite.ts
+++ b/source/lib/utils/markdown-lite.ts
@@ -1,0 +1,176 @@
+import {
+	extractCommentLead,
+	extractCommentSnippet,
+	formatDiffCaption,
+	parseDiffCommentMeta,
+	stripDiffCommentMarker,
+} from './diff-comment.js';
+
+// The little markdown a terminal can honour: paragraphs, headings, fenced
+// code, inline code, and the diff marker rendered as its caption. Everything
+// else is left as the text it is.
+
+export type Span = {text: string; code?: boolean};
+
+export type RenderedLine =
+	| {kind: 'text'; spans: Span[]}
+	| {kind: 'heading'; spans: Span[]}
+	| {kind: 'code'; text: string; number?: number}
+	| {kind: 'fence'}
+	| {kind: 'caption'; text: string}
+	| {kind: 'blank'};
+
+// Word wrap; a word longer than the width is cut rather than overflowing.
+export const wrapText = (text: string, width: number): string[] => {
+	const safeWidth = Math.max(1, Math.floor(width));
+	const words = text.split(/\s+/).filter(Boolean);
+	if (words.length === 0) return [''];
+
+	const lines: string[] = [];
+	let current = '';
+
+	for (const word of words) {
+		let rest = word;
+
+		while (rest.length > safeWidth) {
+			if (current) {
+				lines.push(current);
+				current = '';
+			}
+			lines.push(rest.slice(0, safeWidth));
+			rest = rest.slice(safeWidth);
+		}
+
+		if (!current) {
+			current = rest;
+		} else if (current.length + 1 + rest.length <= safeWidth) {
+			current = `${current} ${rest}`;
+		} else {
+			lines.push(current);
+			current = rest;
+		}
+	}
+
+	if (current) lines.push(current);
+
+	return lines;
+};
+
+// Backtick pairs become code spans; an unbalanced backtick leaves the line
+// as plain text rather than guessing where the code was meant to end.
+export const inlineSpans = (text: string): Span[] => {
+	const parts = text.split('`');
+	if (parts.length % 2 === 0) return [{text}];
+
+	return parts
+		.map((part, index) =>
+			index % 2 === 1 ? {text: part, code: true} : {text: part},
+		)
+		.filter(span => span.text.length > 0);
+};
+
+const spansToText = (spans: Span[]): string =>
+	spans.map(span => (span.code ? `\`${span.text}\`` : span.text)).join('');
+
+// One rendered line per source row, nothing wrapped or dropped: what a
+// line-numbered view needs, since its rows have to keep lining up with the
+// text they came from. The marker row becomes its caption; fence rows stay.
+export const classifyRows = (rows: string[]): RenderedLine[] => {
+	let inFence = false;
+
+	return rows.map((row): RenderedLine => {
+		if (/^\s*```/.test(row)) {
+			inFence = !inFence;
+			return {kind: 'fence'};
+		}
+		if (inFence) return {kind: 'code', text: row};
+
+		const meta = parseDiffCommentMeta(row);
+		if (meta) return {kind: 'caption', text: formatDiffCaption(meta)};
+
+		if (row.trim() === '') return {kind: 'blank'};
+
+		const heading = /^#{1,6}\s+(.*)$/.exec(row);
+		if (heading) return {kind: 'heading', spans: inlineSpans(heading[1] ?? '')};
+
+		return {kind: 'text', spans: inlineSpans(row)};
+	});
+};
+
+const hardWrap = (text: string, width: number): string[] =>
+	text.length <= width
+		? [text]
+		: text.match(new RegExp(`.{1,${width}}`, 'g')) ?? [''];
+
+const flow = (rows: string[], width: number): RenderedLine[] => {
+	const out: RenderedLine[] = [];
+
+	for (const line of classifyRows(rows)) {
+		if (line.kind === 'fence') continue;
+
+		if (line.kind === 'blank') {
+			if (out.length > 0 && out[out.length - 1]?.kind !== 'blank')
+				out.push(line);
+			continue;
+		}
+
+		if (line.kind === 'code') {
+			for (const text of hardWrap(line.text, width))
+				out.push({kind: 'code', text});
+			continue;
+		}
+
+		if (line.kind === 'caption') {
+			out.push(line);
+			continue;
+		}
+
+		for (const piece of wrapText(spansToText(line.spans), width)) {
+			out.push({kind: line.kind, spans: inlineSpans(piece)});
+		}
+	}
+
+	while (out.length > 0 && out[out.length - 1]?.kind === 'blank') out.pop();
+
+	return out;
+};
+
+// Wrapped to a width, blank runs collapsed: what a comment card needs. A
+// diff-linked body renders as its own words, then the caption, then the
+// quoted lines numbered as they were where they came from.
+export const renderMarkdownLines = (
+	md: string,
+	width: number,
+): RenderedLine[] => {
+	const meta = parseDiffCommentMeta(md);
+	const snippet = meta ? extractCommentSnippet(md) : null;
+
+	if (!meta || snippet === null) {
+		return flow(stripDiffCommentMarker(md).split('\n'), width);
+	}
+
+	const lead = extractCommentLead(md);
+	const lines = snippet.split('\n');
+	// A range crossing from deletions into additions quotes both halves,
+	// which no single run of numbers describes.
+	const startLine = meta.side === meta.endSide ? meta.start : undefined;
+	const gutter =
+		startLine === undefined
+			? 0
+			: String(startLine + lines.length - 1).length + 3;
+
+	return [
+		...(lead
+			? [...flow(lead.split('\n'), width), {kind: 'blank'} as const]
+			: []),
+		{kind: 'caption', text: formatDiffCaption(meta)},
+		...lines.flatMap((text, index) =>
+			hardWrap(text, Math.max(1, width - gutter)).map((piece, chunk) => ({
+				kind: 'code' as const,
+				text: piece,
+				number:
+					startLine === undefined || chunk > 0 ? undefined : startLine + index,
+			})),
+		),
+	];
+};

--- a/source/test/e2e/comments.e2e.test.ts
+++ b/source/test/e2e/comments.e2e.test.ts
@@ -1,0 +1,68 @@
+import {beforeAll, describe, expect, it} from 'vitest';
+import {commonSteps} from './e2e-common-steps.js';
+import {ARROW_DOWN, ENTER, setupTui} from './e2e.helper.js';
+
+const testTimeout = 60_000;
+const EMPTY_CMD = 'for command line';
+
+type Tui = ReturnType<typeof setupTui>;
+
+const run = async (tui: Tui, cmd: string, echo: string) => {
+	tui.input(cmd);
+	await tui.waitFor(echo, 4_000);
+	tui.input(ENTER);
+	await tui.waitFor(EMPTY_CMD, 5_000);
+};
+
+beforeAll(async () => {
+	const tui = setupTui();
+	try {
+		await commonSteps.configureInitialSettings(tui);
+	} finally {
+		await tui.destroy();
+	}
+});
+
+describe('TUI comments', () => {
+	it(
+		'wraps a long comment onto more rows instead of cutting it off',
+		async () => {
+			const tui = setupTui();
+			try {
+				await commonSteps.init(tui);
+				tui.input(ENTER);
+				await tui.waitFor('Todo (0)');
+
+				await run(tui, ':new issue Wrap test', 'new issue Wrap test');
+				await tui.waitFor('Todo (1)', 4_000);
+
+				// Longer than the 120-column terminal, so the end can only be seen
+				// on a second row.
+				const tail = 'lands on its own row';
+				const body = `${'a fairly long remark that keeps going '.repeat(
+					3,
+				)}${tail}`;
+				await run(tui, `:comment ${body}`, 'comment a fairly');
+
+				// Into the ticket, down to its Comments field, and in.
+				tui.input(ENTER);
+				await tui.waitFor('Comments (1) ››', 4_000);
+				// Description, Assignees, Tags, History come first; stop on Comments.
+				for (let step = 0; step < 6; step++) {
+					if (/❯\s+Comments \(1\)/.test(tui.output())) break;
+					tui.input(ARROW_DOWN);
+					await new Promise(resolve => setTimeout(resolve, 150));
+				}
+				await tui.waitFor(/❯\s+Comments \(1\)/, 4_000);
+				tui.input(ENTER);
+				await tui.waitFor('#1 ', 4_000);
+
+				await tui.waitFor(tail, 4_000);
+				expect(tui.output()).not.toContain('…');
+			} finally {
+				await tui.destroy();
+			}
+		},
+		testTimeout,
+	);
+});

--- a/source/test/markdown-lite.test.ts
+++ b/source/test/markdown-lite.test.ts
@@ -1,0 +1,138 @@
+import {describe, expect, it} from 'vitest';
+import {encodeDiffCommentMarker} from '../lib/utils/diff-comment.js';
+import {
+	classifyRows,
+	inlineSpans,
+	renderMarkdownLines,
+	wrapText,
+} from '../lib/utils/markdown-lite.js';
+
+describe('wrapText', () => {
+	it('breaks at spaces and never past the width', () => {
+		expect(wrapText('the quick brown fox jumps', 10)).toEqual([
+			'the quick',
+			'brown fox',
+			'jumps',
+		]);
+	});
+
+	it('cuts a word longer than the width', () => {
+		expect(wrapText('abcdefghij', 4)).toEqual(['abcd', 'efgh', 'ij']);
+	});
+
+	it('gives one empty line for empty text', () => {
+		expect(wrapText('   ', 10)).toEqual(['']);
+	});
+});
+
+describe('inlineSpans', () => {
+	it('marks backtick pairs as code', () => {
+		expect(inlineSpans('run `npm test` now')).toEqual([
+			{text: 'run '},
+			{text: 'npm test', code: true},
+			{text: ' now'},
+		]);
+	});
+
+	it('leaves an unbalanced backtick alone', () => {
+		expect(inlineSpans('a ` b')).toEqual([{text: 'a ` b'}]);
+	});
+});
+
+describe('classifyRows', () => {
+	it('keeps one line per row and styles fences, headings and the marker', () => {
+		const marker = encodeDiffCommentMarker({
+			filePath: 'a.ts',
+			start: 3,
+			side: 'additions',
+			end: 5,
+			endSide: 'additions',
+			note: '',
+		});
+		const rows = ['# Title', '', marker, '```', 'code', '```', 'after'];
+
+		expect(classifyRows(rows).map(line => line.kind)).toEqual([
+			'heading',
+			'blank',
+			'caption',
+			'fence',
+			'code',
+			'fence',
+			'text',
+		]);
+		expect(classifyRows(rows)[2]).toEqual({
+			kind: 'caption',
+			text: 'a.ts lines 3-5 (added)',
+		});
+	});
+});
+
+describe('renderMarkdownLines', () => {
+	it('wraps paragraphs, drops fence rows and collapses blank runs', () => {
+		const md = 'one two three four\n\n\n```\nlet x = 1;\n```\n';
+
+		expect(renderMarkdownLines(md, 9)).toEqual([
+			{kind: 'text', spans: [{text: 'one two'}]},
+			{kind: 'text', spans: [{text: 'three'}]},
+			{kind: 'text', spans: [{text: 'four'}]},
+			{kind: 'blank'},
+			{kind: 'code', text: 'let x = 1'},
+			{kind: 'code', text: ';'},
+		]);
+	});
+
+	it('renders a diff-linked body as lead, caption and numbered snippet', () => {
+		const marker = encodeDiffCommentMarker({
+			filePath: 'src/a.ts',
+			start: 12,
+			side: 'additions',
+			end: 13,
+			endSide: 'additions',
+			note: 'looks off',
+			issueRef: 'ABCDEFG',
+		});
+		const md = [
+			'looks off',
+			'',
+			marker,
+			'`src/a.ts` lines 12-13 (added)',
+			'```',
+			'const a = 1;',
+			'const b = 2;',
+			'```',
+		].join('\n');
+
+		expect(renderMarkdownLines(md, 40)).toEqual([
+			{kind: 'text', spans: [{text: 'looks off'}]},
+			{kind: 'blank'},
+			{kind: 'caption', text: 'ABCDEFG · src/a.ts lines 12-13 (added)'},
+			{kind: 'code', text: 'const a = 1;', number: 12},
+			{kind: 'code', text: 'const b = 2;', number: 13},
+		]);
+	});
+
+	it('leaves numbers off a snippet that spans both sides', () => {
+		const marker = encodeDiffCommentMarker({
+			filePath: 'a.ts',
+			start: 1,
+			side: 'deletions',
+			end: 2,
+			endSide: 'additions',
+			note: '',
+		});
+		const md = [
+			marker,
+			'`a.ts` lines 1-2 (added)',
+			'```',
+			'x',
+			'y',
+			'```',
+		].join('\n');
+
+		expect(renderMarkdownLines(md, 40)).toEqual([
+			{kind: 'caption', text: 'a.ts lines 1-2 (added)'},
+			{kind: 'code', text: 'x', number: undefined},
+			{kind: 'code', text: 'y', number: undefined},
+		]);
+	});
+});


### PR DESCRIPTION
Two tickets.

**1J98GDN — comments were cut to one ellipsised line.** `CommentListUI` collapsed a body to one line and the scroll box assumed 4 rows per comment, so anything longer than a line — every diff-linked comment included — vanished behind an ellipsis. Bodies now wrap across the rows they need and `ScrollBoxUI` takes per-item heights, keeping the selected comment in view. TUI e2e `comments.e2e.test.ts` posts a comment longer than the terminal and asserts its tail is on screen with no ellipsis — red on main, green here.

**2STENR2 — light markdown in the TUI.** `lib/utils/markdown-lite.ts` renders paragraphs (wrapped), headings, fenced code as a padded block, inline code, and the diff marker as its caption (origin ticket · file · lines). Diff-linked comments show lead text, caption, then the snippet numbered as it was in the file. The description view keeps its row-per-line model (line numbers still point at the text) and styles rows in place. The marker codec moved from the GUI to `lib/utils/diff-comment.ts` so both UIs share it; the GUI re-exports it from `IssueCommits`, so nothing else changed there.

Not changed: a description row wider than the box is still cut (line-numbered view), and the short-terminal overlap of the last visible row with the box border is pre-existing (verified identical on main).