### PR TITLE
Y76V1ZY: pin init.workspace as the only legal root in event ordering

### DIFF
--- a/source/lib/event/event-load.ts
+++ b/source/lib/event/event-load.ts
@@ -503,7 +503,12 @@ export const getSortedEvents = (
 		}
 	};
 
-	const roots = childrenByRef.get(null) ?? [];
+	// Only genesis is a legal root. Any other `refId: null` event — trivially
+	// forgeable, and able to sort in front of all of history via a low ULID —
+	// is anchored after the known history, with the orphans.
+	const roots = (childrenByRef.get(null) ?? []).filter(
+		event => 'init.workspace' in event,
+	);
 	for (const root of roots) {
 		visit(root);
 	}
@@ -513,7 +518,9 @@ export const getSortedEvents = (
 			const eventId = event.id[0];
 			const refId = event.id[1] ?? null;
 
-			return !placed.has(eventId) && refId !== null && !byEventId.has(refId);
+			if (placed.has(eventId)) return false;
+
+			return refId === null || !byEventId.has(refId);
 		})
 		.sort(compareEvents);
 

--- a/source/test/event-load.test.ts
+++ b/source/test/event-load.test.ts
@@ -116,6 +116,24 @@ describe('getSortedEvents', () => {
 		expect(JSON.stringify(oneWay)).toBe(JSON.stringify(otherWay));
 	});
 
+	// A `refId: null` line is trivially forgeable, and a low ULID made it sort
+	// in front of init.workspace — reordering all of history for every client.
+	it('anchors a forged second root after the known history, not before genesis', () => {
+		const genesis = event('01B0000000000000000000000A', null, 'init.workspace');
+		const first = event('01B0000000000000000000000B', genesis.id[0]);
+		const second = event('01B0000000000000000000000C', first.id[0]);
+		const forged = event('00000000000000000000000000', null, 'evil.event');
+
+		const sorted = getSortedEvents([forged, second, genesis, first]);
+
+		expect(sorted.map(e => e.id[0])).toEqual([
+			genesis.id[0],
+			first.id[0],
+			second.id[0],
+			forged.id[0],
+		]);
+	});
+
 	// Every event refs its predecessor, so a log is one chain as deep as it is
 	// long. Recursing it overflowed the call stack at ~4.7k events, which meant
 	// an ordinary board eventually stopped opening for everybody at once.


### PR DESCRIPTION
Fixes ticket Y76V1ZY (prio-2): `getSortedEvents` treated every `refId: null` event as a root and sorted roots by ULID, so one forged line with a low ULID (`00000...`) sorted in front of the real `init.workspace` and reordered all of history for every client.

## Fix
Of the two options the ticket weighed, this takes the genesis-pinning one (they converge): only events carrying `init.workspace` are legal roots; any other `refId: null` event is anchored after the known history, in the orphan pool, ordered by the same total tiebreak. Still a pure function of the event set; real logs (whose sole root is genesis) derive exactly the order they did before — the existing ordering tests pass unchanged.

## Tests
New regression test: a forged null-ref event with ULID `00000...` now sorts after the genesis chain, not before it (red without the fix). Full gate incl. the collab suite passed on push.

Residuals, deliberate: a forged event claiming `init.workspace` itself with a low ULID can still front-run genesis, and `splitEventsAtTime` still trusts a forged low timestamp — both fall under the trust-model decision parked in ticket FV86AFC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUbAqHYRAqX3S8KwqmoxuG