### PR TITLE
Harden the event log against poisoned ids and forged roots

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"publish:dry": "rm -f epiq-*.tgz && npm pack && FILE=$(ls -t epiq-*.tgz | head -n 1) && npm publish --dry-run \"$FILE\"",
 		"publish:tarball": "FILE=$(ls -t epiq-*.tgz | head -n 1) && echo \"Publishing $FILE\" && npm publish \"$FILE\"",
 		"release": "npm run pack:check && npm run publish:tarball",
-		"start:mcp": "IS_LOCAL=true tsx source/mcp/server.ts",
+		"start:mcp": "IS_LOCAL=true tsx source/mcp/index.ts",
 		"inspect:mcp": "npx @modelcontextprotocol/inspector",
 		"lint": "eslint .",
 		"lint:err": "eslint . --quiet",

--- a/source/lib/command-line/commands/peek.cmd.ts
+++ b/source/lib/command-line/commands/peek.cmd.ts
@@ -1,6 +1,8 @@
 import {getRepoRootDir, getStateBranchRoot} from '../../../git/git-storage.js';
-import {clampUlidTimes, getEventTime} from '../../event/date-utils.js';
-import {loadMergedEvents} from '../../event/event-load.js';
+import {
+	loadEffectiveEventTimes,
+	loadMergedEvents,
+} from '../../event/event-load.js';
 import {
 	logSkippedEvents,
 	materializeAll,
@@ -65,27 +67,28 @@ export const peekCommand = async () => {
 
 	let targetTime: number;
 
-	// Clamped over the same full set splitEventsAtTime sees, so a step onto a
-	// poisoned far-future id cuts where the checkout will.
-	const {eventLog, unappliedEvents} = getState();
-	const stepTimes = clampUlidTimes(
-		[...eventLog, ...unappliedEvents].map(event => getEventTime(event)),
-	);
+	if (modifier === 'prev' || modifier === 'next') {
+		// Effective times over the same full set splitEventsAtTime judges by, so
+		// a step onto a poisoned far-future id cuts where the checkout will.
+		const stepTimes = loadEffectiveEventTimes(stateBranchRoot.value);
+		if (isFail(stepTimes)) return stepTimes;
 
-	if (modifier === 'prev') {
-		const previousTime =
-			eventLog.length > 0 ? stepTimes[eventLog.length - 1] ?? null : null;
+		const stepId =
+			modifier === 'prev'
+				? getState().eventLog.at(-1)?.id
+				: getState().unappliedEvents.at(0)?.id;
+		const stepTime =
+			stepId === undefined ? null : stepTimes.value.get(stepId) ?? null;
 
-		if (previousTime === null) return failed('No previous event to peek');
+		if (stepTime === null) {
+			return failed(
+				modifier === 'prev'
+					? 'No previous event to peek'
+					: 'No next event to peek',
+			);
+		}
 
-		targetTime = previousTime;
-	} else if (modifier === 'next') {
-		const nextTime =
-			unappliedEvents.length > 0 ? stepTimes[eventLog.length] ?? null : null;
-
-		if (nextTime === null) return failed('No next event to peek');
-
-		targetTime = nextTime + 1;
+		targetTime = modifier === 'prev' ? stepTime : stepTime + 1;
 	} else {
 		// Offsets (e.g. `2y`) arrive as `modifier`; absolute dates (YYYY-MM-DD)
 		// are not in the modifier allow-list, so they arrive as `inputString`.

--- a/source/lib/command-line/commands/peek.cmd.ts
+++ b/source/lib/command-line/commands/peek.cmd.ts
@@ -1,5 +1,5 @@
 import {getRepoRootDir, getStateBranchRoot} from '../../../git/git-storage.js';
-import {getEventTime} from '../../event/date-utils.js';
+import {clampUlidTimes, getEventTime} from '../../event/date-utils.js';
 import {loadMergedEvents} from '../../event/event-load.js';
 import {
 	logSkippedEvents,
@@ -65,16 +65,23 @@ export const peekCommand = async () => {
 
 	let targetTime: number;
 
+	// Clamped over the same full set splitEventsAtTime sees, so a step onto a
+	// poisoned far-future id cuts where the checkout will.
+	const {eventLog, unappliedEvents} = getState();
+	const stepTimes = clampUlidTimes(
+		[...eventLog, ...unappliedEvents].map(event => getEventTime(event)),
+	);
+
 	if (modifier === 'prev') {
-		const previousEvent = getState().eventLog.at(-1);
-		const previousTime = getEventTime(previousEvent);
+		const previousTime =
+			eventLog.length > 0 ? stepTimes[eventLog.length - 1] ?? null : null;
 
 		if (previousTime === null) return failed('No previous event to peek');
 
 		targetTime = previousTime;
 	} else if (modifier === 'next') {
-		const nextEvent = getState().unappliedEvents.at(0);
-		const nextTime = getEventTime(nextEvent);
+		const nextTime =
+			unappliedEvents.length > 0 ? stepTimes[eventLog.length] ?? null : null;
 
 		if (nextTime === null) return failed('No next event to peek');
 

--- a/source/lib/command-line/commands/peek.cmd.ts
+++ b/source/lib/command-line/commands/peek.cmd.ts
@@ -1,4 +1,5 @@
 import {getRepoRootDir, getStateBranchRoot} from '../../../git/git-storage.js';
+import {clampUlidTime, getEventTime} from '../../event/date-utils.js';
 import {
 	loadEffectiveEventTimes,
 	loadMergedEvents,
@@ -73,12 +74,21 @@ export const peekCommand = async () => {
 		const stepTimes = loadEffectiveEventTimes(stateBranchRoot.value);
 		if (isFail(stepTimes)) return stepTimes;
 
-		const stepId =
+		const stepEvent =
 			modifier === 'prev'
-				? getState().eventLog.at(-1)?.id
-				: getState().unappliedEvents.at(0)?.id;
+				? getState().eventLog.at(-1)
+				: getState().unappliedEvents.at(0);
+
+		// An event minted this session carries its creation ULID in memory, while
+		// the log carries the edge-chained id `persist` assigned it, so the lookup
+		// misses until a reload puts the persisted ids back into state. That id is
+		// honest by construction — the mint guard clamps it — so it stands in.
+		const ownTime = stepEvent === undefined ? null : getEventTime(stepEvent);
 		const stepTime =
-			stepId === undefined ? null : stepTimes.value.get(stepId) ?? null;
+			(stepEvent === undefined
+				? null
+				: stepTimes.value.get(stepEvent.id) ?? null) ??
+			(ownTime === null ? null : clampUlidTime(ownTime));
 
 		if (stepTime === null) {
 			return failed(

--- a/source/lib/command-line/commands/replay-engine.ts
+++ b/source/lib/command-line/commands/replay-engine.ts
@@ -1,4 +1,4 @@
-import {clampUlidTimes, getEventTime} from '../../event/date-utils.js';
+import {getEventTime, toEffectiveUlidTimes} from '../../event/date-utils.js';
 import {AppEvent} from '../../event/event.model.js';
 import {describeEvent} from '../../event/format-log-utils.js';
 import {
@@ -104,11 +104,11 @@ export const startReplay = ({
 	cancelActiveReplay();
 
 	const totalCount = events.length;
-	// Set-clamped so one poisoned far-future id cannot swallow the whole
+	// Effective times, so one poisoned far-future id cannot swallow the whole
 	// playback budget in a single gap.
-	const times = clampUlidTimes(events.map(event => getEventTime(event))).map(
-		time => time ?? startTime,
-	);
+	const times = toEffectiveUlidTimes(
+		events.map(event => getEventTime(event)),
+	).map(time => time ?? startTime);
 	const endTime = times[totalCount - 1] ?? Date.now();
 	const fractions = buildPlaybackFractions(times);
 

--- a/source/lib/command-line/commands/replay-engine.ts
+++ b/source/lib/command-line/commands/replay-engine.ts
@@ -1,4 +1,4 @@
-import {getEventTime} from '../../event/date-utils.js';
+import {clampUlidTimes, getEventTime} from '../../event/date-utils.js';
 import {AppEvent} from '../../event/event.model.js';
 import {describeEvent} from '../../event/format-log-utils.js';
 import {
@@ -104,7 +104,11 @@ export const startReplay = ({
 	cancelActiveReplay();
 
 	const totalCount = events.length;
-	const times = events.map(event => getEventTime(event) ?? startTime);
+	// Set-clamped so one poisoned far-future id cannot swallow the whole
+	// playback budget in a single gap.
+	const times = clampUlidTimes(events.map(event => getEventTime(event))).map(
+		time => time ?? startTime,
+	);
 	const endTime = times[totalCount - 1] ?? Date.now();
 	const fractions = buildPlaybackFractions(times);
 
@@ -142,6 +146,7 @@ export const startReplay = ({
 
 		const flashNodeIds: string[] = [];
 		let lastApplied: AppEvent | undefined;
+		let lastAppliedTime: number | undefined;
 
 		// Apply every event whose scheduled position has been reached this frame.
 		while (cursor < totalCount && fractions[cursor]! <= progress) {
@@ -166,6 +171,7 @@ export const startReplay = ({
 
 			flashNodeIds.push(...getAffectedNodeIds(event));
 			lastApplied = event;
+			lastAppliedTime = times[cursor];
 			cursor++;
 		}
 
@@ -211,7 +217,7 @@ export const startReplay = ({
 				// On idle fast-forward frames (no event applied) keep showing the last
 				// event's caption, time, and spotlight rather than blanking out.
 				currentTime: lastApplied
-					? getEventTime(lastApplied) ?? previous?.currentTime ?? startTime
+					? lastAppliedTime ?? previous?.currentTime ?? startTime
 					: previous?.currentTime ?? startTime,
 				currentLabel: lastApplied
 					? describeEvent(lastApplied)

--- a/source/lib/components/AttachmentListUI.tsx
+++ b/source/lib/components/AttachmentListUI.tsx
@@ -2,7 +2,7 @@ import {Box, Text} from 'ink';
 import React, {useEffect, useMemo, useRef} from 'react';
 import {decodeTime} from 'ulid';
 import {navigationUtils} from '../actions/default/navigation-action-utils.js';
-import {clampUlidTime} from '../event/date-utils.js';
+import {ulidTimeMs} from '../event/date-utils.js';
 import {timeAgo} from '../utils/date.utils.js';
 import {isFieldNode, Ticket} from '../model/context.model.js';
 import {AttachmentState} from '../model/app-state.model.js';
@@ -157,7 +157,7 @@ export function AttachmentListUI({ticket, width, height}: Props) {
 									{'  ' +
 										formatKb(attachment.bytes) +
 										'  ' +
-										timeAgo(clampUlidTime(decodeTime(attachment.id)))}
+										timeAgo(ulidTimeMs(attachment.id))}
 								</Text>
 							</Box>
 						</Box>

--- a/source/lib/components/AttachmentListUI.tsx
+++ b/source/lib/components/AttachmentListUI.tsx
@@ -2,6 +2,7 @@ import {Box, Text} from 'ink';
 import React, {useEffect, useMemo, useRef} from 'react';
 import {decodeTime} from 'ulid';
 import {navigationUtils} from '../actions/default/navigation-action-utils.js';
+import {clampUlidTime} from '../event/date-utils.js';
 import {timeAgo} from '../utils/date.utils.js';
 import {isFieldNode, Ticket} from '../model/context.model.js';
 import {AttachmentState} from '../model/app-state.model.js';
@@ -156,7 +157,7 @@ export function AttachmentListUI({ticket, width, height}: Props) {
 									{'  ' +
 										formatKb(attachment.bytes) +
 										'  ' +
-										timeAgo(decodeTime(attachment.id))}
+										timeAgo(clampUlidTime(decodeTime(attachment.id)))}
 								</Text>
 							</Box>
 						</Box>

--- a/source/lib/components/CommentListUI.tsx
+++ b/source/lib/components/CommentListUI.tsx
@@ -2,7 +2,7 @@ import {Box, Text} from 'ink';
 import React, {useEffect, useMemo, useRef} from 'react';
 import {decodeTime} from 'ulid';
 import {navigationUtils} from '../actions/default/navigation-action-utils.js';
-import {clampUlidTime} from '../event/date-utils.js';
+import {ulidTimeMs} from '../event/date-utils.js';
 import {timeAgo} from '../utils/date.utils.js';
 import {
 	Comment,
@@ -161,7 +161,7 @@ export function CommentListUI({ticket, width, height}: Props) {
 									<Text color={theme.secondary2}>{`#${index + 1} `}</Text>
 									<AssigneeUI id={comment.authorId} />
 									<Text color={theme.secondary2}>
-										{' ' + timeAgo(clampUlidTime(decodeTime(comment.id)))}
+										{' ' + timeAgo(ulidTimeMs(comment.id))}
 									</Text>
 								</Box>
 							</Box>

--- a/source/lib/components/CommentListUI.tsx
+++ b/source/lib/components/CommentListUI.tsx
@@ -2,6 +2,7 @@ import {Box, Text} from 'ink';
 import React, {useEffect, useMemo, useRef} from 'react';
 import {decodeTime} from 'ulid';
 import {navigationUtils} from '../actions/default/navigation-action-utils.js';
+import {clampUlidTime} from '../event/date-utils.js';
 import {timeAgo} from '../utils/date.utils.js';
 import {
 	Comment,
@@ -160,7 +161,7 @@ export function CommentListUI({ticket, width, height}: Props) {
 									<Text color={theme.secondary2}>{`#${index + 1} `}</Text>
 									<AssigneeUI id={comment.authorId} />
 									<Text color={theme.secondary2}>
-										{' ' + timeAgo(decodeTime(comment.id))}
+										{' ' + timeAgo(clampUlidTime(decodeTime(comment.id)))}
 									</Text>
 								</Box>
 							</Box>

--- a/source/lib/event/date-utils.ts
+++ b/source/lib/event/date-utils.ts
@@ -2,49 +2,49 @@ import {decodeTime} from 'ulid';
 import {failed, Result, succeeded} from '../model/result-types.js';
 import {AppEvent} from './event.model.js';
 
-// Mirrors MAX_EDGE_AHEAD_MS in event-persist: honest clock skew is minutes.
-// The mint guard keeps new ids near the wall clock, but the log is append-only,
-// so a far-future id already in it is permanent — its decoded time is not a
-// fact. Clamp before displaying, pacing or windowing by it.
-const MAX_ULID_AHEAD_MS = 24 * 60 * 60 * 1000;
+// Honest clock skew between machines is minutes; a decoded time further ahead
+// than this is not a fact about time. Also bounds the mint seed in event-persist.
+export const MAX_ULID_AHEAD_MS = 24 * 60 * 60 * 1000;
 
 export const clampUlidTime = (t: number, now = Date.now()): number =>
 	t > now + MAX_ULID_AHEAD_MS ? now : t;
 
-// For consumers that compare times within one event set (time-travel cuts,
-// replay pacing, timeline windows): a poisoned time becomes the latest honest
-// time in the set, so its placement is the same on every machine no matter
-// when the set is read. Nulls (undecodable ids) pass through.
-export const clampUlidTimes = (
+// Display-boundary decode: a poisoned far-future id reads as now. Throws like
+// decodeTime on an undecodable id.
+export const ulidTimeMs = (id: string): number => clampUlidTime(decodeTime(id));
+
+// Effective times for one causally ordered event set: a poisoned time inherits
+// its predecessor's (else the first honest) time, deterministically per set. A
+// set with no honest time passes through raw; nulls (undecodable ids) pass through.
+export const toEffectiveUlidTimes = (
 	times: ReadonlyArray<number | null>,
 ): Array<number | null> => {
 	const ceiling = Date.now() + MAX_ULID_AHEAD_MS;
-	let latestHonest: number | null = null;
+	const firstHonest = times.find(t => t !== null && t <= ceiling) ?? null;
+	if (firstHonest === null) return [...times];
 
-	for (const t of times) {
-		if (
-			t !== null &&
-			t <= ceiling &&
-			(latestHonest === null || t > latestHonest)
-		) {
-			latestHonest = t;
-		}
-	}
+	let previous: number | null = null;
 
-	return times.map(t =>
-		t === null || t <= ceiling ? t : latestHonest ?? Date.now(),
-	);
+	return times.map(t => {
+		if (t === null) return null;
+
+		const effective = t <= ceiling ? t : previous ?? firstHonest;
+		previous = effective;
+
+		return effective;
+	});
 };
 
 export const safeDateFromUlid = (id: string): Result<Date> => {
 	try {
-		return succeeded('Decoded date', new Date(clampUlidTime(decodeTime(id))));
+		return succeeded('Decoded date', new Date(ulidTimeMs(id)));
 	} catch (error) {
 		return failed('Decoding failed + ' + (error as Error).message);
 	}
 };
 
-// Raw decode — route display or cross-event comparisons through clampUlidTime(s).
+// Raw decode — route displays through ulidTimeMs and cross-event comparisons
+// through toEffectiveUlidTimes.
 export const getEventTime = (event: AppEvent | undefined): number | null => {
 	if (!event?.id) return null;
 

--- a/source/lib/event/date-utils.ts
+++ b/source/lib/event/date-utils.ts
@@ -2,14 +2,49 @@ import {decodeTime} from 'ulid';
 import {failed, Result, succeeded} from '../model/result-types.js';
 import {AppEvent} from './event.model.js';
 
+// Mirrors MAX_EDGE_AHEAD_MS in event-persist: honest clock skew is minutes.
+// The mint guard keeps new ids near the wall clock, but the log is append-only,
+// so a far-future id already in it is permanent — its decoded time is not a
+// fact. Clamp before displaying, pacing or windowing by it.
+const MAX_ULID_AHEAD_MS = 24 * 60 * 60 * 1000;
+
+export const clampUlidTime = (t: number, now = Date.now()): number =>
+	t > now + MAX_ULID_AHEAD_MS ? now : t;
+
+// For consumers that compare times within one event set (time-travel cuts,
+// replay pacing, timeline windows): a poisoned time becomes the latest honest
+// time in the set, so its placement is the same on every machine no matter
+// when the set is read. Nulls (undecodable ids) pass through.
+export const clampUlidTimes = (
+	times: ReadonlyArray<number | null>,
+): Array<number | null> => {
+	const ceiling = Date.now() + MAX_ULID_AHEAD_MS;
+	let latestHonest: number | null = null;
+
+	for (const t of times) {
+		if (
+			t !== null &&
+			t <= ceiling &&
+			(latestHonest === null || t > latestHonest)
+		) {
+			latestHonest = t;
+		}
+	}
+
+	return times.map(t =>
+		t === null || t <= ceiling ? t : latestHonest ?? Date.now(),
+	);
+};
+
 export const safeDateFromUlid = (id: string): Result<Date> => {
 	try {
-		return succeeded('Decoded date', new Date(decodeTime(id)));
+		return succeeded('Decoded date', new Date(clampUlidTime(decodeTime(id))));
 	} catch (error) {
 		return failed('Decoding failed + ' + (error as Error).message);
 	}
 };
 
+// Raw decode — route display or cross-event comparisons through clampUlidTime(s).
 export const getEventTime = (event: AppEvent | undefined): number | null => {
 	if (!event?.id) return null;
 

--- a/source/lib/event/event-boot.ts
+++ b/source/lib/event/event-boot.ts
@@ -241,8 +241,15 @@ const isCheckedOutInThePast = (): boolean => {
 const reportUnreadableEvents = (unreadable: UnreadableEvent[]): void => {
 	if (unreadable.length === 0) return;
 
-	const corrupt = unreadable.filter(event => event.reason === 'corrupt-line');
-	const newer = unreadable.filter(event => event.reason !== 'corrupt-line');
+	const corrupt = unreadable.filter(
+		event =>
+			event.reason === 'corrupt-line' || event.reason === 'invalid-payload',
+	);
+	const newer = unreadable.filter(
+		event =>
+			event.reason === 'unsupported-schema-version' ||
+			event.reason === 'unknown-action',
+	);
 
 	if (newer.length > 0) {
 		const detail = [...new Set(newer.map(event => event.detail))].join(', ');
@@ -252,7 +259,7 @@ const reportUnreadableEvents = (unreadable: UnreadableEvent[]): void => {
 		);
 	}
 
-	// Not an upgrade problem: these lines have no envelope, so they are lost
+	// Not an upgrade problem: these lines are malformed, so they are lost
 	// rather than pending. Named precisely so the damage can be located.
 	if (corrupt.length > 0) {
 		const detail = [...new Set(corrupt.map(event => event.detail))].join(', ');

--- a/source/lib/event/event-load.ts
+++ b/source/lib/event/event-load.ts
@@ -5,6 +5,7 @@ import {z} from 'zod';
 import {logger} from '../../logger.js';
 import {failed, isFail, Result, succeeded} from '../model/result-types.js';
 import {getEventsDirPath} from '../storage/paths.js';
+import {clampUlidTimes} from './date-utils.js';
 import {AppEvent, AppEventMap, isKnownEventAction} from './event.model.js';
 import {
 	isSupportedSchemaVersion,
@@ -550,17 +551,25 @@ export const splitEventsAtTime = (
 	const appliedEvents: ReconstructedEvent[] = [];
 	const unappliedEvents: ReconstructedEvent[] = [];
 
-	for (const event of events) {
+	// Clamped over the whole set so a poisoned far-future id cuts at the latest
+	// honest time instead of hiding its causal descendants from every checkout.
+	const times = clampUlidTimes(
+		events.map(event => {
+			try {
+				return decodeTime(event.id[0]);
+			} catch {
+				return null;
+			}
+		}),
+	);
+
+	for (let index = 0; index < events.length; index++) {
+		const event = events[index]!;
 		const eventId = event.id[0];
 		const refId = event.id[1];
 
-		let shouldBeApplied = false;
-
-		try {
-			shouldBeApplied = decodeTime(eventId) < targetTime;
-		} catch {
-			shouldBeApplied = false;
-		}
+		const time = times[index] ?? null;
+		const shouldBeApplied = time !== null && time < targetTime;
 
 		if (!shouldBeApplied || (refId && unappliedIds.has(refId))) {
 			unappliedIds.add(eventId);

--- a/source/lib/event/event-load.ts
+++ b/source/lib/event/event-load.ts
@@ -5,7 +5,7 @@ import {z} from 'zod';
 import {logger} from '../../logger.js';
 import {failed, isFail, Result, succeeded} from '../model/result-types.js';
 import {getEventsDirPath} from '../storage/paths.js';
-import {clampUlidTimes} from './date-utils.js';
+import {toEffectiveUlidTimes} from './date-utils.js';
 import {AppEvent, AppEventMap, isKnownEventAction} from './event.model.js';
 import {
 	isSupportedSchemaVersion,
@@ -540,6 +540,43 @@ export const getSortedEvents = (
 	return result;
 };
 
+// The time a checkout cut judges each event by: raw where honest, inherited
+// where poisoned. One computation over the full reconstructed set, so every
+// consumer of a cut agrees on where a poisoned id falls.
+export const effectiveEventTimes = (
+	events: ReadonlyArray<Pick<ReconstructedEvent, 'id'>>,
+): Array<number | null> =>
+	toEffectiveUlidTimes(
+		events.map(event => {
+			try {
+				return decodeTime(event.id[0]);
+			} catch {
+				return null;
+			}
+		}),
+	);
+
+// For callers that pick a cut time from one event (`:peek prev/next`) — the
+// values come from the same full set splitEventsAtTime will judge by.
+export function loadEffectiveEventTimes(
+	stateBranchRoot: string,
+): Result<Map<string, number | null>> {
+	const allEvents = loadAllPersistedEvents(stateBranchRoot);
+	if (isFail(allEvents)) return failed(allEvents.message);
+
+	const times = effectiveEventTimes(allEvents.value);
+
+	return succeeded(
+		'Loaded effective event times',
+		new Map(
+			allEvents.value.map((event, index) => [
+				event.id[0],
+				times[index] ?? null,
+			]),
+		),
+	);
+}
+
 export const splitEventsAtTime = (
 	events: ReconstructedEvent[],
 	targetTime: number,
@@ -551,17 +588,7 @@ export const splitEventsAtTime = (
 	const appliedEvents: ReconstructedEvent[] = [];
 	const unappliedEvents: ReconstructedEvent[] = [];
 
-	// Clamped over the whole set so a poisoned far-future id cuts at the latest
-	// honest time instead of hiding its causal descendants from every checkout.
-	const times = clampUlidTimes(
-		events.map(event => {
-			try {
-				return decodeTime(event.id[0]);
-			} catch {
-				return null;
-			}
-		}),
-	);
+	const times = effectiveEventTimes(events);
 
 	for (let index = 0; index < events.length; index++) {
 		const event = events[index]!;

--- a/source/lib/event/event-load.ts
+++ b/source/lib/event/event-load.ts
@@ -516,10 +516,15 @@ export const getSortedEvents = (
 
 	// Only genesis is a legal root. Any other `refId: null` event — trivially
 	// forgeable, and able to sort in front of all of history via a low ULID —
-	// is anchored after the known history, with the orphans.
-	const roots = (childrenByRef.get(null) ?? []).filter(
-		event => 'init.workspace' in event,
-	);
+	// is anchored after the known history, with the orphans. Exactly one action
+	// key, or extra keys smuggle a payload past a bare `in` check.
+	const roots = (childrenByRef.get(null) ?? []).filter(event => {
+		const keys = Object.keys(event).filter(
+			key =>
+				key !== 'id' && key !== 'v' && key !== 'userId' && key !== 'userName',
+		);
+		return keys.length === 1 && keys[0] === 'init.workspace';
+	});
 	for (const root of roots) {
 		visit(root);
 	}

--- a/source/lib/event/event-load.ts
+++ b/source/lib/event/event-load.ts
@@ -30,7 +30,11 @@ export type ReconstructedEvent = PersistedEnvelope & {
 // `targetNodeId` scopes the resulting lock.
 export type UnreadableEvent = {
 	eventId: string | null;
-	reason: 'unsupported-schema-version' | 'unknown-action' | 'corrupt-line';
+	reason:
+		| 'unsupported-schema-version'
+		| 'unknown-action'
+		| 'invalid-payload'
+		| 'corrupt-line';
 	detail: string;
 	targetNodeId: string | null;
 };
@@ -207,12 +211,18 @@ export const decodeReconstructedEvents = (
 
 		const eventResult = fromPersistedEvent(entry);
 
+		// Quarantined, not fatal: `merge=union` splices any line a peer pushes
+		// into every clone, so a malformed payload that failed the load would
+		// brick the board for everyone, permanently. The envelope parsed, so the
+		// event keeps its place in the chain.
 		if (isFail(eventResult)) {
-			return failed(
-				`Failed to decode event ${entry.id?.[0] ?? '<unknown>'}: ${
-					eventResult.message
-				}`,
-			);
+			unreadable?.push({
+				eventId: entry.id[0],
+				reason: 'invalid-payload',
+				detail: eventResult.message,
+				targetNodeId: getTargetNodeId(entry),
+			});
+			continue;
 		}
 
 		// Events written by a newer epiq may carry actions this version does

--- a/source/lib/event/event-materialize.ts
+++ b/source/lib/event/event-materialize.ts
@@ -212,6 +212,7 @@ type ReplayBatch = {
 	appLog: AppEvent[];
 	nodeLog: Map<string, AppEvent[]>;
 	virtualNodeIds: Set<string>;
+	genesisApplied: boolean;
 };
 
 let replayBatch: ReplayBatch | null = null;
@@ -937,6 +938,20 @@ export function materialize<A extends EventAction>(
 		);
 	}
 
+	// Genesis initializes state from scratch, so a second one part-way through a
+	// replay discards everything applied before it. A forged root carrying a lone
+	// `init.workspace` satisfies the root filter, and a high ULID anchors it
+	// after real history — one such line would empty the board on every clone
+	// that pulled it. Only the replay's first genesis counts; the guard is per
+	// batch because state stays initialized between replays.
+	if (event.action === 'init.workspace' && replayBatch) {
+		if (replayBatch.genesisApplied) {
+			return materializeSkip('the workspace is already initialized', event);
+		}
+
+		replayBatch.genesisApplied = true;
+	}
+
 	const result = handler(event);
 	if (isFail(result)) return result;
 
@@ -960,6 +975,7 @@ export const materializeAll = <const T extends readonly AppEvent[]>(
 				appLog: [],
 				nodeLog: new Map(),
 				virtualNodeIds: new Set(),
+				genesisApplied: false,
 			};
 		}
 

--- a/source/lib/event/event-persist.ts
+++ b/source/lib/event/event-persist.ts
@@ -8,6 +8,7 @@ import {failed, isFail, Result, succeeded} from '../model/result-types.js';
 import {getSettingsState, User} from '../state/settings.state.js';
 import {ensureEventsDir, getEventsDirPath} from '../storage/paths.js';
 import {sanitizeFilePart} from '../utils/file-part.js';
+import {MAX_ULID_AHEAD_MS} from './date-utils.js';
 import {getEdgeRef} from './event-load.js';
 import {
 	AppEvent,
@@ -28,11 +29,9 @@ const getNextId = monotonicFactory();
 // successor.
 const ULID_TIME_MAX = 281474976710655;
 
-// Honest clock skew between machines is minutes. An edge further ahead of the
-// wall clock than this would, via `Math.max` below, become the lower bound of
-// every id minted by every client from then on — one century-out ULID drags
-// all later `createdAt`s and the whole time-travel axis with it, permanently.
-const MAX_EDGE_AHEAD_MS = 24 * 60 * 60 * 1000;
+// An edge further ahead than this would, via `Math.max` below, become the
+// lower bound of every id minted by every client from then on, permanently.
+const MAX_EDGE_AHEAD_MS = MAX_ULID_AHEAD_MS;
 
 /**
  * The edge's timestamp is a lower bound for the next id and nothing more —

--- a/source/lib/event/format-log-utils.ts
+++ b/source/lib/event/format-log-utils.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import stringWidth from 'string-width';
 import {decodeTime} from 'ulid';
+import {clampUlidTime} from './date-utils.js';
 import {nodeRepo} from '../repository/node-repo.js';
 import {getState} from '../state/state.js';
 import {getStringColor} from '../utils/color.js';
@@ -169,7 +170,7 @@ const formatEventDetails = (event: AppEvent): string => {
 };
 
 const formatLogTime = (id: string): string => {
-	const ago = timeAgo(decodeTime(id));
+	const ago = timeAgo(clampUlidTime(decodeTime(id)));
 	return chalk.gray(padVisibleStart(ago, 8));
 };
 

--- a/source/lib/event/format-log-utils.ts
+++ b/source/lib/event/format-log-utils.ts
@@ -1,7 +1,6 @@
 import chalk from 'chalk';
 import stringWidth from 'string-width';
-import {decodeTime} from 'ulid';
-import {clampUlidTime} from './date-utils.js';
+import {ulidTimeMs} from './date-utils.js';
 import {nodeRepo} from '../repository/node-repo.js';
 import {getState} from '../state/state.js';
 import {getStringColor} from '../utils/color.js';
@@ -170,7 +169,7 @@ const formatEventDetails = (event: AppEvent): string => {
 };
 
 const formatLogTime = (id: string): string => {
-	const ago = timeAgo(clampUlidTime(decodeTime(id)));
+	const ago = timeAgo(ulidTimeMs(id));
 	return chalk.gray(padVisibleStart(ago, 8));
 };
 

--- a/source/mcp/epiq-api.ts
+++ b/source/mcp/epiq-api.ts
@@ -6,6 +6,7 @@ import {ensureLocalStateBranch, ensureStateBranchWorktree} from '../git/git.js';
 import {syncEpiqWithRemote} from '../git/sync.js';
 import {loadSettingsFromConfig} from '../lib/config/user-config.js';
 import {createIssueEvents} from '../lib/event/common-events.js';
+import {clampUlidTime} from '../lib/event/date-utils.js';
 import {bootStateFromEventLog} from '../lib/event/event-boot.js';
 import {
 	loadEventActors,
@@ -453,7 +454,7 @@ export const getIssue = async (input: GetIssueInput) => {
 		ref: nodeRef(issue.id),
 		title: sanitizeInlineText(issue.title),
 		description: issue.props.description ?? '',
-		createdAt: decodeTime(issue.id),
+		createdAt: clampUlidTime(decodeTime(issue.id)),
 		parentNodeId: issue.parentNodeId!,
 		isClosed: issue.parentNodeId === CLOSED_SWIMLANE_ID,
 		readonly: Boolean(issue.readonly),
@@ -487,7 +488,7 @@ export const listIssues = async (input: ListIssuesInput) => {
 					ref: nodeRef(n.id),
 					title: sanitizeInlineText(n.title),
 					description: n.props.description ?? '',
-					createdAt: decodeTime(n.id),
+					createdAt: clampUlidTime(decodeTime(n.id)),
 					parentNodeId: n.parentNodeId!,
 					isClosed: n.parentNodeId === CLOSED_SWIMLANE_ID,
 					readonly: Boolean(n.readonly),
@@ -1071,7 +1072,7 @@ export const getIssueHistory = (
 		'Read issue history',
 		(issue.log ?? []).map(event => ({
 			id: event.id,
-			t: decodeTime(event.id),
+			t: clampUlidTime(decodeTime(event.id)),
 			action: event.action,
 			label: describeEvent(event),
 			actor: {
@@ -1154,7 +1155,7 @@ export const deriveGuiState = (): Result<ApiState> => {
 						name: contributor?.name ?? 'Unknown',
 						color: getStringColor(contributor?.name ?? comment.authorId),
 					},
-					createdAt: decodeTime(comment.id),
+					createdAt: clampUlidTime(decodeTime(comment.id)),
 				};
 			});
 	}
@@ -1179,7 +1180,7 @@ export const deriveGuiState = (): Result<ApiState> => {
 				name: attachment.name,
 				fileName: getAttachmentFileName(attachment.hash, attachment.ext),
 				bytes: attachment.bytes,
-				createdAt: decodeTime(attachment.id),
+				createdAt: clampUlidTime(decodeTime(attachment.id)),
 				canDelete:
 					attachmentOwners.get(attachment.id) === settingsRes.value.userId,
 			}));
@@ -1208,7 +1209,7 @@ export const deriveGuiState = (): Result<ApiState> => {
 										ref: nodeRef(issue.id),
 										title: sanitizeInlineText(issue.title),
 										description: issue.props.description ?? '',
-										createdAt: decodeTime(issue.id),
+										createdAt: clampUlidTime(decodeTime(issue.id)),
 										readonly: Boolean(issue.readonly) || forceReadonly,
 										tags: getIssueTags(issue),
 										assignees: getIssueAssignees(issue),

--- a/source/mcp/epiq-api.ts
+++ b/source/mcp/epiq-api.ts
@@ -1,4 +1,4 @@
-import {decodeTime, ulid} from 'ulid';
+import {ulid} from 'ulid';
 import {getStateBranchRoot} from '../git/git-storage.js';
 import {execGit} from '../git/git-utils.js';
 import {getStateBranch} from '../git/git-constants.js';
@@ -6,7 +6,7 @@ import {ensureLocalStateBranch, ensureStateBranchWorktree} from '../git/git.js';
 import {syncEpiqWithRemote} from '../git/sync.js';
 import {loadSettingsFromConfig} from '../lib/config/user-config.js';
 import {createIssueEvents} from '../lib/event/common-events.js';
-import {clampUlidTime} from '../lib/event/date-utils.js';
+import {ulidTimeMs} from '../lib/event/date-utils.js';
 import {bootStateFromEventLog} from '../lib/event/event-boot.js';
 import {
 	loadEventActors,
@@ -454,7 +454,7 @@ export const getIssue = async (input: GetIssueInput) => {
 		ref: nodeRef(issue.id),
 		title: sanitizeInlineText(issue.title),
 		description: issue.props.description ?? '',
-		createdAt: clampUlidTime(decodeTime(issue.id)),
+		createdAt: ulidTimeMs(issue.id),
 		parentNodeId: issue.parentNodeId!,
 		isClosed: issue.parentNodeId === CLOSED_SWIMLANE_ID,
 		readonly: Boolean(issue.readonly),
@@ -488,7 +488,7 @@ export const listIssues = async (input: ListIssuesInput) => {
 					ref: nodeRef(n.id),
 					title: sanitizeInlineText(n.title),
 					description: n.props.description ?? '',
-					createdAt: clampUlidTime(decodeTime(n.id)),
+					createdAt: ulidTimeMs(n.id),
 					parentNodeId: n.parentNodeId!,
 					isClosed: n.parentNodeId === CLOSED_SWIMLANE_ID,
 					readonly: Boolean(n.readonly),
@@ -1072,7 +1072,7 @@ export const getIssueHistory = (
 		'Read issue history',
 		(issue.log ?? []).map(event => ({
 			id: event.id,
-			t: clampUlidTime(decodeTime(event.id)),
+			t: ulidTimeMs(event.id),
 			action: event.action,
 			label: describeEvent(event),
 			actor: {
@@ -1155,7 +1155,7 @@ export const deriveGuiState = (): Result<ApiState> => {
 						name: contributor?.name ?? 'Unknown',
 						color: getStringColor(contributor?.name ?? comment.authorId),
 					},
-					createdAt: clampUlidTime(decodeTime(comment.id)),
+					createdAt: ulidTimeMs(comment.id),
 				};
 			});
 	}
@@ -1180,7 +1180,7 @@ export const deriveGuiState = (): Result<ApiState> => {
 				name: attachment.name,
 				fileName: getAttachmentFileName(attachment.hash, attachment.ext),
 				bytes: attachment.bytes,
-				createdAt: clampUlidTime(decodeTime(attachment.id)),
+				createdAt: ulidTimeMs(attachment.id),
 				canDelete:
 					attachmentOwners.get(attachment.id) === settingsRes.value.userId,
 			}));
@@ -1209,7 +1209,7 @@ export const deriveGuiState = (): Result<ApiState> => {
 										ref: nodeRef(issue.id),
 										title: sanitizeInlineText(issue.title),
 										description: issue.props.description ?? '',
-										createdAt: clampUlidTime(decodeTime(issue.id)),
+										createdAt: ulidTimeMs(issue.id),
 										readonly: Boolean(issue.readonly) || forceReadonly,
 										tags: getIssueTags(issue),
 										assignees: getIssueAssignees(issue),

--- a/source/mcp/epiq-time-travel.ts
+++ b/source/mcp/epiq-time-travel.ts
@@ -11,7 +11,7 @@ import {
 	openEditorDiffNonBlocking,
 	openEditorOnFileNonBlocking,
 } from '../lib/editor/editor.js';
-import {clampUlidTimes, getEventTime} from '../lib/event/date-utils.js';
+import {getEventTime, toEffectiveUlidTimes} from '../lib/event/date-utils.js';
 import {AppEvent, EventAction} from '../lib/event/event.model.js';
 import {formatLogAction} from '../lib/event/format-log-utils.js';
 import {getStringColor} from '../lib/utils/color.js';
@@ -288,14 +288,20 @@ export const getEventTimeline = async (
 	// ULIDs where it means "bug" or "jola".
 	const names = buildNameIndex(eventsResult.value);
 
-	// Set-clamped: a poisoned far-future id lands at the latest honest time
-	// instead of falling outside every window ending at now.
-	const clampedTimes = clampUlidTimes(
-		scopedEvents.map(event => getEventTime(event)),
+	// Effective times over the full log, not the board-scoped subset, so a
+	// poisoned id's dot lands where the scrub/checkout path will cut.
+	const effectiveTimes = toEffectiveUlidTimes(
+		eventsResult.value.map(event => getEventTime(event)),
+	);
+	const timeByEventId = new Map(
+		eventsResult.value.map((event, index) => [
+			event.id,
+			effectiveTimes[index] ?? null,
+		]),
 	);
 
-	const timed = scopedEvents.flatMap((event, index) => {
-		const t = clampedTimes[index] ?? null;
+	const timed = scopedEvents.flatMap(event => {
+		const t = timeByEventId.get(event.id) ?? null;
 
 		return t === null
 			? []

--- a/source/mcp/epiq-time-travel.ts
+++ b/source/mcp/epiq-time-travel.ts
@@ -11,7 +11,7 @@ import {
 	openEditorDiffNonBlocking,
 	openEditorOnFileNonBlocking,
 } from '../lib/editor/editor.js';
-import {getEventTime} from '../lib/event/date-utils.js';
+import {clampUlidTimes, getEventTime} from '../lib/event/date-utils.js';
 import {AppEvent, EventAction} from '../lib/event/event.model.js';
 import {formatLogAction} from '../lib/event/format-log-utils.js';
 import {getStringColor} from '../lib/utils/color.js';
@@ -288,8 +288,14 @@ export const getEventTimeline = async (
 	// ULIDs where it means "bug" or "jola".
 	const names = buildNameIndex(eventsResult.value);
 
-	const timed = scopedEvents.flatMap(event => {
-		const t = getEventTime(event);
+	// Set-clamped: a poisoned far-future id lands at the latest honest time
+	// instead of falling outside every window ending at now.
+	const clampedTimes = clampUlidTimes(
+		scopedEvents.map(event => getEventTime(event)),
+	);
+
+	const timed = scopedEvents.flatMap((event, index) => {
+		const t = clampedTimes[index] ?? null;
 
 		return t === null
 			? []

--- a/source/scripts/watch-npm.mjs
+++ b/source/scripts/watch-npm.mjs
@@ -20,7 +20,7 @@ const index = await esbuild.context({
 
 const mcp = await esbuild.context({
 	...shared,
-	entryPoints: ['source/mcp/server.ts'],
+	entryPoints: ['source/mcp/index.ts'],
 	outfile: 'dist/mcp.js',
 });
 

--- a/source/test/epiq-time-travel.test.ts
+++ b/source/test/epiq-time-travel.test.ts
@@ -231,6 +231,33 @@ describe('epiq-time-travel', () => {
 			]);
 		});
 
+		it('keeps a poisoned far-future event visible at the latest honest time', async () => {
+			const baseTime = Date.now() - 60_000;
+			const poisonedTime = Date.now() + 100 * 365 * 24 * 60 * 60 * 1000;
+			const events = [
+				{id: ulid(baseTime), action: 'add.issue'},
+				{id: ulid(baseTime + 10_000), action: 'close.issue'},
+				{id: ulid(poisonedTime), action: 'add.issue.tag'},
+			];
+
+			vi.mocked(loadMergedEvents).mockReturnValue(
+				succeeded('events', events as never),
+			);
+
+			const result = await getEventTimeline();
+
+			expect(isSuccess(result)).toBe(true);
+			if (isFail(result)) return;
+
+			// The default window ends at now; the poisoned event must not fall
+			// outside it, and must land at the set's latest honest time.
+			expect(result.value.events).toHaveLength(3);
+			const poisoned = result.value.events.find(
+				entry => entry.action === 'add.issue.tag',
+			);
+			expect(poisoned?.t).toBe(baseTime + 10_000);
+		});
+
 		it('keeps comments, which hang off `issue` rather than `parent`', async () => {
 			const baseTime = 1_700_000_000_000;
 			const events = [

--- a/source/test/event-date-utils.test.ts
+++ b/source/test/event-date-utils.test.ts
@@ -2,8 +2,9 @@ import {describe, expect, it} from 'vitest';
 import {ulid} from 'ulid';
 import {
 	clampUlidTime,
-	clampUlidTimes,
 	safeDateFromUlid,
+	toEffectiveUlidTimes,
+	ulidTimeMs,
 } from '../lib/event/date-utils.js';
 import {isSuccess} from '../lib/model/result-types.js';
 
@@ -28,31 +29,68 @@ describe('clampUlidTime', () => {
 	});
 });
 
-describe('clampUlidTimes', () => {
-	it('maps a poisoned time to the latest honest time in the set', () => {
-		const now = Date.now();
-		const honest = [now - 10_000, now - 5_000];
+describe('ulidTimeMs', () => {
+	it('decodes an honest id exactly', () => {
+		const t = Date.now() - 5_000;
+		expect(ulidTimeMs(ulid(t))).toBe(t);
+	});
 
-		expect(clampUlidTimes([...honest, now + CENTURY_MS])).toEqual([
-			...honest,
+	it('clamps a poisoned id to the present', () => {
+		const before = Date.now();
+		const t = ulidTimeMs(ulid(before + CENTURY_MS));
+		const after = Date.now();
+
+		expect(t).toBeGreaterThanOrEqual(before);
+		expect(t).toBeLessThanOrEqual(after);
+	});
+});
+
+describe('toEffectiveUlidTimes', () => {
+	it('gives a poisoned time its predecessor’s effective time, not the set maximum', () => {
+		const now = Date.now();
+		const times = [now - 10_000, now + CENTURY_MS, now - 5_000];
+
+		expect(toEffectiveUlidTimes(times)).toEqual([
+			now - 10_000,
+			now - 10_000,
 			now - 5_000,
 		]);
 	});
 
-	it('leaves nulls and honest times untouched', () => {
+	it('chains inherited times through consecutive poisoned entries', () => {
 		const now = Date.now();
-		const times = [null, now - 1_000, null];
+		const times = [now - 10_000, now + CENTURY_MS, now + CENTURY_MS * 2];
 
-		expect(clampUlidTimes(times)).toEqual(times);
+		expect(toEffectiveUlidTimes(times)).toEqual([
+			now - 10_000,
+			now - 10_000,
+			now - 10_000,
+		]);
 	});
 
-	it('falls back to now when every time is poisoned', () => {
-		const before = Date.now();
-		const [clamped] = clampUlidTimes([before + CENTURY_MS]);
-		const after = Date.now();
+	it('falls back to the first honest time for a poisoned leading entry', () => {
+		const now = Date.now();
+		const times = [now + CENTURY_MS, now - 5_000];
 
-		expect(clamped).toBeGreaterThanOrEqual(before);
-		expect(clamped).toBeLessThanOrEqual(after);
+		expect(toEffectiveUlidTimes(times)).toEqual([now - 5_000, now - 5_000]);
+	});
+
+	it('passes an all-poisoned set through raw, keeping it self-consistent', () => {
+		const now = Date.now();
+		const times = [now + CENTURY_MS, now + CENTURY_MS + 1_000];
+
+		expect(toEffectiveUlidTimes(times)).toEqual(times);
+	});
+
+	it('passes nulls through without advancing the inheritance', () => {
+		const now = Date.now();
+		const times = [now - 10_000, null, now + CENTURY_MS];
+
+		expect(toEffectiveUlidTimes(times)).toEqual([
+			now - 10_000,
+			null,
+			now - 10_000,
+		]);
 	});
 });
 

--- a/source/test/event-date-utils.test.ts
+++ b/source/test/event-date-utils.test.ts
@@ -1,0 +1,71 @@
+import {describe, expect, it} from 'vitest';
+import {ulid} from 'ulid';
+import {
+	clampUlidTime,
+	clampUlidTimes,
+	safeDateFromUlid,
+} from '../lib/event/date-utils.js';
+import {isSuccess} from '../lib/model/result-types.js';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const CENTURY_MS = 100 * 365 * DAY_MS;
+
+describe('clampUlidTime', () => {
+	it('passes an honest time through untouched', () => {
+		const t = Date.now() - 5_000;
+		expect(clampUlidTime(t)).toBe(t);
+	});
+
+	it('tolerates a time within a day of skew ahead', () => {
+		const now = Date.now();
+		const t = now + 60_000;
+		expect(clampUlidTime(t, now)).toBe(t);
+	});
+
+	it('clamps a far-future time to now', () => {
+		const now = Date.now();
+		expect(clampUlidTime(now + CENTURY_MS, now)).toBe(now);
+	});
+});
+
+describe('clampUlidTimes', () => {
+	it('maps a poisoned time to the latest honest time in the set', () => {
+		const now = Date.now();
+		const honest = [now - 10_000, now - 5_000];
+
+		expect(clampUlidTimes([...honest, now + CENTURY_MS])).toEqual([
+			...honest,
+			now - 5_000,
+		]);
+	});
+
+	it('leaves nulls and honest times untouched', () => {
+		const now = Date.now();
+		const times = [null, now - 1_000, null];
+
+		expect(clampUlidTimes(times)).toEqual(times);
+	});
+
+	it('falls back to now when every time is poisoned', () => {
+		const before = Date.now();
+		const [clamped] = clampUlidTimes([before + CENTURY_MS]);
+		const after = Date.now();
+
+		expect(clamped).toBeGreaterThanOrEqual(before);
+		expect(clamped).toBeLessThanOrEqual(after);
+	});
+});
+
+describe('safeDateFromUlid', () => {
+	it('clamps a poisoned id to the present instead of a far-future date', () => {
+		const before = Date.now();
+		const result = safeDateFromUlid(ulid(before + CENTURY_MS));
+		const after = Date.now();
+
+		expect(isSuccess(result)).toBe(true);
+		if (!isSuccess(result)) return;
+
+		expect(result.value.getTime()).toBeGreaterThanOrEqual(before);
+		expect(result.value.getTime()).toBeLessThanOrEqual(after);
+	});
+});

--- a/source/test/event-load.test.ts
+++ b/source/test/event-load.test.ts
@@ -12,6 +12,7 @@ import {
 	loadMergedEventsWithUnreadable,
 	ReconstructedEvent,
 	splitEventsAtTime,
+	UnreadableEvent,
 } from '../lib/event/event-load.js';
 import {persist} from '../lib/event/event-persist.js';
 import {AppEvent} from '../lib/event/event.model.js';
@@ -400,7 +401,7 @@ describe('decodeReconstructedEvents', () => {
 		]);
 	});
 
-	it('still fails on structurally invalid entries', () => {
+	it('quarantines an entry with no action key instead of failing the load', () => {
 		const malformed = {
 			id: ['01KQMFD60TR62NRKX8B32KNKWH', null],
 			userId: 'user',
@@ -408,9 +409,36 @@ describe('decodeReconstructedEvents', () => {
 			v: 1,
 		} as unknown as ReconstructedEvent;
 
-		const result = decodeReconstructedEvents([malformed]);
+		const unreadable: UnreadableEvent[] = [];
+		const result = decodeReconstructedEvents([malformed], unreadable);
 
-		expect(isFail(result)).toBe(true);
+		expect(isFail(result)).toBe(false);
+		if (isFail(result)) return;
+		expect(result.value).toEqual([]);
+		expect(unreadable.map(e => e.reason)).toEqual(['invalid-payload']);
+	});
+
+	it('quarantines an entry with two action keys instead of failing the load', () => {
+		const goodId = '01KQMFD60TR62NRKX8B32KNKWH';
+		const twoKeys = {
+			id: ['01KQN37Z9877YBRV6P2YG7Q62S', goodId],
+			'evil.event': {},
+			'init.workspace': {id: 'ws', name: 'Forged'},
+			userId: 'user',
+			userName: 'User',
+			v: 1,
+		} as unknown as ReconstructedEvent;
+
+		const unreadable: UnreadableEvent[] = [];
+		const result = decodeReconstructedEvents(
+			[entry(goodId, 'edit.title', {id: 'node-1', name: 'Renamed'}), twoKeys],
+			unreadable,
+		);
+
+		expect(isFail(result)).toBe(false);
+		if (isFail(result)) return;
+		expect(result.value.map(e => e.action)).toEqual(['edit.title']);
+		expect(unreadable.map(e => e.reason)).toEqual(['invalid-payload']);
 	});
 });
 

--- a/source/test/event-load.test.ts
+++ b/source/test/event-load.test.ts
@@ -135,6 +135,25 @@ describe('getSortedEvents', () => {
 		]);
 	});
 
+	// An `init.workspace` key alongside another action would otherwise pass a
+	// bare `'init.workspace' in event` check and front-run genesis.
+	it('anchors a forged root that smuggles an init.workspace key after history too', () => {
+		const genesis = event('01B0000000000000000000000A', null, 'init.workspace');
+		const first = event('01B0000000000000000000000B', genesis.id[0]);
+		const forged = {
+			...event('00000000000000000000000000', null, 'evil.event'),
+			'init.workspace': {id: 'ws-forged', name: 'Forged'},
+		} as ReconstructedEvent;
+
+		const sorted = getSortedEvents([forged, genesis, first]);
+
+		expect(sorted.map(e => e.id[0])).toEqual([
+			genesis.id[0],
+			first.id[0],
+			forged.id[0],
+		]);
+	});
+
 	// Every event refs its predecessor, so a log is one chain as deep as it is
 	// long. Recursing it overflowed the call stack at ~4.7k events, which meant
 	// an ordinary board eventually stopped opening for everybody at once.

--- a/source/test/event-load.test.ts
+++ b/source/test/event-load.test.ts
@@ -311,7 +311,29 @@ describe('splitEventsAtTime', () => {
 		expect(unappliedEvents).toEqual([]);
 	});
 
-	it('keeps a poisoned event unapplied for a checkout before the latest honest time', () => {
+	it('keeps honest descendants of a poisoned event visible at a historical checkout', () => {
+		const root = ulid(Date.now() - 60_000);
+		const poisoned = ulid(Date.now() + 100 * 365 * 24 * 60 * 60 * 1000);
+		const child = ulid(Date.now() - 40_000);
+		const grandChild = ulid(Date.now() - 20_000);
+
+		const {appliedEvents, unappliedEvents} = splitEventsAtTime(
+			[
+				event(root, null),
+				event(poisoned, root),
+				event(child, poisoned),
+				event(grandChild, child),
+			],
+			Date.now() - 30_000,
+		);
+
+		// The poisoned event inherits its predecessor's time, so the checkout
+		// keeps it and its honest descendants up to the target.
+		expect(appliedEvents.map(e => e.id[0])).toEqual([root, poisoned, child]);
+		expect(unappliedEvents.map(e => e.id[0])).toEqual([grandChild]);
+	});
+
+	it('keeps a poisoned event unapplied for a checkout before its inherited time', () => {
 		const early = ulid(Date.now() - 60_000);
 		const late = ulid(Date.now() - 5_000);
 		const poisoned = ulid(Date.now() + 100 * 365 * 24 * 60 * 60 * 1000);

--- a/source/test/event-load.test.ts
+++ b/source/test/event-load.test.ts
@@ -284,6 +284,46 @@ describe('splitEventsAtTime', () => {
 		expect(appliedEvents).toEqual([]);
 		expect(unappliedEvents.map(e => e.id[0])).toEqual([invalidId]);
 	});
+
+	it('applies a poisoned far-future event at a checkout of the present', () => {
+		const honest = ulid(Date.now() - 10_000);
+		const poisoned = ulid(Date.now() + 100 * 365 * 24 * 60 * 60 * 1000);
+
+		const {appliedEvents, unappliedEvents} = splitEventsAtTime(
+			[event(honest, null), event(poisoned, honest)],
+			Date.now(),
+		);
+
+		expect(appliedEvents.map(e => e.id[0])).toEqual([honest, poisoned]);
+		expect(unappliedEvents).toEqual([]);
+	});
+
+	it('does not let a poisoned event hide its honest descendants at the present', () => {
+		const poisoned = ulid(Date.now() + 100 * 365 * 24 * 60 * 60 * 1000);
+		const honestChild = ulid(Date.now() - 5_000);
+
+		const {appliedEvents, unappliedEvents} = splitEventsAtTime(
+			[event(poisoned, null), event(honestChild, poisoned)],
+			Date.now(),
+		);
+
+		expect(appliedEvents.map(e => e.id[0])).toEqual([poisoned, honestChild]);
+		expect(unappliedEvents).toEqual([]);
+	});
+
+	it('keeps a poisoned event unapplied for a checkout before the latest honest time', () => {
+		const early = ulid(Date.now() - 60_000);
+		const late = ulid(Date.now() - 5_000);
+		const poisoned = ulid(Date.now() + 100 * 365 * 24 * 60 * 60 * 1000);
+
+		const {appliedEvents, unappliedEvents} = splitEventsAtTime(
+			[event(early, null), event(late, early), event(poisoned, late)],
+			Date.now() - 30_000,
+		);
+
+		expect(appliedEvents.map(e => e.id[0])).toEqual([early]);
+		expect(unappliedEvents.map(e => e.id[0])).toEqual([late, poisoned]);
+	});
 });
 
 describe('decodeReconstructedEvents', () => {

--- a/source/test/event-materialize.test.ts
+++ b/source/test/event-materialize.test.ts
@@ -1,5 +1,9 @@
 import {beforeEach, describe, expect, it} from 'vitest';
-import {materialize, materializeAll} from '../lib/event/event-materialize.js';
+import {
+	isConvergenceFail,
+	materialize,
+	materializeAll,
+} from '../lib/event/event-materialize.js';
 import {AppEvent} from '../lib/event/event.model.js';
 import {CLOSED_SWIMLANE_ID} from '../lib/event/static-ids.js';
 import {isTicketNode} from '../lib/model/context.model.js';
@@ -260,6 +264,38 @@ describe('event materialize', () => {
 
 		expect(results).toHaveLength(2);
 		expect(results.every(result => !isFail(result as Result))).toBe(true);
+	});
+
+	// A forged root carrying a lone `init.workspace` passes the root filter by
+	// construction, and a high ULID anchors it after real history. Re-running
+	// genesis resets state, wiping the board for every clone that pulls it.
+	it('skips a second genesis rather than resetting the board', () => {
+		const results = materializeAll([
+			event('init.workspace', {
+				id: IDS.workspace,
+				name: 'Workspace',
+				rank: rank(),
+			}),
+			event('add.board', {
+				id: IDS.board,
+				name: 'Board',
+				parent: IDS.workspace,
+				rank: rank(),
+			}),
+			event('init.workspace', {
+				id: IDS.missing,
+				name: 'Forged',
+				rank: rank(),
+			}),
+		] as const);
+
+		expectOk(results[0]);
+		expectOk(results[1]);
+		// Skipped, not fatal: replay carries on past the forged root.
+		expect(isConvergenceFail(results[2])).toBe(true);
+
+		expect(nodeRepo.getNode(IDS.workspace)).toBeDefined();
+		expect(nodeRepo.getNode(IDS.board)?.parentNodeId).toBe(IDS.workspace);
 	});
 });
 

--- a/source/test/peek.cmd.test.ts
+++ b/source/test/peek.cmd.test.ts
@@ -12,6 +12,7 @@ vi.mock('../lib/actions/default/navigation-action-utils.js', () => ({
 }));
 
 vi.mock('../lib/event/event-load.js', () => ({
+	loadEffectiveEventTimes: vi.fn(),
 	loadMergedEvents: vi.fn(),
 	loadMergedEventsBefore: vi.fn(),
 	getLastUnreadableEvents: vi.fn(() => []),
@@ -52,6 +53,7 @@ import {getRepoRootDir, getStateBranchRoot} from '../git/git-storage.js';
 import {navigationUtils} from '../lib/actions/default/navigation-action-utils.js';
 
 import {
+	loadEffectiveEventTimes,
 	loadMergedEvents,
 	loadMergedEventsBefore,
 } from '../lib/event/event-load.js';
@@ -218,6 +220,10 @@ describe('peekCommand', () => {
 		const previousTime = Date.now() - 1000;
 		const previousId = ulid(previousTime);
 
+		vi.mocked(loadEffectiveEventTimes).mockReturnValue(
+			succeeded('times', new Map([[previousId, previousTime]])),
+		);
+
 		vi.mocked(getCmdState).mockReturnValue({
 			commandMeta: {
 				modifier: 'prev',
@@ -257,6 +263,10 @@ describe('peekCommand', () => {
 	it('uses next unapplied event time plus one for :peek next', async () => {
 		const nextTime = Date.now() + 1000;
 		const nextId = ulid(nextTime);
+
+		vi.mocked(loadEffectiveEventTimes).mockReturnValue(
+			succeeded('times', new Map([[nextId, nextTime]])),
+		);
 
 		vi.mocked(getCmdState).mockReturnValue({
 			commandMeta: {

--- a/source/test/peek.cmd.test.ts
+++ b/source/test/peek.cmd.test.ts
@@ -304,6 +304,50 @@ describe('peekCommand', () => {
 		);
 	});
 
+	// Events created this session hold their creation ULID in memory while the
+	// log holds the edge-chained id persist gave them, so the lookup misses on
+	// every one of them until a reload. Stepping has to fall back to the event's
+	// own time rather than report there is nothing to step to.
+	it('falls back to the event own time when the log has no entry for its id', async () => {
+		const previousTime = Date.now() - 1000;
+		const previousId = ulid(previousTime);
+
+		vi.mocked(loadEffectiveEventTimes).mockReturnValue(
+			succeeded('times', new Map([[ulid(previousTime - 5000), 1]])),
+		);
+
+		vi.mocked(getCmdState).mockReturnValue({
+			commandMeta: {
+				modifier: 'prev',
+			},
+		} as never);
+
+		vi.mocked(getState).mockReturnValue({
+			breadCrumb: [],
+			eventLog: [{id: previousId}],
+			unappliedEvents: [],
+			nodes: {
+				'board-1': {
+					id: 'board-1',
+				},
+			},
+		} as never);
+
+		vi.mocked(loadMergedEventsBefore).mockReturnValue(
+			succeeded('events', {
+				appliedEvents: [],
+				unappliedEvents: [],
+			} as never),
+		);
+
+		await peekCommand();
+
+		expect(loadMergedEventsBefore).toHaveBeenCalledWith(
+			'/repo/.epiq',
+			previousTime,
+		);
+	});
+
 	it('restores previous state if materialization fails', async () => {
 		const previousState = {
 			breadCrumb: [],


### PR DESCRIPTION
Closes four prio-tagged tickets found by review of `fix-61g931z`.

**7GBW8QW (prio-1)** — a line with two action keys passed the envelope schema but failed decode, and that failure aborted the whole load. With `merge=union` one such line pushed by any peer permanently bricked the board for everyone. It is now quarantined as `invalid-payload`, keeping its place in the chain.

**902MKKV (prio-2)** — the genesis root filter checked only for the presence of an `init.workspace` key, so extra keys smuggled a forged root past it. Now it requires exactly one action key. The review also found the ticket's second half unimplemented: a forged root carrying *only* `init.workspace` satisfies that filter by construction, and a high ULID anchors it after real history, so replay re-ran genesis and `initWorkspaceState` wiped everything applied before it. A second `init.workspace` within a replay is now skipped.

**1J17C3V (prio-2)** — `watch:npm` and `start:mcp` still entered at `mcp/server.ts`, which no longer starts the server. Both now point at `mcp/index.ts`.

**V0YQDXV (prio-3)** — an already-poisoned far-future id in the log was trusted as fact by five readers. Times are now clamped at the read boundary, and cross-event comparisons run through one effective-time computation per set, so a poisoned id inherits its predecessor's time and every consumer of a cut agrees where it falls.

Gate: lint, typecheck, prettier, 944 unit tests, e2e, collaboration and the 58 GUI browser tests all pass.