### PR TITLE
NDHG2BW darker background for comment code snippets

### DIFF
--- a/source/gui/client/components/CodeSnippet.tsx
+++ b/source/gui/client/components/CodeSnippet.tsx
@@ -11,6 +11,11 @@ import {IconChevronRight} from './IconChevronRight';
 // the quoting side keeps the real file path around.
 const PIERRE_THEME = 'github-dark';
 
+// The theme's own background is a near match for the comment card the
+// snippet sits in; the app's darker one keeps the two apart. The theme sets
+// `--diffs-bg` on the shadow host, where only its own CSS can reach.
+const SNIPPET_CSS = `:host { --diffs-bg: ${GUI_THEME.bg}; background-color: ${GUI_THEME.bg}; }`;
+
 const CODE_FONT =
 	'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace';
 
@@ -139,6 +144,7 @@ export const CodeSnippet = ({
 					style={
 						{
 							display: 'flex',
+							background: GUI_THEME.bg,
 							'--diffs-line-height': `${LINE_HEIGHT}px`,
 							'--diffs-font-size': `${FONT_SIZE}px`,
 							'--diffs-gap-block': `${BLOCK_GAP}px`,
@@ -175,6 +181,7 @@ export const CodeSnippet = ({
 								// snippet was taken from — the gutter beside it has those.
 								disableFileHeader: true,
 								disableLineNumbers: true,
+								unsafeCSS: SNIPPET_CSS,
 							}}
 						/>
 					</div>

--- a/source/test/e2e-gui/diff-composer.pw.ts
+++ b/source/test/e2e-gui/diff-composer.pw.ts
@@ -113,6 +113,17 @@ test('selecting lines opens one composer under them; write, then comment or file
 	await expect(page.getByTestId('code-snippet')).toContainText('beta');
 	await page.screenshot({path: testInfo.outputPath('comment-snippet.png')});
 
+	// The snippet paints the app's background, not the highlighter theme's,
+	// which is a near match for the card around it.
+	const snippetBackground = await page.evaluate<string>(`
+		(() => {
+			const snippet = document.querySelector('[data-testid="code-snippet"]');
+			const host = [...snippet.querySelectorAll('*')].find(el => el.shadowRoot);
+			return getComputedStyle(host).backgroundColor;
+		})()
+	`);
+	expect(snippetBackground).toBe('rgb(6, 7, 10)');
+
 	// Editing a diff comment edits its note; the link and snippet stay.
 	await page.getByTitle('Edit comment').click();
 	const editor = page.locator('aside textarea').first();


### PR DESCRIPTION
A snippet quoted into a comment rendered with pierre's github-dark background, a near match for the comment card it sits in. The snippet now paints the app's darker background, set through pierre's `unsafeCSS` since the theme pins `--diffs-bg` on the shadow host.

Regression assertion in the diff-composer e2e test: red without the fix (rgb 36 41 46), green with it.