### PR TITLE
7PWF54X: navigate to a created ticket on the request's own reply, not the broadcast

### DIFF
--- a/source/gui/api/lib/websocket.ts
+++ b/source/gui/api/lib/websocket.ts
@@ -504,11 +504,6 @@ export const setupWebsocket = (
 						});
 					}
 
-					broadcastGuiMessage({
-						type: 'issue:created',
-						payload: result.value,
-					});
-
 					onStateChanged();
 					return sendGuiState(socket, repoRoot);
 				}

--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -219,9 +219,8 @@ export const App = () => {
 	const socketRef = useRef<WebSocket | null>(null);
 	// Set right before an issues:create request that came from "File ticket"
 	// on a diff selection, consumed by that request's own issues:create:result
-	// reply (not the issue:created broadcast, which fires for every creation
-	// on the board) — that's how the origin ticket's back-comment knows which
-	// creation to react to.
+	// reply — that's how the origin ticket's back-comment knows which creation
+	// to react to.
 	const pendingFileTicketOrigin = useRef<{
 		originIssueId: string;
 		originRef: string;
@@ -531,7 +530,14 @@ export const App = () => {
 				if (detail) setIssueDetail(detail);
 			}
 
-			if (message.type === 'issue:created') {
+			// Keyed off this request's own reply, never a broadcast: a broadcast
+			// fires for every creation on the board, including other people's,
+			// and navigating on one yanked every connected client to whichever
+			// ticket happened to be created next.
+			if (message.type === 'issues:create:result') {
+				const origin = pendingFileTicketOrigin.current;
+				pendingFileTicketOrigin.current = null;
+
 				const created = getResultValue<{id: string}>(message.payload);
 
 				if (created && boardId) {
@@ -539,17 +545,6 @@ export const App = () => {
 						`/board/${boardId}/issue/${nodeRef(created.id)}?tab=overview`,
 					);
 				}
-			}
-
-			// Keyed off this request's own reply rather than the issue:created
-			// broadcast above: that one fires for every creation on the board,
-			// including other people's, and would attach the back-comment to
-			// whichever creation happened to land next.
-			if (message.type === 'issues:create:result') {
-				const origin = pendingFileTicketOrigin.current;
-				pendingFileTicketOrigin.current = null;
-
-				const created = getResultValue<{id: string}>(message.payload);
 
 				if (origin && created) {
 					sendSocketJson(socket, {

--- a/source/gui/client/lib/gui-broadcast.ts
+++ b/source/gui/client/lib/gui-broadcast.ts
@@ -15,7 +15,7 @@ export const registerGuiSocket = (socket: WebSocket) => {
 };
 
 export const broadcastGuiMessage = (body: {
-	type: 'state' | 'sync-status' | 'issue:created' | 'failed';
+	type: 'state' | 'sync-status' | 'failed';
 	payload: unknown;
 }) => {
 	const json = JSON.stringify(body);

--- a/source/test/e2e-gui/create-issue.pw.ts
+++ b/source/test/e2e-gui/create-issue.pw.ts
@@ -28,6 +28,38 @@ test('creates the ticket when Enter is pressed in the title field', async ({
 	expect(pageErrors).toEqual([]);
 });
 
+// Navigation used to be keyed to the issue:created broadcast, which reaches
+// every connected client — so anyone else creating a ticket (another tab, a
+// teammate, an agent) yanked this client to it, and a late broadcast reset
+// the tab on a ticket you had already moved on from.
+test('another client creating a ticket does not navigate this one', async ({
+	page,
+	context,
+	appUrl,
+	pageErrors,
+}) => {
+	const creator = await context.newPage();
+	await creator.goto(appUrl);
+	await expect(creator.getByTestId('board-switcher')).toContainText('Default');
+
+	const title = `Someone else's ticket ${Date.now()}`;
+	await openModal(creator);
+	await creator.getByPlaceholder('issue name').fill(title);
+	await creator.getByPlaceholder('issue name').press('Enter');
+
+	// The creator navigates to its new ticket.
+	await expect(creator).toHaveURL(/\/issue\//);
+
+	// The old broadcast-driven navigation landed within milliseconds of the
+	// creator's own; a grace window after it must leave the bystander where
+	// it was. (It sees the ticket itself only on the next sync cycle.)
+	await page.waitForTimeout(1500);
+	await expect(page).not.toHaveURL(/\/issue\//);
+
+	await creator.close();
+	expect(pageErrors).toEqual([]);
+});
+
 test('cancel still closes without creating anything', async ({page}) => {
 	await openModal(page);
 


### PR DESCRIPTION
Fixes ticket 7PWF54X: creating a ticket navigated on the `issue:created` reply, always to `?tab=overview`, unraced against anything — a slow reply landed after a tab switch and dragged you back to Overview.

The root is worse than the ticket's symptom: `issue:created` is a broadcast that reaches **every** connected client, and every client navigated on it — another browser tab, a teammate, or an MCP agent creating a ticket yanked all connected GUIs to it. The commit already on main for this ticket (`ec13c933`) only made the flaky test wait; the app behavior was untouched.

## Fix
Navigation moves into the `issues:create:result` handler — the request's own reply, delivered only to the creating socket. This is the pattern the code itself already documents for the back-comment, two lines below. The now-consumerless `issue:created` broadcast is removed from the server and the message type union; bystanders keep learning about new tickets through the state sync cycle, as before.

## Tests
New two-client GUI e2e: the creator navigates to its new ticket, the bystander page stays put through a grace window — verified red against the old code (the bystander got navigated) and green with the fix. `tab-persistence` and `create-issue` suites pass, 924 unit tests pass, full gate passed on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUbAqHYRAqX3S8KwqmoxuG