### PR TITLE
EGNYYS7: resolve the edge once per batch instead of re-reading the log per event

### DIFF
--- a/source/lib/event/event-materialize-and-persist.ts
+++ b/source/lib/event/event-materialize-and-persist.ts
@@ -9,7 +9,7 @@ import {
 import {nodeRepo} from '../repository/node-repo.js';
 import {getState} from '../state/state.js';
 import {materialize} from './event-materialize.js';
-import {persist} from './event-persist.js';
+import {EdgeCursor, persist} from './event-persist.js';
 import {
 	AppEvent,
 	AppEventMap,
@@ -26,6 +26,7 @@ type MaterializedValue<A extends EventAction> = {
 function materializeAndPersist<A extends EventAction>(
 	event: AppEvent<A>,
 	rootDir: string,
+	edge?: EdgeCursor,
 ): MaterializeResult<A> {
 	const materialized = materialize(event);
 
@@ -33,7 +34,7 @@ function materializeAndPersist<A extends EventAction>(
 		return materialized;
 	}
 
-	const persistResult = persist({event, rootDir});
+	const persistResult = persist({event, rootDir, edge});
 	if (isFail(persistResult)) return persistResult;
 
 	return materialized;
@@ -57,13 +58,19 @@ export function materializeAndPersistAll<const T extends AppEvent[]>(
 		);
 	}
 
-	const contributorResult = ensureContributorCurrent(events[0], rootDir);
+	// One cursor for the whole batch: the loop below is synchronous, so
+	// nothing in this process appends between two of its persists.
+	const edge: EdgeCursor = {};
+
+	const contributorResult = ensureContributorCurrent(events[0], rootDir, edge);
 
 	if (isFail(contributorResult)) {
 		return contributorResult;
 	}
 
-	const results = events.map(event => materializeAndPersist(event, rootDir));
+	const results = events.map(event =>
+		materializeAndPersist(event, rootDir, edge),
+	);
 
 	const failures = results.filter(isFail);
 	if (failures.length > 0) {
@@ -88,6 +95,7 @@ export function materializeAndPersistAll<const T extends AppEvent[]>(
 export const ensureContributorCurrent = (
 	event: AppEvent,
 	rootDir: string,
+	edge?: EdgeCursor,
 ): Result<void> => {
 	if (
 		event.action === 'create.contributor' ||
@@ -118,7 +126,7 @@ export const ensureContributorCurrent = (
 		return succeeded('Contributor name is current', undefined);
 	}
 
-	const result = materializeAndPersist(actorEvent, rootDir);
+	const result = materializeAndPersist(actorEvent, rootDir, edge);
 
 	if (isFail(result)) {
 		return failed(result.message);

--- a/source/lib/event/event-persist.ts
+++ b/source/lib/event/event-persist.ts
@@ -205,12 +205,20 @@ export const toPersistedEvent = (
 
 	return parsePersistedEvent(candidate);
 };
+// A batch's edge, threaded through its persists: resolved from disk by the
+// first persist that needs it (`undefined` = unresolved, `null` = empty log)
+// and advanced in place per event, instead of re-reading and re-sorting the
+// whole log every time.
+export type EdgeCursor = {current?: string | null};
+
 export function persist({
 	event,
 	rootDir,
+	edge,
 }: {
 	event: AppEvent;
 	rootDir: string;
+	edge?: EdgeCursor;
 }): Result<PersistSuccess> {
 	try {
 		const ensureEventsDirResult = ensureEventsDir(rootDir);
@@ -222,17 +230,20 @@ export function persist({
 		});
 		if (isFail(filePath)) return filePath;
 
-		const edgeRef = getEdgeRef(rootDir);
-		if (isFail(edgeRef)) return failed(edgeRef.message);
+		let edgeValue: string | null;
+		if (edge && edge.current !== undefined) {
+			edgeValue = edge.current;
+		} else {
+			const edgeRef = getEdgeRef(rootDir);
+			if (isFail(edgeRef)) return failed(edgeRef.message);
+			edgeValue = edgeRef.value;
+		}
 
-		const newId = edgeRef.value
-			? getNextId(seedFromEdgeRef(edgeRef.value))
+		const newId = edgeValue
+			? getNextId(seedFromEdgeRef(edgeValue))
 			: getNextId();
 
-		const entryResult = toPersistedEvent(stripActor(event), [
-			newId,
-			edgeRef.value,
-		]);
+		const entryResult = toPersistedEvent(stripActor(event), [newId, edgeValue]);
 
 		if (isFail(entryResult)) return failed(entryResult.message);
 
@@ -241,6 +252,10 @@ export function persist({
 			`${JSON.stringify(entryResult.value)}\n`,
 			'utf8',
 		);
+
+		// Advanced only after the line is on disk, so a failed persist leaves
+		// the cursor pointing at an event that exists.
+		if (edge) edge.current = newId;
 
 		return succeeded<PersistSuccess>('Event persisted', {
 			path: filePath.value,

--- a/source/test/event-persist-batch.test.ts
+++ b/source/test/event-persist-batch.test.ts
@@ -1,0 +1,148 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {materializeAndPersistAll} from '../lib/event/event-materialize-and-persist.js';
+import {getPersistFileName} from '../lib/event/event-persist.js';
+import {AppEvent} from '../lib/event/event.model.js';
+import {isFail} from '../lib/model/result-types.js';
+import {nodes} from '../lib/state/node-builder.js';
+import {initWorkspaceState} from '../lib/state/state.js';
+import {midRank} from '../lib/utils/rank.js';
+
+// A batch resolves the edge once and advances it locally per persist, rather
+// than re-reading the whole log for every event.
+
+const IDS = {
+	root: '01H00000000000000000000000',
+	board: '01H00000000000000000000002',
+} as const;
+
+const actor = {userId: 'u1', userName: 'alice'};
+
+let seq = 0;
+const eventId = () => `01H00000000000000000${String(++seq).padStart(6, '0')}`;
+
+const rank = () => {
+	const result = midRank();
+	if (isFail(result)) throw new Error(result.message);
+	return result.value;
+};
+
+const addSwimlane = (id: string, name: string): AppEvent<'add.swimlane'> => ({
+	id: eventId(),
+	action: 'add.swimlane',
+	payload: {id, name, parent: IDS.board, rank: rank()},
+	...actor,
+});
+
+let rootDir = '';
+
+beforeEach(() => {
+	rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'epiq-batch-'));
+	fs.mkdirSync(path.join(rootDir, '.epiq'), {recursive: true});
+
+	initWorkspaceState(nodes.workspace(IDS.root, 'Test Root', rank()));
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	fs.rmSync(rootDir, {recursive: true, force: true});
+});
+
+const ownLogLines = (): Array<{id: [string, string | null]}> =>
+	fs
+		.readFileSync(
+			path.join(
+				rootDir,
+				'.epiq',
+				'events',
+				getPersistFileName({userId: 'u1', userName: 'alice'}),
+			),
+			'utf8',
+		)
+		.trim()
+		.split('\n')
+		.map(line => JSON.parse(line));
+
+describe('materializeAndPersistAll edge threading', () => {
+	it('reads the log once per batch, not once per event', () => {
+		// The dir must exist or the loads short-circuit before readdir.
+		fs.mkdirSync(path.join(rootDir, '.epiq', 'events'), {recursive: true});
+
+		const readdirSpy = vi.spyOn(fs, 'readdirSync');
+
+		const result = materializeAndPersistAll(
+			[
+				addSwimlane('01H00000000000000000100001', 'A'),
+				addSwimlane('01H00000000000000000100002', 'B'),
+				addSwimlane('01H00000000000000000100003', 'C'),
+			],
+			rootDir,
+		);
+
+		expect(isFail(result)).toBe(false);
+
+		const eventDirReads = readdirSpy.mock.calls.filter(([dir]) =>
+			String(dir).endsWith(path.join('.epiq', 'events')),
+		);
+		expect(eventDirReads).toHaveLength(1);
+	});
+
+	it('chains every persisted event to its predecessor, starting at the loaded edge', () => {
+		// Another actor's log provides the edge the batch must anchor to.
+		const eventsDir = path.join(rootDir, '.epiq', 'events');
+		fs.mkdirSync(eventsDir, {recursive: true});
+		const existingEdge = '01H00000000000000000000099';
+		fs.writeFileSync(
+			path.join(eventsDir, '01ARZ3NDEKTSV4RRFFQ69G5FAV.mallory.jsonl'),
+			JSON.stringify({
+				v: 1,
+				id: [existingEdge, null],
+				'init.workspace': {id: 'w', name: 'W'},
+			}) + '\n',
+		);
+
+		const result = materializeAndPersistAll(
+			[
+				addSwimlane('01H00000000000000000100001', 'A'),
+				addSwimlane('01H00000000000000000100002', 'B'),
+			],
+			rootDir,
+		);
+
+		expect(isFail(result)).toBe(false);
+
+		// create.contributor is written first, then the two batch events; each
+		// line refs the id minted just before it.
+		const lines = ownLogLines();
+		expect(lines).toHaveLength(3);
+		expect(lines[0]?.id[1]).toBe(existingEdge);
+		expect(lines[1]?.id[1]).toBe(lines[0]?.id[0]);
+		expect(lines[2]?.id[1]).toBe(lines[1]?.id[0]);
+	});
+
+	it('does not advance the cursor past an event that was never persisted', () => {
+		const editMissingNode: AppEvent<'edit.title'> = {
+			id: eventId(),
+			action: 'edit.title',
+			payload: {id: '01H00000000000000000999999', name: 'nope'},
+			...actor,
+		};
+
+		materializeAndPersistAll(
+			[
+				addSwimlane('01H00000000000000000100001', 'A'),
+				editMissingNode,
+				addSwimlane('01H00000000000000000100003', 'C'),
+			],
+			rootDir,
+		);
+
+		// contributor, A, C — the skipped edit writes nothing, and C must chain
+		// to A, not to an id that never reached disk.
+		const lines = ownLogLines();
+		expect(lines).toHaveLength(3);
+		expect(lines[2]?.id[1]).toBe(lines[1]?.id[0]);
+	});
+});


### PR DESCRIPTION
Fixes ticket EGNYYS7 (prio-3): `persist` called `getEdgeRef` — the whole log read, parsed and sorted — once per event, so an M-event batch over an N-event log cost O(N·M) (~9 full log reads for one `createIssue`).

## Fix
`materializeAndPersistAll` threads one `EdgeCursor` through the batch. The first persist that needs the edge resolves it from disk (inside persist's existing try/catch, so rejection-only batches still do zero disk work and filesystem errors stay `Result`s); each subsequent persist chains to the id minted just before it, advanced only after the line is on disk. The loop is synchronous, so nothing in this process appends between two of its persists; a concurrent writer in another process is the ordinary CRDT shared-parent case, which `getSortedEvents` orders identically everywhere.

## Tests
- Reads the log once per batch, not once per event (red without the fix: 4 reads).
- Every persisted event chains to its predecessor, starting at another actor's pre-existing edge.
- A skipped mid-batch event (edit of a missing node) never advances the cursor — the next event chains to the last id that actually reached disk.
- `replay-equivalence` and the collab suite pass; full gate passed on push.

Self-review applied: lazy cursor (kept `getEdgeRef` inside persist's try/catch, no upfront read on rejection paths), dead ternary collapsed, comments trimmed, log filename derived via `getPersistFileName`. Known deliberate non-changes: the in-memory per-event `materialize()` cost (separate concern from disk I/O) and init.cmd's cursor-less seeding loop (empty log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUbAqHYRAqX3S8KwqmoxuG