### PR TITLE
Fix the right panel's fullscreen flash and the diff headers painting over the scrubber filter

### DIFF
--- a/source/gui/client/components/Aside.tsx
+++ b/source/gui/client/components/Aside.tsx
@@ -2,6 +2,7 @@ import React, {
 	forwardRef,
 	useCallback,
 	useEffect,
+	useLayoutEffect,
 	useRef,
 	useState,
 } from 'react';
@@ -144,8 +145,11 @@ export const Aside = forwardRef<
 	// window's, not the stored one — so layout decisions track what is on
 	// screen. Fires on mount too, not just on drag, so a caller that only
 	// reads this (rather than also calling readStoredAsideWidth itself) sees
-	// the persisted width immediately.
-	useEffect(() => {
+	// the persisted width immediately. A layout effect so the caller's
+	// re-render lands before the browser paints: a passive effect would let
+	// a frame through with the panel at its new width but the content still
+	// laid out for the old one.
+	useLayoutEffect(() => {
 		onWidthChange?.(effectiveWidth);
 	}, [effectiveWidth]);
 

--- a/source/gui/client/components/Panel.tsx
+++ b/source/gui/client/components/Panel.tsx
@@ -147,10 +147,13 @@ export const Panel = <T extends ElementType = 'div'>({
 				}}
 			/>
 
+			{/* Positioned so it paints over the glow above (same z level, later in
+			    the tree), but with no z-index of its own: that would make the panel
+			    a stacking context and trap any popover inside it under positioned
+			    content elsewhere on the page. */}
 			<div
 				style={{
 					position: 'relative',
-					zIndex: 1,
 					height: '100%',
 					display: 'flex',
 					flexDirection: 'column',

--- a/source/test/e2e-gui/aside-stacking.pw.ts
+++ b/source/test/e2e-gui/aside-stacking.pw.ts
@@ -1,5 +1,6 @@
 import type {Page} from '@playwright/test';
 import {expect, test} from './fixtures.js';
+import {COMMIT_CACHE_MS, commitLinkedFile} from './linked-commit.js';
 
 const addTicket = async (page: Page, title: string) => {
 	await page.getByTitle('Add issue').first().click();
@@ -8,9 +9,84 @@ const addTicket = async (page: Page, title: string) => {
 	await expect(page.locator('aside')).toContainText(title);
 };
 
+const expandDiff = async (page: Page, subject: string) => {
+	await page.getByRole('button', {name: /^Commits/}).click();
+	for (const name of [subject, 'notes.txt']) {
+		const toggle = page.getByRole('button', {name});
+		await expect(toggle).toBeVisible();
+		if ((await toggle.getAttribute('aria-expanded')) !== 'true') {
+			await toggle.click();
+		}
+		await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+	}
+};
+
 test.beforeEach(async ({page, appUrl}) => {
 	await page.goto(appUrl);
 	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+});
+
+test('the scrubber filter list stays above a diff header in the panel', async ({
+	page,
+	pageErrors,
+	repoRoot,
+}) => {
+	// Short, so the panel has to scroll.
+	await page.setViewportSize({width: 1280, height: 480});
+	const stamp = Date.now();
+	await addTicket(page, `Stacking ${stamp}`);
+	const ref = (
+		await page.locator('aside button[title^="Copy "]').first().textContent()
+	)?.trim();
+	expect(ref).toBeTruthy();
+
+	// Long enough that the panel can scroll its header up under the popover.
+	commitLinkedFile(
+		repoRoot,
+		ref!,
+		'add notes',
+		'notes.txt',
+		Array.from({length: 60}, (_, index) => `line ${index + 1}`).join('\n') +
+			'\n',
+	);
+	await page.waitForTimeout(COMMIT_CACHE_MS);
+	await page.reload();
+	await expect(page.locator('aside')).toContainText(`Stacking ${stamp}`);
+	await expandDiff(page, 'add notes');
+
+	await page.getByText('All board events').click();
+	await expect(page.getByRole('radiogroup')).toBeVisible();
+
+	// The diff renders its own file header with a z-index inside a shadow
+	// root. Scroll it under the popover and ask the browser which is on top.
+	const onTop = await page.evaluate(`
+(() => {
+	const aside = document.querySelector('aside');
+	const popover = document.querySelector('[role="radiogroup"]');
+	const host = [...aside.querySelectorAll('*')].find(element =>
+		element.shadowRoot?.querySelector('[data-diffs-header]'),
+	);
+	const header = host.shadowRoot.querySelector('[data-diffs-header]');
+
+	const popoverBox = popover.getBoundingClientRect();
+	aside.scrollTop +=
+		header.getBoundingClientRect().top -
+		(popoverBox.top + popoverBox.height / 2);
+
+	const headerBox = header.getBoundingClientRect();
+	const left = Math.max(popoverBox.left, headerBox.left);
+	const right = Math.min(popoverBox.right, headerBox.right);
+	const top = Math.max(popoverBox.top, headerBox.top);
+	const bottom = Math.min(popoverBox.bottom, headerBox.bottom);
+	if (right <= left || bottom <= top) return 'no overlap';
+
+	const hit = document.elementFromPoint((left + right) / 2, (top + bottom) / 2);
+	return popover.contains(hit) ? 'popover' : hit?.tagName ?? 'nothing';
+})()
+`);
+	expect(onTop).toBe('popover');
+
+	expect(pageErrors).toEqual([]);
 });
 
 test('entering fullscreen lays the panel out for its full width in the same frame', async ({

--- a/source/test/e2e-gui/aside-stacking.pw.ts
+++ b/source/test/e2e-gui/aside-stacking.pw.ts
@@ -1,0 +1,43 @@
+import type {Page} from '@playwright/test';
+import {expect, test} from './fixtures.js';
+
+const addTicket = async (page: Page, title: string) => {
+	await page.getByTitle('Add issue').first().click();
+	await page.getByPlaceholder('issue name').fill(title);
+	await page.getByPlaceholder('issue name').press('Enter');
+	await expect(page.locator('aside')).toContainText(title);
+};
+
+test.beforeEach(async ({page, appUrl}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+});
+
+test('entering fullscreen lays the panel out for its full width in the same frame', async ({
+	page,
+	pageErrors,
+}) => {
+	await page.setViewportSize({width: 1600, height: 900});
+	await addTicket(page, `Frame ${Date.now()}`);
+	await expect(page.getByTestId('lane-overview')).toHaveCount(0);
+
+	// Observes the panel going fullscreen and reads the layout in that same
+	// commit: the lanes must already be there, not arrive a render later after
+	// a frame of tabs stretched across the window.
+	const lanesWhenFullscreen = await page.evaluate(`
+new Promise(resolve => {
+	const aside = document.querySelector('aside');
+	const observer = new MutationObserver(() => {
+		if (getComputedStyle(aside).position !== 'absolute') return;
+		observer.disconnect();
+		resolve(document.querySelectorAll('[data-testid="lane-overview"]').length);
+	});
+	observer.observe(aside, {attributes: true, attributeFilter: ['style']});
+	aside.querySelector('button[title="Fullscreen"]').click();
+})
+`);
+	expect(lanesWhenFullscreen).toBe(1);
+	await expect(page.getByTestId('lane-overview')).toBeVisible();
+
+	expect(pageErrors).toEqual([]);
+});


### PR DESCRIPTION
Two GUI glitches in the right panel, one commit each.

- **AAFMYR3** — toggling fullscreen showed the panel's narrow layout (unified diff / tabbed ticket) stretched across the whole window for a frame before it re-laid out as split / lanes. `Aside` reported its drawn width from a passive effect, so the caller's re-render landed a task after the panel had already grown. Now a layout effect, so the width-dependent layout is in the same commit as the size change.
- **3YWGDN4** — with a diff open in the panel, the scrubber's filter popover was hidden under the diff view's file headers. `Panel` gave its content wrapper `z-index: 1`, making every panel a stacking context; the scrubber's popover (`z-index: 30`) was trapped inside it while pierre's file header (`z-index: 2`) competed at the root. The wrapper is positioned later in the tree than the glow, so it paints over it without any z-index.

Both have e2e regressions in `aside-stacking.pw.ts`, verified red without the fixes. Full GUI suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MM8w1wVHBtY7PA9gKheFD