### PR TITLE
YM6TKAV placeholders in the theme's dim tone

### DIFF
--- a/source/gui/client/components/GlobalScrollbarStyles.tsx
+++ b/source/gui/client/components/GlobalScrollbarStyles.tsx
@@ -8,6 +8,14 @@ const SCROLLBAR_SIZE = 3;
 
 export const GlobalScrollbarStyles = () => (
 	<style>{`
+		/* Placeholders are a pseudo-element too. Unstyled they take the
+		   browser's warm grey, which sits oddly against the palette. */
+		input::placeholder,
+		textarea::placeholder {
+			color: ${GUI_THEME.dim};
+			opacity: 1;
+		}
+
 		/* Gated deliberately: Chrome implements scrollbar-width/-color too, and
 		   setting either makes it ignore the ::-webkit-scrollbar rules below. */
 		@supports not selector(::-webkit-scrollbar) {


### PR DESCRIPTION
Ticket YM6TKAV.

There was no `::placeholder` rule, so the board filter box — and every input and textarea — showed the browser's default warm grey, which sat oddly against the cold palette. A global rule (in the existing pseudo-element stylesheet next to the scrollbar rules) sets placeholders to `GUI_THEME.dim` with full opacity, so Firefox doesn't fade it further.