### PR TITLE
0J26XQ7: show the comment count on the wide board card too

### DIFF
--- a/source/lib/components/TicketListItem.tsx
+++ b/source/lib/components/TicketListItem.tsx
@@ -1,6 +1,7 @@
 import {Box, Text} from 'ink';
 import React from 'react';
 import {Ticket} from '../model/context.model.js';
+import {nodeRepo} from '../repository/node-repo.js';
 import {theme} from '../theme/themes.js';
 import {
 	sanitizeInlineText,
@@ -91,6 +92,12 @@ export const TicketListItemUI: React.FC<{
 	// a single badge never pushes the others off the row on its own
 	const maxNameWidth = Math.max(1, contentWidth - TAG_WIDTH);
 
+	// '[N]' plus one column of air, same form as the compact row's count
+	const comments = nodeRepo.getCommentsByIssue(ticket.id);
+	const commentsWidth = comments.length
+		? String(comments.length).length + 2 + 1
+		: 0;
+
 	const {shown, hidden} = fitBadges(
 		[
 			...tags.map(tag => ({
@@ -107,7 +114,7 @@ export const TicketListItemUI: React.FC<{
 					(hasAuthoredEvents(assignee.id) ? 0 : 1),
 			})),
 		],
-		contentWidth,
+		contentWidth - commentsWidth,
 	);
 
 	return (
@@ -137,21 +144,32 @@ export const TicketListItemUI: React.FC<{
 				)}
 			</Box>
 
-			<Box flexDirection="row" paddingLeft={1} paddingRight={1}>
-				{shown.map(badge => (
-					<Box paddingRight={1} key={badge.id}>
-						{badge.isTag ? (
-							<TagUI id={badge.id} maxWidth={maxNameWidth} />
-						) : (
-							<AssigneeUI id={badge.id} maxWidth={maxNameWidth} />
-						)}
-					</Box>
-				))}
+			<Box
+				flexDirection="row"
+				paddingLeft={1}
+				paddingRight={1}
+				justifyContent="space-between"
+			>
+				<Box flexDirection="row">
+					{shown.map(badge => (
+						<Box paddingRight={1} key={badge.id}>
+							{badge.isTag ? (
+								<TagUI id={badge.id} maxWidth={maxNameWidth} />
+							) : (
+								<AssigneeUI id={badge.id} maxWidth={maxNameWidth} />
+							)}
+						</Box>
+					))}
 
-				{hidden > 0 && (
-					<Text color={theme.secondary2} dimColor>
-						+{hidden}
-					</Text>
+					{hidden > 0 && (
+						<Text color={theme.secondary2} dimColor>
+							+{hidden}
+						</Text>
+					)}
+				</Box>
+
+				{comments.length > 0 && (
+					<Text color={theme.accent}>[{comments.length}]</Text>
 				)}
 			</Box>
 		</Box>

--- a/source/test/e2e/comments.e2e.test.ts
+++ b/source/test/e2e/comments.e2e.test.ts
@@ -24,6 +24,37 @@ beforeAll(async () => {
 });
 
 describe('TUI comments', () => {
+	// The compact row showed `[N]`; the wide card showed nothing, so widening
+	// the terminal lost information.
+	it(
+		'shows the comment count on the board row in wide view too',
+		async () => {
+			const tui = setupTui();
+			try {
+				await commonSteps.init(tui);
+				tui.input(ENTER);
+				await tui.waitFor('Todo (0)');
+
+				await run(tui, ':new issue Count badge', 'new issue Count badge');
+				await tui.waitFor('Todo (1)', 4_000);
+				await run(tui, ':comment first', 'comment first');
+				await run(tui, ':comment second', 'comment second');
+
+				// The dense board (the default) already shows the count.
+				await tui.waitFor('[2]', 4_000);
+
+				await run(tui, ':config view wide', 'config view wide');
+
+				// The screen is now the wide board: the card, and on it the count.
+				await tui.waitFor('Count badge', 4_000);
+				await tui.waitFor('[2]', 4_000);
+			} finally {
+				await tui.destroy();
+			}
+		},
+		testTimeout,
+	);
+
 	it(
 		'wraps a long comment onto more rows instead of cutting it off',
 		async () => {


### PR DESCRIPTION
Fixes ticket 0J26XQ7: the compact TUI row shows `[N]` for a ticket's comments; the wide card showed nothing, so widening the terminal lost information.

## Fix
The wide card's badge row now renders the same `[N]` (accent color, right edge — mirroring the compact row's placement), sourced from `nodeRepo.getCommentsByIssue` like compact. Its width is subtracted from the tag/assignee `fitBadges` budget so badges never collide with it; with zero comments nothing is reserved or rendered.

## Tests
New TUI e2e: create a ticket, add two comments, confirm the dense board shows `[2]`, switch to `:config view wide`, and assert the wide card shows `[2]` too — verified red without the fix (the wide card rendered, the count did not; the assertion reads the live screen buffer, so no stale-frame false positive). 924 unit tests and the full gate passed on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUbAqHYRAqX3S8KwqmoxuG