### PR TITLE
2STENR2 TUI code lines: expand tabs before measuring

### DIFF
--- a/source/lib/utils/markdown-lite.ts
+++ b/source/lib/utils/markdown-lite.ts
@@ -72,13 +72,21 @@ export const inlineSpans = (text: string): Span[] => {
 const spansToText = (spans: Span[]): string =>
 	spans.map(span => (span.code ? `\`${span.text}\`` : span.text)).join('');
 
+// A terminal advances a tab to the next tab stop while string measuring
+// counts it as nothing, so a tab-indented line looks narrower than it draws
+// and overflows the box. Spaces measure as they draw.
+const TAB_WIDTH = 4;
+
+export const expandTabs = (text: string): string =>
+	text.replace(/\r$/, '').replaceAll('\t', ' '.repeat(TAB_WIDTH));
+
 // One rendered line per source row, nothing wrapped or dropped: what a
 // line-numbered view needs, since its rows have to keep lining up with the
 // text they came from. The marker row becomes its caption; fence rows stay.
-export const classifyRows = (rows: string[]): RenderedLine[] => {
+export const classifyRows = (rawRows: string[]): RenderedLine[] => {
 	let inFence = false;
 
-	return rows.map((row): RenderedLine => {
+	return rawRows.map(expandTabs).map((row): RenderedLine => {
 		if (/^\s*```/.test(row)) {
 			inFence = !inFence;
 			return {kind: 'fence'};
@@ -150,7 +158,7 @@ export const renderMarkdownLines = (
 	}
 
 	const lead = extractCommentLead(md);
-	const lines = snippet.split('\n');
+	const lines = snippet.split('\n').map(expandTabs);
 	// A range crossing from deletions into additions quotes both halves,
 	// which no single run of numbers describes.
 	const startLine = meta.side === meta.endSide ? meta.start : undefined;

--- a/source/test/markdown-lite.test.ts
+++ b/source/test/markdown-lite.test.ts
@@ -68,6 +68,39 @@ describe('classifyRows', () => {
 });
 
 describe('renderMarkdownLines', () => {
+	it('expands tabs so a code line measures as wide as it draws', () => {
+		const md = '```\n\tif (x) {\n\t\treturn;\n```';
+
+		expect(renderMarkdownLines(md, 40)).toEqual([
+			{kind: 'code', text: '    if (x) {'},
+			{kind: 'code', text: '        return;'},
+		]);
+	});
+
+	it('wraps a tab-indented snippet line by its drawn width', () => {
+		const marker = encodeDiffCommentMarker({
+			filePath: 'a.ts',
+			start: 7,
+			side: 'additions',
+			end: 7,
+			endSide: 'additions',
+			note: '',
+		});
+		const md = [
+			marker,
+			'`a.ts` line 7 (added)',
+			'```',
+			'\t\tabcdef',
+			'```',
+		].join('\n');
+
+		// Width 20, gutter "7 │ " is 4: 16 columns per row, the line is 14.
+		expect(renderMarkdownLines(md, 20)).toEqual([
+			{kind: 'caption', text: 'a.ts line 7 (added)'},
+			{kind: 'code', text: '        abcdef', number: 7},
+		]);
+	});
+
 	it('wraps paragraphs, drops fence rows and collapses blank runs', () => {
 		const md = 'one two three four\n\n\n```\nlet x = 1;\n```\n';
 


### PR DESCRIPTION
Follow-up to #141 (ticket 2STENR2).

Quoted code is usually tab-indented. Ink measures a tab as zero columns (string-width), the terminal draws it as eight, so every such line overflowed the box and wrapped — the gutter landed on one row, the code on the next, and a code block came out as doubled rows of background. Tabs are now expanded to four spaces before anything is measured, wrapped or padded (`expandTabs` in `markdown-lite`, applied to rows and to a diff-linked snippet's lines).

Unit tests cover the expansion and that a tab-indented snippet line wraps by its drawn width; verified in a real terminal via the description view.