### PR TITLE
61G931Z: seed from the wall clock when the edge id is more than a day ahead

### DIFF
--- a/.claude/skills/epiq-architecture/SKILL.md
+++ b/.claude/skills/epiq-architecture/SKILL.md
@@ -27,7 +27,7 @@ There is no server and no shared clock. Every actor appends to **its own** JSONL
 ## Never
 
 - **Never order, compare or resolve conflicts by wall clock.** No "latest write wins by timestamp". `Date.now()` is a lower bound for id generation and a display value; it is not a fact about ordering.
-- **Never mint an id without seeding past the current edge.** An id that sorts before its own parent corrupts the DAG.
+- **Never mint an id without seeding past the current edge.** An id that sorts before its own parent corrupts the DAG. Exception: an edge that is itself damage — undecodable, at ULID's ceiling, or more than a day ahead of the wall clock — seeds from the wall clock instead (`seedFromEdgeRef`); ordering survives because it comes from `refId`, not the timestamp.
 - **Never hard-delete** a node, contributor, tag or event, and never reuse or rewrite an id. Replay would then reach a reference that no longer exists.
 - **Never rewrite, reorder or de-duplicate existing log lines.** Rewriting breaks the identity that union merge depends on.
 - **Never abort replay on an event that merely lost.** One concurrent edit would leave a board that never opens again for whoever's build understands the most.

--- a/source/lib/event/event-persist.ts
+++ b/source/lib/event/event-persist.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import {decodeTime, monotonicFactory} from 'ulid';
 import {z} from 'zod';
+import {logger} from '../../logger.js';
 import {isValidUserId, isValidUserName} from '../config/actor-env.js';
 import {failed, isFail, Result, succeeded} from '../model/result-types.js';
 import {getSettingsState, User} from '../state/settings.state.js';
@@ -27,6 +28,12 @@ const getNextId = monotonicFactory();
 // successor.
 const ULID_TIME_MAX = 281474976710655;
 
+// Honest clock skew between machines is minutes. An edge further ahead of the
+// wall clock than this would, via `Math.max` below, become the lower bound of
+// every id minted by every client from then on — one century-out ULID drags
+// all later `createdAt`s and the whole time-travel axis with it, permanently.
+const MAX_EDGE_AHEAD_MS = 24 * 60 * 60 * 1000;
+
 /**
  * The edge's timestamp is a lower bound for the next id and nothing more —
  * ordering comes from `refId`, not from this number.
@@ -49,6 +56,14 @@ const seedFromEdgeRef = (edgeRef: string): number => {
 	}
 
 	if (edgeTime >= ULID_TIME_MAX) return now;
+
+	if (edgeTime > now + MAX_EDGE_AHEAD_MS) {
+		logger.error(
+			'[persist] edge id is too far in the future; seeding from the wall clock instead',
+			{edgeRef, edgeTime, now},
+		);
+		return now;
+	}
 
 	return Math.max(now, edgeTime + 1);
 };

--- a/source/test/event-persist.test.ts
+++ b/source/test/event-persist.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import {decodeTime, ulid} from 'ulid';
 import {beforeEach, describe, expect, it} from 'vitest';
 import {
 	isSupportedSchemaVersion,
@@ -201,6 +202,21 @@ describe('event persist', () => {
 		const result = persist({event: event(), rootDir});
 
 		expect(isFail(result)).toBe(false);
+	});
+
+	it('seeds from the wall clock when the edge is absurdly far in the future', () => {
+		const centuryOut = ulid(Date.now() + 100 * 365 * 24 * 60 * 60 * 1000);
+		writeEdge(centuryOut);
+
+		const result = persist({event: event(), rootDir});
+
+		expect(isFail(result)).toBe(false);
+		if (isFail(result)) return;
+
+		expect(decodeTime(result.value.entry.id[0])).toBeLessThan(
+			Date.now() + 60_000,
+		);
+		expect(result.value.entry.id[1]).toBe(centuryOut);
 	});
 
 	// `getEventLogPath` refuses a name containing two `.jsonl`, which used to


### PR DESCRIPTION
Fixes ticket 61G931Z (prio-2): one far-future-but-legal ULID edge permanently dragged every later event id forward for every client — a century-out edge put all subsequent `createdAt`s and the whole time-travel axis a century out.

## Fix
`seedFromEdgeRef` now treats an edge more than 24h ahead of the wall clock as damage, seeds from the wall clock instead, and reports the clamp via `logger.error`. Causal ordering is untouched: the poisoned edge stays the `refId`, ordering still derives from `refId` + ULID tiebreak. This matches the two existing damage-fallbacks (undecodable edge, ULID ceiling) from the TIME_MAX fix, and the architecture skill's "never mint without seeding past the edge" rule now documents the exception.

## Tests
- New regression test: a century-out edge no longer seeds the mint (red without the fix — minted id decoded to 2126), while the poisoned edge is still kept as the causal ref.
- Full gate (lint, typecheck, unit, e2e, collab, GUI) passed on push.

Reviewed by multi-angle self-review; the one deliberate leftover — read-side consumers that still trust `decodeTime` of an already-poisoned id (replay pacing, scrubber window, comment sort, peek status) — is filed separately as ticket V0YQDXV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUbAqHYRAqX3S8KwqmoxuG