### PR TITLE
PJ10QQP: isolate every test run's Epiq global dir under tmp

### DIFF
--- a/source/test/global-dir-guard.test.ts
+++ b/source/test/global-dir-guard.test.ts
@@ -1,0 +1,33 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {describe, expect, it} from 'vitest';
+import {getGlobalConfigDir} from '../lib/storage/global-config-dir.js';
+import {assertGlobalDirThrowaway} from './setup/global-dir-in-tmp.js';
+
+describe('global dir isolation', () => {
+	it('defaults EPIQ_GLOBAL_DIR to a throwaway dir for the whole run', () => {
+		const tempRoot = fs.realpathSync(os.tmpdir());
+
+		expect(process.env['EPIQ_GLOBAL_DIR']).toBeTruthy();
+		expect(getGlobalConfigDir().startsWith(tempRoot)).toBe(true);
+	});
+
+	it('accepts a dir under the temp root', () => {
+		expect(() =>
+			assertGlobalDirThrowaway(path.join(os.tmpdir(), 'epiq-global-x')),
+		).not.toThrow();
+	});
+
+	it('refuses the real global dir', () => {
+		expect(() =>
+			assertGlobalDirThrowaway(path.join(os.homedir(), '.epiq-global')),
+		).toThrow(/throwaway/);
+	});
+
+	it('refuses a missing dir outside tmp rather than allowing it', () => {
+		expect(() =>
+			assertGlobalDirThrowaway('/definitely/not/a/real/path/epiq-global'),
+		).toThrow(/throwaway/);
+	});
+});

--- a/source/test/setup/global-dir-in-tmp.ts
+++ b/source/test/setup/global-dir-in-tmp.ts
@@ -1,0 +1,66 @@
+/**
+ * The real `~/.epiq-global` holds the state-branch worktree — the live event
+ * logs of every project on this machine. A test that resolves it writes real
+ * events without ever running git outside tmp, so `no-git-outside-tmp` never
+ * fires; a 529-line `*.test.jsonl` log ended up committed to this repo's own
+ * state branch that way.
+ *
+ * Defaulted first, so a suite that forgets `EPIQ_GLOBAL_DIR` is isolated
+ * rather than failed; asserted per test, so one that points it somewhere real
+ * fails on the spot.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {beforeEach} from 'vitest';
+import {getGlobalConfigDir} from '../../lib/storage/global-config-dir.js';
+
+const tempRoot = fs.realpathSync(os.tmpdir());
+
+// Realpath through the nearest existing ancestor, so a not-yet-created dir
+// under the symlinked macOS tmpdir still canonicalizes to the same root.
+const canonicalize = (target: string): string => {
+	let current = path.resolve(target);
+	let suffix = '';
+
+	for (;;) {
+		try {
+			return path.join(fs.realpathSync(current), suffix);
+		} catch {
+			suffix = path.join(path.basename(current), suffix);
+			const parent = path.dirname(current);
+			if (parent === current) return path.join(current, suffix);
+			current = parent;
+		}
+	}
+};
+
+export const assertGlobalDirThrowaway = (dir: string): void => {
+	// Unlike the git guard, a missing dir is NOT safe here — the first write
+	// mkdirs it for real — so canonicalize rather than allow.
+	const resolved = canonicalize(dir);
+
+	if (resolved === tempRoot || resolved.startsWith(tempRoot + path.sep)) {
+		return;
+	}
+
+	throw new Error(
+		`Refusing to run tests with the Epiq global dir outside a throwaway directory.\n` +
+			`  resolved: ${resolved}\n` +
+			`It holds the real state-branch worktree, so tests writing there ` +
+			`publish events into production boards. Point EPIQ_GLOBAL_DIR under ` +
+			`${tempRoot}.`,
+	);
+};
+
+if (!process.env['EPIQ_GLOBAL_DIR']) {
+	process.env['EPIQ_GLOBAL_DIR'] = fs.mkdtempSync(
+		path.join(tempRoot, 'epiq-global-'),
+	);
+}
+
+assertGlobalDirThrowaway(getGlobalConfigDir());
+
+beforeEach(() => {
+	assertGlobalDirThrowaway(getGlobalConfigDir());
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,8 +2,12 @@ import {configDefaults, defineConfig} from 'vitest/config';
 
 export default defineConfig({
 	test: {
-		// Fails a test that aims git at the checkout instead of a temp dir.
-		setupFiles: ['source/test/setup/no-git-outside-tmp.ts'],
+		// Fail a test that aims git at the checkout instead of a temp dir, and
+		// one that resolves the real Epiq global dir (the live state worktree).
+		setupFiles: [
+			'source/test/setup/no-git-outside-tmp.ts',
+			'source/test/setup/global-dir-in-tmp.ts',
+		],
 		// Worktrees live under `.claude/worktrees`, and a checkout of a code
 		// branch there carries its own copy of every test. Without this they run
 		// twice, and the e2e ones run on the host rather than in their container.


### PR DESCRIPTION
Fixes ticket PJ10QQP (prio-2): test runs were writing events into the real state branch — a 529-line `*.test.jsonl` sat in production state. `no-git-outside-tmp` only guards git; a test that resolves the real `EPIQ_GLOBAL_DIR` (where the state worktree lives) writes real event files without ever running git outside tmp.

## Fix
New shared setup file `global-dir-in-tmp.ts` (registered alongside `no-git-outside-tmp.ts` in the one vitest config all suites share):
- defaults `EPIQ_GLOBAL_DIR` to a per-run temp dir, so a suite that forgets is isolated rather than failed;
- asserts before every test that `getGlobalConfigDir()` canonicalizes under the temp root, failing on the spot when a test points it somewhere real — a missing dir outside tmp is refused too, since the first write would `mkdir` it for real.

Canonicalization walks up to the nearest existing ancestor so paths under macOS's symlinked tmpdir still match.

## Tests
Guard has its own suite (default applied, tmp accepted, real global dir refused, missing-outside-tmp refused); the full unit suite passes under the new guard, and the full gate passed on push.

Not touched: the 529 lines already in the live log — append-only history, removing them means rewriting the state branch. Flagged on the ticket for a human call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUbAqHYRAqX3S8KwqmoxuG