### PR TITLE
SWTV1Z6 scrubber commit dots open the diff inside the linked ticket

### DIFF
--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -27,6 +27,7 @@ import {
 	formatSelectionLabel,
 	clearDiffLocationParams,
 	DiffLocation,
+	readCommitFocusParam,
 	encodeDiffCommentMarker,
 	readDiffLocationParams,
 	writeDiffLocationParams,
@@ -43,6 +44,7 @@ import {moveSwimlane} from './lib/gui-move-swimlane';
 import {DropTarget} from './lib/gui-result.model';
 import {nodeRef} from '../../lib/utils/node-ref.js';
 import {issueMatchesText} from '../../lib/utils/text-match.js';
+import {commitTicketRef} from '../../lib/utils/commit-ref.js';
 import {
 	findBoard,
 	findIssue,
@@ -245,7 +247,8 @@ export const App = () => {
 			: 'overview';
 	// Where a followed comment permalink points, if any. Read straight off the
 	// URL so the deep link survives a reload rather than living in state.
-	const diffFocus = readDiffLocationParams(searchParams);
+	const diffFocus =
+		readDiffLocationParams(searchParams) ?? readCommitFocusParam(searchParams);
 	const navigate = useNavigate();
 
 	// Route params carry shorthand refs (full ids in old links still resolve).
@@ -1105,13 +1108,30 @@ export const App = () => {
 		setPickedIssueIds([]);
 	}, [selectedBoardId]);
 
-	const openCommitDiff = useCallback((sha: string) => {
-		setCommitDiff({sha, loading: true, error: null, files: null});
-		sendSocketJson(socketRef.current, {
-			type: 'commit:diff:get',
-			payload: {sha},
-		});
-	}, []);
+	// A commit that links to a ticket is read on that ticket's Commits tab,
+	// next to its comments and the rest of its commits; only one that links
+	// nowhere gets the bare panel.
+	const openCommitDiff = useCallback(
+		(sha: string) => {
+			const subject =
+				history.commits.find(commit => commit.sha === sha)?.subject ?? '';
+			const ref = commitTicketRef(subject, knownTicketRefs);
+
+			if (ref && boardSlug) {
+				void navigate(
+					`/board/${boardSlug}/issue/${ref}?tab=code&commit=${sha}`,
+				);
+				return;
+			}
+
+			setCommitDiff({sha, loading: true, error: null, files: null});
+			sendSocketJson(socketRef.current, {
+				type: 'commit:diff:get',
+				payload: {sha},
+			});
+		},
+		[history.commits, knownTicketRefs, boardSlug, navigate],
+	);
 
 	const closeCommitDiff = useCallback(() => setCommitDiff(null), []);
 

--- a/source/gui/client/components/IssueCommits.tsx
+++ b/source/gui/client/components/IssueCommits.tsx
@@ -180,6 +180,17 @@ export const writeDiffLocationParams = (
 	params.set('endSide', location.endSide);
 };
 
+// A deep link that names only a commit: open it, nothing narrower to show.
+// A full DiffLocation is one of these too.
+export type CommitFocus = {sha: string} & Partial<Omit<DiffLocation, 'sha'>>;
+
+export const readCommitFocusParam = (
+	params: URLSearchParams,
+): CommitFocus | null => {
+	const sha = params.get('commit');
+	return sha ? {sha} : null;
+};
+
 export const clearDiffLocationParams = (params: URLSearchParams): void => {
 	for (const key of DIFF_LOCATION_PARAMS) params.delete(key);
 };
@@ -694,7 +705,7 @@ const CommitRow = ({
 	onFileTicket?: (params: FileTicketParams) => void;
 	comments: GuiComment[];
 	// Non-null only on the commit a permalink points at.
-	focus?: DiffLocation | null;
+	focus?: CommitFocus | null;
 }) => {
 	const [hovered, setHovered] = useState(false);
 	// Also tracks focus (not just mouse hover): the copy button is a real
@@ -819,7 +830,11 @@ const CommitRow = ({
 							onFileTicket={onFileTicket}
 							comments={comments}
 							focusRange={
-								focus?.filePath === file.path
+								focus?.filePath === file.path &&
+								focus.start !== undefined &&
+								focus.end !== undefined &&
+								focus.side &&
+								focus.endSide
 									? {
 											start: focus.start,
 											end: focus.end,
@@ -873,7 +888,7 @@ export const IssueCommits = ({
 	onFileTicket?: (params: FileTicketParams) => void;
 	comments: GuiComment[];
 	// Where a comment permalink points, read from the URL by the caller.
-	focus?: DiffLocation | null;
+	focus?: CommitFocus | null;
 	// Open every commit and file as it appears — for a layout meant for
 	// reading rather than scanning. Each is opened once, so collapsing it by
 	// hand afterwards sticks.
@@ -931,7 +946,7 @@ export const IssueCommits = ({
 	// link into a tab you were already using doesn't throw your place away.
 	// Keyed on the location's own values rather than object identity, which
 	// the caller rebuilds from URL params on every render.
-	const focusKey = focus ? `${focus.sha}:${focus.filePath}` : null;
+	const focusKey = focus ? `${focus.sha}:${focus.filePath ?? ''}` : null;
 
 	useEffect(() => {
 		if (!focus) return;
@@ -940,12 +955,15 @@ export const IssueCommits = ({
 			prev.has(focus.sha) ? prev : new Set(prev).add(focus.sha),
 		);
 
+		const filePath = focus.filePath;
+		if (filePath === undefined) return;
+
 		setExpandedFilesBySha(prev =>
-			prev[focus.sha]?.has(focus.filePath)
+			prev[focus.sha]?.has(filePath)
 				? prev
 				: {
 						...prev,
-						[focus.sha]: new Set(prev[focus.sha] ?? []).add(focus.filePath),
+						[focus.sha]: new Set(prev[focus.sha] ?? []).add(filePath),
 				  },
 		);
 	}, [focusKey]);

--- a/source/gui/client/components/IssueDetails.tsx
+++ b/source/gui/client/components/IssueDetails.tsx
@@ -34,6 +34,7 @@ import {AttachmentUploadStatus, IssueAttachments} from './IssueAttachments';
 import {CommentBody, IssueComments} from './IssueComments';
 import {
 	CommitDiffState,
+	CommitFocus,
 	DiffLocation,
 	FileTicketParams,
 	IssueCommits,
@@ -158,7 +159,7 @@ export const IssueDetails = ({
 	// Following a comment's permalink: the caller puts it in the URL, and
 	// hands back where it currently points so the Commits tab can open there.
 	onOpenDiffLocation?: (location: DiffLocation) => void;
-	diffFocus?: DiffLocation | null;
+	diffFocus?: CommitFocus | null;
 	attachments: GuiAttachment[];
 	attachmentUploadStatus: AttachmentUploadStatus;
 	onUploadAttachments?: (issueId: string, files: File[]) => void;

--- a/source/lib/utils/commit-ref.ts
+++ b/source/lib/utils/commit-ref.ts
@@ -90,3 +90,15 @@ export const checkCommitRef = (
 	// Ambiguous or ordinary prose. Not enough evidence to block a commit.
 	return {ok: true};
 };
+
+// The ticket a commit subject links to: its leading token, when that is one
+// of the refs on the board. Null for a commit that links nowhere — including
+// one whose token merely looks like a ref, which checkCommitRef is for.
+export const commitTicketRef = (
+	subject: string,
+	knownRefs: ReadonlySet<string>,
+): string | null => {
+	const token = (subject.trim().split(/\s+/)[0] ?? '').toUpperCase();
+
+	return token && knownRefs.has(token) ? token : null;
+};

--- a/source/test/commit-ref.test.ts
+++ b/source/test/commit-ref.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest';
-import {checkCommitRef} from '../lib/utils/commit-ref.js';
+import {checkCommitRef, commitTicketRef} from '../lib/utils/commit-ref.js';
 
 // Real shape: a ULID whose last 7 characters are the ref.
 const ids = [
@@ -100,5 +100,20 @@ describe('checkCommitRef', () => {
 				'01M179WTBBX27A6EKNHW1TCS1X',
 			]).ok,
 		).toBe(true);
+	});
+});
+
+describe('commitTicketRef', () => {
+	const known = new Set(['ABCDEFG', '1234567']);
+
+	it('is the leading token when it is a known ref, whatever its case', () => {
+		expect(commitTicketRef('abcdefg fix the thing', known)).toBe('ABCDEFG');
+		expect(commitTicketRef('  1234567 tidy', known)).toBe('1234567');
+	});
+
+	it('is null for a subject that links nowhere', () => {
+		expect(commitTicketRef('BUILD the thing', known)).toBeNull();
+		expect(commitTicketRef('fix ABCDEFG later', known)).toBeNull();
+		expect(commitTicketRef('', known)).toBeNull();
 	});
 });

--- a/source/test/e2e-gui/diff-composer.pw.ts
+++ b/source/test/e2e-gui/diff-composer.pw.ts
@@ -48,10 +48,19 @@ test('selecting lines opens one composer under them; write, then comment or file
 	)?.trim();
 	expect(ref).toBeTruthy();
 
-	commitLinkedFile(repoRoot, ref!, 'add notes');
+	const sha = commitLinkedFile(repoRoot, ref!, 'add notes');
 	await page.waitForTimeout(COMMIT_CACHE_MS);
 	await page.reload();
 	await expect(page.locator('aside')).toContainText(`Composer ${stamp}`);
+
+	// A link naming only the commit (what a scrubber dot opens for a linked
+	// commit) lands on the Commits tab with it open.
+	await page.goto(`${page.url().split('?')[0]}?tab=code&commit=${sha}`);
+	await expect(
+		page.getByRole('button', {name: 'add notes +3 -0'}),
+	).toHaveAttribute('aria-expanded', 'true');
+	await expect(page.getByRole('button', {name: 'notes.txt'})).toBeVisible();
+	await page.getByRole('button', {name: 'Overview'}).click();
 
 	await openDiffAndSelectLine(page, 'add notes');
 	const composer = page.getByTestId('selection-composer');

--- a/source/test/e2e-gui/linked-commit.ts
+++ b/source/test/e2e-gui/linked-commit.ts
@@ -14,7 +14,7 @@ export const commitLinkedFile = (
 	subject: string,
 	fileName = 'notes.txt',
 	contents = 'alpha\nbeta\ngamma\n',
-) => {
+): string => {
 	fs.writeFileSync(path.join(repoRoot, fileName), contents);
 	const git = (...args: string[]) =>
 		execFileSync(
@@ -24,4 +24,6 @@ export const commitLinkedFile = (
 		);
 	git('add', fileName);
 	git('commit', '-q', '-m', `${ref} ${subject}`);
+
+	return git('rev-parse', 'HEAD').toString().trim();
 };


### PR DESCRIPTION
Ticket SWTV1Z6.

Clicking a commit dot on the timeline used to open the bare diff panel. Now, when the commit's subject leads with a ref that resolves on the board (`commitTicketRef` in `lib/utils/commit-ref.ts`), it navigates to that ticket's Commits tab with the commit open — `?tab=code&commit=<sha>` — so the diff is read next to the ticket's comments and its other commits. A commit that links nowhere still gets the bare panel.

That needed a commit-only deep link: `CommitFocus` (`{sha}` plus an optional file/range) replaces `DiffLocation` as the focus type on the Commits tab; a focus without a file expands just the commit and loads its diff. Leaving the tab still clears the link, as before.

Tests: `commitTicketRef` unit cases; the composer e2e now also lands on `?tab=code&commit=<sha>` and asserts the commit is open with its file listed (`commitLinkedFile` returns the sha). The dot's hit-test is on a canvas, so the click itself isn't driven by e2e — the routing function it calls is the part with logic.