### PR TITLE
Scrubber: no text selection mid-drag, fainter centre baseline

### DIFF
--- a/source/gui/client/components/ScrubberLayout.tsx
+++ b/source/gui/client/components/ScrubberLayout.tsx
@@ -187,6 +187,10 @@ export const ScrubberLayout = ({
 							flexDirection: 'column',
 							gap: 8,
 							cursor: chart.connected ? 'pointer' : 'default',
+							// A scrub-drag must never turn into a native text selection or
+							// drag of the axis labels underneath the pointer.
+							userSelect: 'none',
+							WebkitUserSelect: 'none',
 						}}
 					>
 						{chart.hoveredSegment && (

--- a/source/gui/client/components/ScrubberParts.tsx
+++ b/source/gui/client/components/ScrubberParts.tsx
@@ -825,7 +825,9 @@ export const TrackBaseline = ({
 			height: anchor === 'top' ? 1 : 2,
 			borderRadius: 999,
 			background: color,
-			opacity: 0.2,
+			// The centre line runs through the scatter's dots, so it sits a shade
+			// fainter than the edge-anchored baselines.
+			opacity: anchor === 'centre' ? 0.14 : 0.2,
 		}}
 	/>
 );

--- a/source/test/e2e-gui/scrub-dispatch.pw.ts
+++ b/source/test/e2e-gui/scrub-dispatch.pw.ts
@@ -68,6 +68,38 @@ test('a click on the track asks the server to scrub once', async ({
 	expect(pageErrors).toEqual([]);
 });
 
+// A drag is a scrub, never a native text selection: without user-select off,
+// sweeping the needle could pick up the axis labels and drag them as a ghost.
+test('a drag never starts a text selection', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	const track = page.getByTestId('scrubber-track');
+	await expect(track).toHaveCSS('user-select', 'none');
+
+	const box = await track.boundingBox();
+	if (!box) throw new Error('scrubber track is not on screen');
+
+	const y = box.y + box.height / 2;
+	await page.mouse.move(box.x + box.width * 0.2, y);
+	await page.mouse.down();
+	await page.mouse.move(box.x + box.width * 0.8, y, {steps: 10});
+
+	const selected = await page.evaluate(
+		'window.getSelection()?.toString() ?? ""',
+	);
+	await page.mouse.up();
+
+	expect(selected).toBe('');
+
+	await returnToLive(page);
+	expect(pageErrors).toEqual([]);
+});
+
 // The press dispatches immediately and the moves are throttled, so without the
 // release the last stretch of a drag would never be asked for.
 test('a drag commits the position it ends on', async ({


### PR DESCRIPTION
Fixes NAMHFH7 and CB0PGEF: dragging the scatter timeline could start a native text selection and drag the hour-axis labels as a ghost — the track now has user-select off, with a regression test. Also draws the centre baseline at 0.14 instead of 0.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBpQGx8sMmPvoZHGqFRKmZ