### PR TITLE
TVWQZ8S drag out a stretch of the timeline to zoom the window to it

### DIFF
--- a/source/gui/client/components/ScrubberLayout.tsx
+++ b/source/gui/client/components/ScrubberLayout.tsx
@@ -108,7 +108,9 @@ export type ScrubberChart = {
 	hoveredSegment: Segment | null;
 	// Nothing can be asked for with the socket down.
 	connected: boolean;
-	thumbFraction: number;
+	// Null when the moment it marks is outside the window, which is drawn as no
+	// needle at all rather than one clamped to an edge it is not at.
+	thumbFraction: number | null;
 	// The one event singled out by a hovered Log row, or null.
 	highlightEventId: string | null;
 	trackWidthPx: number;
@@ -310,10 +312,12 @@ export const ScrubberLayout = ({
 								</div>
 							)}
 
-						<ScrubberNeedle
-							fraction={chart.thumbFraction}
-							onGrab={on.onGrabNeedle}
-						/>
+						{chart.thumbFraction !== null && (
+							<ScrubberNeedle
+								fraction={chart.thumbFraction}
+								onGrab={on.onGrabNeedle}
+							/>
+						)}
 
 						{chart.rangeSelection && (
 							<RangeSelection {...chart.rangeSelection} />

--- a/source/gui/client/components/ScrubberLayout.tsx
+++ b/source/gui/client/components/ScrubberLayout.tsx
@@ -26,6 +26,7 @@ import {formatDateTime} from '../../../lib/utils/date.utils.js';
 import {
 	BucketHighlight,
 	HourAxisLabels,
+	RangeSelection,
 	ScatterCanvas,
 	ScatterLayer,
 	ScatterPoint,
@@ -60,6 +61,7 @@ export type ScrubberChartHandlers = {
 	onPointerDown: (event: React.PointerEvent<HTMLDivElement>) => void;
 	onPointerMove: (event: React.PointerEvent<HTMLDivElement>) => void;
 	onPointerEnd: () => void;
+	onGrabNeedle: () => void;
 	onTrackMouseMove: (event: React.MouseEvent<HTMLDivElement>) => void;
 	onTrackMouseLeave: () => void;
 	onCommitTrackMouseEnter: () => void;
@@ -96,6 +98,9 @@ export type ScrubberChart = {
 	// track otherwise crosses hundreds of them, and each enter and leave sets
 	// state — 1.5s of blocking over a three-second drag.
 	dragging: boolean;
+	// The stretch a range drag has covered so far, in track fractions, or null
+	// when no range is being dragged out.
+	rangeSelection: {from: number; to: number} | null;
 	commits: GuiCommitEntry[];
 	hoveredCommitSha: string | null;
 	hoveredBucketIndex: number | null;
@@ -186,9 +191,11 @@ export const ScrubberLayout = ({
 							display: 'flex',
 							flexDirection: 'column',
 							gap: 8,
-							cursor: chart.connected ? 'pointer' : 'default',
-							// A scrub-drag must never turn into a native text selection or
-							// drag of the axis labels underneath the pointer.
+							// Crosshair, not a hand: a press picks a moment but a drag picks
+							// out a range, and the pointer has to say the second is on offer.
+							cursor: chart.connected ? 'crosshair' : 'default',
+							// A drag must never turn into a native text selection or a drag
+							// of the axis labels underneath the pointer.
 							userSelect: 'none',
 							WebkitUserSelect: 'none',
 						}}
@@ -303,7 +310,14 @@ export const ScrubberLayout = ({
 								</div>
 							)}
 
-						<ScrubberNeedle fraction={chart.thumbFraction} />
+						<ScrubberNeedle
+							fraction={chart.thumbFraction}
+							onGrab={on.onGrabNeedle}
+						/>
+
+						{chart.rangeSelection && (
+							<RangeSelection {...chart.rangeSelection} />
+						)}
 
 						{/* Both hints belong on the wrapper so they hang below the whole
 						    scrubber rather than on top of the commit chart. */}

--- a/source/gui/client/components/ScrubberParts.tsx
+++ b/source/gui/client/components/ScrubberParts.tsx
@@ -512,7 +512,6 @@ export const ScrubberControls = ({
 	periodRange,
 	zoomed,
 	atLatest,
-	onClearZoom,
 	layoutMode,
 	showIssues,
 	showCommits,
@@ -543,13 +542,12 @@ export const ScrubberControls = ({
 	scope: Scope;
 	offset: number;
 	periodRange: PeriodRange | null;
-	// The window was dragged out on the chart. The scope buttons still show the
-	// one it reads as, since that is what the chart is drawn at.
+	// The window was dragged out on the chart, so it is none of the periods the
+	// scope row lists and a seventh option stands for it instead.
 	zoomed: boolean;
 	// The window already reaches the present, so there is nothing later to page
 	// to.
 	atLatest: boolean;
-	onClearZoom: () => void;
 	layoutMode: LayoutMode;
 	showIssues: boolean;
 	showCommits: boolean;
@@ -587,17 +585,6 @@ export const ScrubberControls = ({
 		<div style={{display: 'flex', alignItems: 'center', gap: 6}}>
 			{(scope !== 'all' || zoomed) && (
 				<div style={{display: 'flex', alignItems: 'center', gap: 2}}>
-					{zoomed && (
-						<button
-							title="Back to the whole period"
-							aria-label="Clear zoom"
-							disabled={!connected}
-							onClick={onClearZoom}
-							style={{...navButtonStyle, ...(connected ? {} : mutedStyle)}}
-						>
-							✕
-						</button>
-					)}
 					<button
 						title="Earlier"
 						disabled={!connected}
@@ -640,17 +627,45 @@ export const ScrubberControls = ({
 				{SCOPES.map(option => (
 					<button
 						key={option}
-						aria-pressed={scope === option}
+						// Nothing in this row is what a zoomed window is, so while one is
+						// up none of them reads as pressed and Zoom does instead.
+						aria-pressed={!zoomed && scope === option}
 						disabled={!connected}
 						onClick={() => onChangeScope(option)}
 						style={{
-							...scopeButtonStyle(scope === option),
+							...scopeButtonStyle(!zoomed && scope === option),
 							...(connected ? {} : mutedStyle),
 						}}
 					>
 						{scopeButtonLabel(option)}
 					</button>
 				))}
+
+				{/* Only ever the current state, never a way in: a window is zoomed by
+				    dragging one out on the chart, and left by naming any period to
+				    its left. It sits at the end of the row because it is not a period
+				    on the same scale as the rest.
+
+				    Faded rather than unmounted, the way the pager's ▶ sits out a
+				    period it cannot go to: the row must not shift by its width
+				    underneath the pointer as a zoom comes and goes. Its title carries
+				    the gesture, since a button nobody can press has to say why. */}
+				<button
+					title={
+						zoomed
+							? 'A window dragged out on the chart — pick a period to leave it'
+							: 'Drag across the chart to zoom the window to a stretch of it'
+					}
+					aria-pressed={zoomed}
+					disabled
+					style={{
+						...scopeButtonStyle(zoomed),
+						opacity: zoomed ? 1 : 0.35,
+						cursor: 'default',
+					}}
+				>
+					Zoom
+				</button>
 			</div>
 		</div>
 

--- a/source/gui/client/components/ScrubberParts.tsx
+++ b/source/gui/client/components/ScrubberParts.tsx
@@ -20,7 +20,10 @@ import {
 	HOVER_HINT_WIDTH,
 	LayoutMode,
 	NEEDLE_COLOR,
+	NEEDLE_GRIP_WIDTH,
 	PeriodRange,
+	RANGE_SELECTION_COLOR,
+	RANGE_SELECTION_EDGE,
 	Scope,
 	scopeButtonLabel,
 	SCOPES,
@@ -507,6 +510,9 @@ export const ScrubberControls = ({
 	scope,
 	offset,
 	periodRange,
+	zoomed,
+	atLatest,
+	onClearZoom,
 	layoutMode,
 	showIssues,
 	showCommits,
@@ -537,6 +543,13 @@ export const ScrubberControls = ({
 	scope: Scope;
 	offset: number;
 	periodRange: PeriodRange | null;
+	// The window was dragged out on the chart. The scope buttons still show the
+	// one it reads as, since that is what the chart is drawn at.
+	zoomed: boolean;
+	// The window already reaches the present, so there is nothing later to page
+	// to.
+	atLatest: boolean;
+	onClearZoom: () => void;
 	layoutMode: LayoutMode;
 	showIssues: boolean;
 	showCommits: boolean;
@@ -572,8 +585,19 @@ export const ScrubberControls = ({
 		}}
 	>
 		<div style={{display: 'flex', alignItems: 'center', gap: 6}}>
-			{scope !== 'all' && (
+			{(scope !== 'all' || zoomed) && (
 				<div style={{display: 'flex', alignItems: 'center', gap: 2}}>
+					{zoomed && (
+						<button
+							title="Back to the whole period"
+							aria-label="Clear zoom"
+							disabled={!connected}
+							onClick={onClearZoom}
+							style={{...navButtonStyle, ...(connected ? {} : mutedStyle)}}
+						>
+							✕
+						</button>
+					)}
 					<button
 						title="Earlier"
 						disabled={!connected}
@@ -595,16 +619,16 @@ export const ScrubberControls = ({
 							textAlign: 'center',
 						}}
 					>
-						{formatPeriodLabel(scope, offset, periodRange)}
+						{formatPeriodLabel(scope, offset, periodRange, zoomed)}
 					</span>
 					<button
 						title="Later"
-						disabled={offset === 0 || !connected}
-						onClick={() => onChangeOffset(Math.max(0, offset - 1))}
+						disabled={atLatest || !connected}
+						onClick={() => onChangeOffset(offset - 1)}
 						style={{
 							...navButtonStyle,
-							opacity: offset === 0 ? 0.35 : 1,
-							cursor: offset === 0 ? 'default' : 'pointer',
+							opacity: atLatest ? 0.35 : 1,
+							cursor: atLatest ? 'default' : 'pointer',
 						}}
 					>
 						▶
@@ -804,6 +828,34 @@ export const SegmentHighlight = ({
 		>
 			{segment.label}
 		</div>
+	);
+};
+
+// The stretch a range drag has covered so far. Spans both charts and the gap,
+// like the segment highlight, because the window it will zoom to is one window
+// over both series.
+export const RangeSelection = ({from, to}: {from: number; to: number}) => {
+	const left = Math.min(from, to);
+
+	return (
+		<div
+			data-testid="scrubber-range-selection"
+			style={{
+				position: 'absolute',
+				left: `${left * 100}%`,
+				width: `${Math.abs(to - from) * 100}%`,
+				top: 0,
+				bottom: 0,
+				background: RANGE_SELECTION_COLOR,
+				borderLeft: `1px solid ${RANGE_SELECTION_EDGE}`,
+				borderRight: `1px solid ${RANGE_SELECTION_EDGE}`,
+				boxSizing: 'border-box',
+				pointerEvents: 'none',
+				// Over the needle: the needle marks where the board is, the selection
+				// what is about to replace the whole window.
+				zIndex: 4,
+			}}
+		/>
 	);
 };
 
@@ -1049,18 +1101,43 @@ export const ScatterDot = ({
 
 // Lives on the chart wrapper rather than inside either chart, so it runs
 // unbroken through both and the gap between them.
-export const ScrubberNeedle = ({fraction}: {fraction: number}) => {
+export const ScrubberNeedle = ({
+	fraction,
+	onGrab,
+}: {
+	fraction: number;
+	// A press here is a scrub, not the start of a range drag. The event still
+	// bubbles to the track, which owns the pointer capture and the moving.
+	onGrab: () => void;
+}) => {
 	const [hovered, setHovered] = useState(false);
 
-	const hover = {
+	const grip = {
 		onMouseEnter: () => setHovered(true),
 		onMouseLeave: () => setHovered(false),
+		onPointerDown: onGrab,
 	};
 
 	return (
 		<>
+			{/* A hairline is a 1px drag target. This is the same line's worth of
+			    grabbable width, invisible, centred on it. */}
 			<div
-				{...hover}
+				{...grip}
+				data-testid="scrubber-needle-grip"
+				style={{
+					position: 'absolute',
+					left: `${fraction * 100}%`,
+					top: 0,
+					bottom: 0,
+					width: NEEDLE_GRIP_WIDTH,
+					transform: `translateX(${-NEEDLE_GRIP_WIDTH / 2}px)`,
+					zIndex: 3,
+					pointerEvents: 'auto',
+					cursor: 'ew-resize',
+				}}
+			/>
+			<div
 				style={{
 					position: 'absolute',
 					left: `${fraction * 100}%`,
@@ -1072,12 +1149,11 @@ export const ScrubberNeedle = ({fraction}: {fraction: number}) => {
 					background: NEEDLE_COLOR,
 					zIndex: 3,
 					transform: 'translateX(-0.5px)',
-					pointerEvents: 'auto',
-					cursor: 'pointer',
+					pointerEvents: 'none',
 				}}
 			/>
 			<div
-				{...hover}
+				{...grip}
 				style={{
 					position: 'absolute',
 					left: `${fraction * 100}%`,
@@ -1090,7 +1166,7 @@ export const ScrubberNeedle = ({fraction}: {fraction: number}) => {
 					zIndex: 3,
 					transform: `translateX(${hovered ? -6 : -5}px)`,
 					pointerEvents: 'auto',
-					cursor: 'pointer',
+					cursor: 'ew-resize',
 				}}
 			/>
 		</>

--- a/source/gui/client/components/TimeScrubber.tsx
+++ b/source/gui/client/components/TimeScrubber.tsx
@@ -474,10 +474,26 @@ export const TimeScrubber = ({
 		[commitPoints, issuePoints, commitScatter, issueScatter, windowKey],
 	);
 
+	// Null when the moment the needle stands for is not in the window, so it is
+	// not drawn rather than drawn somewhere it is not. fractionForTime clamps,
+	// so a moment off either end would otherwise pin the needle to that edge and
+	// read as "the board is parked here" — pointing at a time the window does
+	// not contain.
+	//
+	// While live it stands for the present, which is in the window exactly when
+	// the window runs up to it. That is read off the selection rather than by
+	// comparing against the clock: an "up to now" window is only fetched up to
+	// the moment it was asked for, so seconds later the clock is already past
+	// its end and the needle would blink out.
 	const confirmedFraction =
 		timeTravel.mode === 'scrub' && timeTravel.asOfTime !== null
-			? axis.fractionForTime(timeTravel.asOfTime)
-			: 1;
+			? timeTravel.asOfTime >= axis.earliest &&
+			  timeTravel.asOfTime <= axis.latest
+				? axis.fractionForTime(timeTravel.asOfTime)
+				: null
+			: atLatest
+			? 1
+			: null;
 
 	const fractionFromClientX = (clientX: number) => {
 		const track = trackRef.current;

--- a/source/gui/client/components/TimeScrubber.tsx
+++ b/source/gui/client/components/TimeScrubber.tsx
@@ -36,8 +36,11 @@ import {
 	getPeriodRange,
 	hourFractionForTime,
 	LayoutMode,
+	MIN_RANGE_DRAG_PX,
+	MIN_ZOOM_SPAN_MS,
 	populatedRange,
 	Scope,
+	scopeForSpan,
 	segmentAt,
 	useExitTransition,
 	usePersistedFlag,
@@ -111,7 +114,14 @@ export const TimeScrubber = ({
 	// identity the window itself holds no event for.
 	knownIdentities: Record<'actor' | 'tag' | 'assignee', GuiEventIdentity[]>;
 }) => {
-	const {scope, offset, layout: layoutMode, view: boardView, only} = selection;
+	const {
+		scope,
+		offset,
+		zoom,
+		layout: layoutMode,
+		view: boardView,
+		only,
+	} = selection;
 	const animate = !usePrefersReducedMotion();
 	const trackRef = useRef<HTMLDivElement | null>(null);
 	const lastDispatchRef = useRef(0);
@@ -119,6 +129,14 @@ export const TimeScrubber = ({
 	const lastTargetRef = useRef<number | null>(null);
 
 	const [dragFraction, setDragFraction] = useState<number | null>(null);
+	// Where a range drag started and where it has reached, as track fractions.
+	const [rangeDrag, setRangeDrag] = useState<{
+		from: number;
+		to: number;
+	} | null>(null);
+	// Set by the needle's own press, which fires before the track's: it says
+	// this drag moves the needle rather than dragging out a range.
+	const grabbedNeedleRef = useRef(false);
 
 	const [collapsed, setCollapsed] = usePersistedFlag(
 		COLLAPSED_STORAGE_KEY,
@@ -179,10 +197,13 @@ export const TimeScrubber = ({
 		number | null
 	>(null);
 
-	const periodRange = getPeriodRange(scope, offset);
+	// A dragged-out window stands in for the rolling one, and is the only kind
+	// with fixed bounds — every other is anchored to now.
+	const periodRange = zoom ?? getPeriodRange(scope, offset);
 
 	// periodRange is derived from scope/offset each render, so it is
-	// deliberately absent from the dependencies.
+	// deliberately absent from the dependencies; the zoom's own bounds are
+	// listed instead, since it is a fresh object on every read of the URL.
 	useEffect(() => {
 		if (!connected) return;
 
@@ -191,19 +212,65 @@ export const TimeScrubber = ({
 			periodRange?.end,
 			allBoards,
 		);
-	}, [scope, offset, boardId, allBoards, connected, socketEpoch]);
+	}, [
+		scope,
+		offset,
+		zoom?.start,
+		zoom?.end,
+		boardId,
+		allBoards,
+		connected,
+		socketEpoch,
+	]);
 
 	const changeLayoutMode = (next: LayoutMode) =>
 		onChangeSelection({layout: next});
 
+	// Naming a scope is also the way out of a zoom, which applySelectionPatch
+	// clears for any patch that names one.
 	const changeScope = (nextScope: Scope) => {
 		armEntrance();
 		onChangeSelection({scope: nextScope});
 	};
 
+	const clearZoom = () => {
+		armEntrance();
+		onChangeSelection({zoom: null});
+	};
+
+	// Under a zoom there are no periods to count back, so the pager slides the
+	// window by its own width instead — one press back is the stretch before the
+	// one on screen.
 	const changeOffset = (nextOffset: number) => {
 		armEntrance();
-		onChangeSelection({offset: nextOffset});
+
+		if (!zoom) {
+			onChangeSelection({offset: nextOffset});
+			return;
+		}
+
+		const span = zoom.end - zoom.start;
+		const shift = (nextOffset - offset) * span;
+		const end = Math.min(Date.now(), zoom.end - shift);
+
+		onChangeSelection({zoom: {start: end - span, end}});
+	};
+
+	// Zooming in on the last few minutes is a legitimate ask; zooming past the
+	// present is not, so a window already at it has nowhere later to go.
+	const atLatest = zoom ? zoom.end >= Date.now() : offset === 0;
+
+	const zoomToRange = (from: number, to: number) => {
+		const start = Math.min(from, to);
+		const span = Math.max(MIN_ZOOM_SPAN_MS, Math.abs(to - from));
+
+		armEntrance();
+		onChangeSelection({
+			zoom: {start, end: start + span},
+			// The window keeps its exact bounds; the scope is what the controls
+			// call it, and what the pager steps by once it is cleared.
+			scope: scopeForSpan(span),
+		});
 	};
 
 	// No armEntrance on either: the window is unchanged, so these filter what is
@@ -304,7 +371,7 @@ export const TimeScrubber = ({
 		[shown, boardView, hiddenIdentityIds],
 	);
 
-	const dragging = dragFraction !== null;
+	const dragging = dragFraction !== null || rangeDrag !== null;
 
 	// Both series as one list for the canvas, in the order they should stack:
 	// commits first, board events over them, as the old zIndex did.
@@ -448,10 +515,29 @@ export const TimeScrubber = ({
 	}, [timeTravel.mode]);
 
 	const endDrag = () => {
-		if (dragFraction === null) return;
+		grabbedNeedleRef.current = false;
 
-		dispatchScrub(dragFraction, true);
-		setDragFraction(null);
+		if (dragFraction !== null) {
+			dispatchScrub(dragFraction, true);
+			setDragFraction(null);
+			return;
+		}
+
+		if (rangeDrag === null) return;
+
+		const {from, to} = rangeDrag;
+		setRangeDrag(null);
+
+		const trackWidth = trackRef.current?.clientWidth ?? 0;
+
+		// Pressed and released on one spot: a click, which still scrubs. Only a
+		// drag wide enough to have been aimed is read as a range.
+		if (Math.abs(to - from) * trackWidth < MIN_RANGE_DRAG_PX) {
+			dispatchScrub(from, true);
+			return;
+		}
+
+		zoomToRange(axis.fractionToTime(from), axis.fractionToTime(to));
 	};
 
 	// Measures `event.currentTarget`, not trackRef, so one handler serves both
@@ -583,6 +669,21 @@ export const TimeScrubber = ({
 
 	const segmentUnit = chooseSegmentUnit(axis.span);
 
+	// Everything hover puts on the chart is about the bucket under the pointer,
+	// which is not what a range drag is asking about — and it is drawn over the
+	// stretch being picked. So the drag takes the chart over while it lasts, and
+	// says what it has covered so far in place of the hover's own hint.
+	const pickingRange = rangeDrag !== null;
+
+	const rangeHint: HintContent | null = rangeDrag && {
+		label: formatInterval(
+			axis.fractionToTime(Math.min(rangeDrag.from, rangeDrag.to)),
+			axis.fractionToTime(Math.max(rangeDrag.from, rangeDrag.to)),
+		),
+		rows: ['Release to zoom the window to this stretch'],
+		fraction: (rangeDrag.from + rangeDrag.to) / 2,
+	};
+
 	return (
 		<ScrubberLayout
 			collapsed={collapsed}
@@ -592,6 +693,9 @@ export const TimeScrubber = ({
 				scope,
 				offset,
 				periodRange,
+				zoomed: zoom !== null,
+				atLatest,
+				onClearZoom: clearZoom,
 				layoutMode,
 				showIssues,
 				showCommits,
@@ -634,39 +738,63 @@ export const TimeScrubber = ({
 				scatterLayers,
 				issueSeriesColor: soleIdentity?.color ?? boardViewColor(boardView),
 				dragging,
+				rangeSelection: rangeDrag,
 				// Exits still need their animation, so this only silences a series
 				// that has finished arriving.
 
 				commits: shown.commits,
 				hoveredCommitSha: hoveredCommit?.commit.sha ?? null,
-				hoveredBucketIndex,
-				hoveredCommitBucketIndex,
+				hoveredBucketIndex: pickingRange ? null : hoveredBucketIndex,
+				hoveredCommitBucketIndex: pickingRange
+					? null
+					: hoveredCommitBucketIndex,
 				hoveredSegment:
-					hoveredSegmentTime !== null
+					hoveredSegmentTime !== null && !pickingRange
 						? segmentAt(hoveredSegmentTime, segmentUnit)
 						: null,
 				connected,
 				thumbFraction: dragFraction ?? confirmedFraction,
 				highlightEventId,
 				trackWidthPx: trackRef.current?.clientWidth ?? 0,
-				boardHint,
-				commitHint,
+				boardHint: pickingRange ? rangeHint : boardHint,
+				commitHint: pickingRange ? null : commitHint,
 				on: {
 					onPointerDown: event => {
 						event.currentTarget.setPointerCapture(event.pointerId);
 
 						const fraction = fractionFromClientX(event.clientX);
+
+						// Off the needle, a press is the corner of a range until it turns
+						// out to have been a click. Scrubbing on the way would checkout
+						// every moment swept over on the way to picking a window.
+						if (!grabbedNeedleRef.current) {
+							setRangeDrag({from: fraction, to: fraction});
+							return;
+						}
+
 						setDragFraction(fraction);
 						dispatchScrub(fraction, true);
 					},
 					onPointerMove: event => {
-						if (dragFraction === null) return;
+						// The handler is on the wrapper, so this runs for every move over
+						// the whole scrubber. Measuring the track is a layout read, and
+						// nothing outside a drag has a use for it.
+						if (dragFraction === null && rangeDrag === null) return;
 
 						const fraction = fractionFromClientX(event.clientX);
+
+						if (rangeDrag !== null) {
+							setRangeDrag({from: rangeDrag.from, to: fraction});
+							return;
+						}
+
 						setDragFraction(fraction);
 						dispatchScrub(fraction, false);
 					},
 					onPointerEnd: endDrag,
+					onGrabNeedle: () => {
+						grabbedNeedleRef.current = true;
+					},
 					onTrackMouseMove: event => {
 						if (layoutMode === 'even') {
 							setHoveredBucketIndex(bucketIndexFromEvent(event));

--- a/source/gui/client/components/TimeScrubber.tsx
+++ b/source/gui/client/components/TimeScrubber.tsx
@@ -40,7 +40,6 @@ import {
 	MIN_ZOOM_SPAN_MS,
 	populatedRange,
 	Scope,
-	scopeForSpan,
 	segmentAt,
 	useExitTransition,
 	usePersistedFlag,
@@ -226,16 +225,13 @@ export const TimeScrubber = ({
 	const changeLayoutMode = (next: LayoutMode) =>
 		onChangeSelection({layout: next});
 
-	// Naming a scope is also the way out of a zoom, which applySelectionPatch
-	// clears for any patch that names one.
+	// Naming a scope is also the only way out of a zoom, which
+	// applySelectionPatch clears for any patch that names one — including a
+	// patch naming the scope already held, since while zoomed no scope button
+	// reads as pressed and every one of them is a way out.
 	const changeScope = (nextScope: Scope) => {
 		armEntrance();
 		onChangeSelection({scope: nextScope});
-	};
-
-	const clearZoom = () => {
-		armEntrance();
-		onChangeSelection({zoom: null});
 	};
 
 	// Under a zoom there are no periods to count back, so the pager slides the
@@ -260,17 +256,17 @@ export const TimeScrubber = ({
 	// present is not, so a window already at it has nowhere later to go.
 	const atLatest = zoom ? zoom.end >= Date.now() : offset === 0;
 
+	// The scope is left as it was rather than inferred from the span: nothing
+	// reads it while a zoom is up. The chart's bucketing and segment unit come
+	// off the axis span, the pager slides by the window's own width, and the
+	// label dates the window — so the only scope that matters is the one named
+	// on the way out.
 	const zoomToRange = (from: number, to: number) => {
 		const start = Math.min(from, to);
 		const span = Math.max(MIN_ZOOM_SPAN_MS, Math.abs(to - from));
 
 		armEntrance();
-		onChangeSelection({
-			zoom: {start, end: start + span},
-			// The window keeps its exact bounds; the scope is what the controls
-			// call it, and what the pager steps by once it is cleared.
-			scope: scopeForSpan(span),
-		});
+		onChangeSelection({zoom: {start, end: start + span}});
 	};
 
 	// No armEntrance on either: the window is unchanged, so these filter what is
@@ -695,7 +691,6 @@ export const TimeScrubber = ({
 				periodRange,
 				zoomed: zoom !== null,
 				atLatest,
-				onClearZoom: clearZoom,
 				layoutMode,
 				showIssues,
 				showCommits,

--- a/source/gui/client/lib/board-selection.test.ts
+++ b/source/gui/client/lib/board-selection.test.ts
@@ -145,7 +145,6 @@ describe('applySelectionPatch', () => {
 	describe('zoom', () => {
 		const zoomed = applySelectionPatch(narrowed, {
 			zoom: {start: 1000, end: 5000},
-			scope: 'hour',
 		});
 
 		it('leaves the offset behind, since a zoom is the window itself', () => {
@@ -153,9 +152,12 @@ describe('applySelectionPatch', () => {
 			expect(zoomed.offset).toBe(0);
 		});
 
-		it('is cleared by naming any scope, including the one it reads as', () => {
+		// While zoomed no scope button reads as pressed, so every one of them is
+		// a way out — the one already held included.
+		it('is cleared by naming any scope, the one already held included', () => {
+			expect(applySelectionPatch(zoomed, {scope: 'day'}).zoom).toBeNull();
 			expect(applySelectionPatch(zoomed, {scope: 'week'}).zoom).toBeNull();
-			expect(applySelectionPatch(zoomed, {scope: 'hour'}).zoom).toBeNull();
+			expect(zoomed.scope).toBe('week');
 		});
 
 		it('survives a patch that says nothing about it', () => {

--- a/source/gui/client/lib/board-selection.test.ts
+++ b/source/gui/client/lib/board-selection.test.ts
@@ -52,6 +52,7 @@ describe('selection in the URL', () => {
 		const selection: BoardSelection = {
 			scope: 'month',
 			offset: 2,
+			zoom: null,
 			layout: 'real',
 			view: 'tagging',
 			only: ['bug', 'docs'],
@@ -108,6 +109,7 @@ describe('applySelectionPatch', () => {
 	const narrowed: BoardSelection = {
 		scope: 'week',
 		offset: 3,
+		zoom: null,
 		layout: 'even',
 		view: 'tagging',
 		only: ['bug'],
@@ -139,6 +141,49 @@ describe('applySelectionPatch', () => {
 		).toBe(true);
 		expect(isDefaultSelection(narrowed)).toBe(false);
 	});
+
+	describe('zoom', () => {
+		const zoomed = applySelectionPatch(narrowed, {
+			zoom: {start: 1000, end: 5000},
+			scope: 'hour',
+		});
+
+		it('leaves the offset behind, since a zoom is the window itself', () => {
+			expect(zoomed.zoom).toEqual({start: 1000, end: 5000});
+			expect(zoomed.offset).toBe(0);
+		});
+
+		it('is cleared by naming any scope, including the one it reads as', () => {
+			expect(applySelectionPatch(zoomed, {scope: 'week'}).zoom).toBeNull();
+			expect(applySelectionPatch(zoomed, {scope: 'hour'}).zoom).toBeNull();
+		});
+
+		it('survives a patch that says nothing about it', () => {
+			expect(applySelectionPatch(zoomed, {layout: 'real'}).zoom).toEqual({
+				start: 1000,
+				end: 5000,
+			});
+		});
+
+		it('refuses a window that is not two moments in order', () => {
+			for (const zoom of [
+				{start: 5000, end: 1000},
+				{start: 1000, end: 1000},
+				{start: Number.NaN, end: 5000},
+			]) {
+				expect(applySelectionPatch(narrowed, {zoom}).zoom).toBeNull();
+			}
+		});
+
+		it('round-trips through the URL', () => {
+			expect(readSelectionParams(params(written(zoomed)))).toEqual(zoomed);
+		});
+
+		it('needs both bounds in the URL to mean anything', () => {
+			expect(readSelectionParams(params('from=1000'))?.zoom).toBeNull();
+			expect(readSelectionParams(params('to=5000'))?.zoom).toBeNull();
+		});
+	});
 });
 
 describe('stored selection', () => {
@@ -160,10 +205,11 @@ describe('stored selection', () => {
 		expect(readStoredSelection()).toEqual(DEFAULT_SELECTION);
 	});
 
-	it('keeps everything but the offset', () => {
+	it('keeps everything but the moment in time — the offset and the zoom', () => {
 		storeSelection({
 			scope: 'month',
 			offset: 4,
+			zoom: {start: 1000, end: 2000},
 			layout: 'real',
 			view: 'tagging',
 			only: ['bug'],
@@ -172,6 +218,7 @@ describe('stored selection', () => {
 		expect(readStoredSelection()).toEqual({
 			scope: 'month',
 			offset: 0,
+			zoom: null,
 			layout: 'real',
 			view: 'tagging',
 			only: ['bug'],

--- a/source/gui/client/lib/board-selection.ts
+++ b/source/gui/client/lib/board-selection.ts
@@ -5,6 +5,7 @@ import {
 	isLayoutMode,
 	isScope,
 	LayoutMode,
+	PeriodRange,
 	Scope,
 } from './scrubber';
 
@@ -13,8 +14,11 @@ import {
 // localStorage as the fallback for a bare board link.
 export type BoardSelection = {
 	scope: Scope;
-	// Periods back from now; meaningless under 'all'.
+	// Periods back from now; meaningless under 'all' or under a zoom.
 	offset: number;
+	// A window dragged out on the timeline, standing in for the rolling one
+	// scope and offset describe. Null while the scope buttons are in charge.
+	zoom: PeriodRange | null;
 	layout: LayoutMode;
 	view: BoardView;
 	// Identity ids the view is narrowed to — a positive list rather than the
@@ -26,31 +30,58 @@ export type BoardSelection = {
 export const DEFAULT_SELECTION: BoardSelection = {
 	scope: 'all',
 	offset: 0,
+	zoom: null,
 	layout: 'even',
 	view: 'all',
 	only: null,
 };
 
-const PARAM_KEYS = ['scope', 'offset', 'layout', 'view', 'only'] as const;
+const PARAM_KEYS = [
+	'scope',
+	'offset',
+	'from',
+	'to',
+	'layout',
+	'view',
+	'only',
+] as const;
 
 const STORAGE_KEY = 'epiq.board.selection';
 
 const unique = (ids: readonly string[]): string[] => [...new Set(ids)];
 
-const normalize = (selection: BoardSelection): BoardSelection => ({
-	...selection,
-	offset:
-		selection.scope === 'all' ||
-		!Number.isInteger(selection.offset) ||
-		selection.offset < 0
-			? 0
-			: selection.offset,
-	only: selection.only === null ? null : unique(selection.only),
-});
+// A window has to be two real moments in order, or the axis it builds spans
+// NaN and every fraction on the chart goes with it.
+const validZoom = (zoom: PeriodRange | null): PeriodRange | null =>
+	zoom !== null &&
+	Number.isFinite(zoom.start) &&
+	Number.isFinite(zoom.end) &&
+	zoom.end > zoom.start
+		? zoom
+		: null;
+
+const normalize = (selection: BoardSelection): BoardSelection => {
+	const zoom = validZoom(selection.zoom);
+
+	return {
+		...selection,
+		zoom,
+		// A zoom is the window, so there is no period left to page by count.
+		offset:
+			zoom !== null ||
+			selection.scope === 'all' ||
+			!Number.isInteger(selection.offset) ||
+			selection.offset < 0
+				? 0
+				: selection.offset,
+		only: selection.only === null ? null : unique(selection.only),
+	};
+};
 
 export const isDefaultSelection = (selection: BoardSelection): boolean =>
 	selection.scope === DEFAULT_SELECTION.scope &&
 	selection.offset === DEFAULT_SELECTION.offset &&
+	selection.zoom === null &&
 	selection.layout === DEFAULT_SELECTION.layout &&
 	selection.view === DEFAULT_SELECTION.view &&
 	selection.only === null;
@@ -66,9 +97,20 @@ export const applySelectionPatch = (
 		patch.scope !== undefined && patch.scope !== current.scope;
 	const viewChanged = patch.view !== undefined && patch.view !== current.view;
 
+	// Reaching for a scope button is how you get back out of a zoom, so it
+	// clears one even when the scope named is the one a zoom inferred — which is
+	// the button that looks pressed while zoomed.
+	const zoom =
+		patch.zoom !== undefined
+			? patch.zoom
+			: patch.scope !== undefined
+			? null
+			: current.zoom;
+
 	return normalize({
 		...current,
 		...patch,
+		zoom,
 		offset: scopeChanged ? 0 : patch.offset ?? current.offset,
 		only:
 			patch.only !== undefined ? patch.only : viewChanged ? null : current.only,
@@ -92,10 +134,16 @@ export const readSelectionParams = (
 	const layout = params.get('layout');
 	const view = params.get('view');
 	const only = params.get('only');
+	const from = params.get('from');
+	const to = params.get('to');
 
 	return normalize({
 		scope: isScope(scope) ? scope : DEFAULT_SELECTION.scope,
 		offset: Number(params.get('offset') ?? 0),
+		zoom:
+			from === null || to === null
+				? null
+				: {start: Number(from), end: Number(to)},
 		layout: isLayoutMode(layout) ? layout : DEFAULT_SELECTION.layout,
 		view: isBoardView(view) ? view : DEFAULT_SELECTION.view,
 		only: only === null ? null : only.split(',').filter(Boolean),
@@ -119,6 +167,8 @@ export const writeSelectionParams = (
 
 	put('scope', next.scope === DEFAULT_SELECTION.scope ? null : next.scope);
 	put('offset', next.offset === 0 ? null : String(next.offset));
+	put('from', next.zoom === null ? null : String(next.zoom.start));
+	put('to', next.zoom === null ? null : String(next.zoom.end));
 	put('layout', next.layout === DEFAULT_SELECTION.layout ? null : next.layout);
 	put('view', next.view === DEFAULT_SELECTION.view ? null : next.view);
 	put('only', next.only === null ? null : next.only.join(','));
@@ -126,8 +176,9 @@ export const writeSelectionParams = (
 
 // ------------------------------------------------------------------- storage
 
-// The offset is not kept: a period back from now is a moment, not a
-// preference, and reopening the board a week later on it would be a surprise.
+// Neither the offset nor a zoom is kept: a stretch of last Tuesday is a
+// moment, not a preference, and reopening the board a week later on it would be
+// a surprise.
 export const readStoredSelection = (): BoardSelection => {
 	try {
 		const stored = localStorage.getItem(STORAGE_KEY);
@@ -143,6 +194,7 @@ export const readStoredSelection = (): BoardSelection => {
 				? (scope as Scope)
 				: DEFAULT_SELECTION.scope,
 			offset: 0,
+			zoom: null,
 			layout: isLayoutMode(String(layout))
 				? (layout as LayoutMode)
 				: DEFAULT_SELECTION.layout,

--- a/source/gui/client/lib/scrubber.test.ts
+++ b/source/gui/client/lib/scrubber.test.ts
@@ -29,6 +29,7 @@ import {
 	isScope,
 	populatedRange,
 	SCOPES,
+	scopeForSpan,
 	SCRUBBER_KEYFRAMES,
 	segmentAt,
 } from './scrubber';
@@ -411,6 +412,56 @@ describe('formatPeriodLabel', () => {
 				end: new Date(2026, 7, 10).getTime(),
 			}),
 		).toBe('8/3 – 8/10');
+	});
+
+	it('dates a zoomed window even at its most recent, which no scope names', () => {
+		expect(
+			formatPeriodLabel('week', 0, {
+				start: new Date(2026, 7, 3).getTime(),
+				end: new Date(2026, 7, 10).getTime(),
+			}),
+		).toBe('Last 7 days');
+
+		expect(
+			formatPeriodLabel(
+				'week',
+				0,
+				{
+					start: new Date(2026, 7, 3).getTime(),
+					end: new Date(2026, 7, 10).getTime(),
+				},
+				true,
+			),
+		).toBe('8/3 – 8/10');
+	});
+
+	it('gives the clock rather than two identical dates inside one day', () => {
+		expect(
+			formatPeriodLabel(
+				'hour',
+				0,
+				{
+					start: new Date(2026, 7, 3, 9, 15).getTime(),
+					end: new Date(2026, 7, 3, 11, 45).getTime(),
+				},
+				true,
+			),
+		).toBe('09:15 – 11:45');
+	});
+});
+
+describe('scopeForSpan', () => {
+	it('names the shortest scope long enough to hold the span', () => {
+		expect(scopeForSpan(30 * 60 * 1000)).toBe('hour');
+		expect(scopeForSpan(60 * 60 * 1000)).toBe('hour');
+		expect(scopeForSpan(60 * 60 * 1000 + 1)).toBe('day');
+		expect(scopeForSpan(3 * DAY)).toBe('week');
+		expect(scopeForSpan(20 * DAY)).toBe('month');
+		expect(scopeForSpan(200 * DAY)).toBe('year');
+	});
+
+	it('falls back to the longest for a span past every scope', () => {
+		expect(scopeForSpan(4000 * DAY)).toBe('year');
 	});
 });
 

--- a/source/gui/client/lib/scrubber.test.ts
+++ b/source/gui/client/lib/scrubber.test.ts
@@ -29,7 +29,6 @@ import {
 	isScope,
 	populatedRange,
 	SCOPES,
-	scopeForSpan,
 	SCRUBBER_KEYFRAMES,
 	segmentAt,
 } from './scrubber';
@@ -447,21 +446,6 @@ describe('formatPeriodLabel', () => {
 				true,
 			),
 		).toBe('09:15 – 11:45');
-	});
-});
-
-describe('scopeForSpan', () => {
-	it('names the shortest scope long enough to hold the span', () => {
-		expect(scopeForSpan(30 * 60 * 1000)).toBe('hour');
-		expect(scopeForSpan(60 * 60 * 1000)).toBe('hour');
-		expect(scopeForSpan(60 * 60 * 1000 + 1)).toBe('day');
-		expect(scopeForSpan(3 * DAY)).toBe('week');
-		expect(scopeForSpan(20 * DAY)).toBe('month');
-		expect(scopeForSpan(200 * DAY)).toBe('year');
-	});
-
-	it('falls back to the longest for a span past every scope', () => {
-		expect(scopeForSpan(4000 * DAY)).toBe('year');
 	});
 });
 

--- a/source/gui/client/lib/scrubber.ts
+++ b/source/gui/client/lib/scrubber.ts
@@ -582,10 +582,14 @@ export type Scope = 'all' | 'hour' | 'day' | 'week' | 'month' | 'year';
 
 export type PeriodRange = {start: number; end: number};
 
-// Shortest first, which is also the order a span is matched against them.
-const TIMED_SCOPES = ['hour', 'day', 'week', 'month', 'year'] as const;
-
-export const SCOPES: readonly Scope[] = [...TIMED_SCOPES, 'all'];
+export const SCOPES: readonly Scope[] = [
+	'hour',
+	'day',
+	'week',
+	'month',
+	'year',
+	'all',
+];
 
 const SCOPE_DURATION_MS: Record<Exclude<Scope, 'all'>, number> = {
 	hour: 60 * 60 * 1000,
@@ -619,12 +623,6 @@ export const getPeriodRange = (
 
 	return {start: end - durationMs, end};
 };
-
-// The shortest scope long enough to hold the span. A hand-picked window keeps
-// its exact bounds; this only decides what the controls call it and how far the
-// pager steps, since what the chart draws is derived from the axis span itself.
-export const scopeForSpan = (spanMs: number): Exclude<Scope, 'all'> =>
-	TIMED_SCOPES.find(scope => SCOPE_DURATION_MS[scope] >= spanMs) ?? 'year';
 
 // Narrow enough for the fixed-width label beside the pager, and dated only when
 // the window spans more than the one day a date would name.

--- a/source/gui/client/lib/scrubber.ts
+++ b/source/gui/client/lib/scrubber.ts
@@ -44,6 +44,22 @@ export const SEGMENT_HIGHLIGHT_COLOR = 'rgba(122, 157, 214, 0.14)';
 export const BUCKET_HIGHLIGHT_COLOR = 'rgba(255, 255, 255, 0.06)';
 export const NEEDLE_COLOR = 'rgba(255, 255, 255, 0.62)';
 
+// Brighter than either highlight: this one is being drawn by hand and has to
+// read against whatever it is dragged over.
+export const RANGE_SELECTION_COLOR = 'rgba(122, 157, 214, 0.22)';
+export const RANGE_SELECTION_EDGE = 'rgba(160, 195, 250, 0.75)';
+
+// The needle is drawn as a hairline, which is a 1px drag target. This is how
+// wide the invisible grip over it is.
+export const NEEDLE_GRIP_WIDTH = 11;
+
+// Under this a press is a click, which scrubs, rather than a range to zoom to.
+export const MIN_RANGE_DRAG_PX = 6;
+
+// A range drag can end a pixel from where it started even past that threshold,
+// and a window of milliseconds has no axis worth drawing.
+export const MIN_ZOOM_SPAN_MS = 60 * 1000;
+
 // Past this count a bar is ~2px, too thin to give up a pixel to the gap.
 const MIN_BUCKET_COUNT_FOR_GAP = 300;
 
@@ -566,14 +582,10 @@ export type Scope = 'all' | 'hour' | 'day' | 'week' | 'month' | 'year';
 
 export type PeriodRange = {start: number; end: number};
 
-export const SCOPES: readonly Scope[] = [
-	'hour',
-	'day',
-	'week',
-	'month',
-	'year',
-	'all',
-];
+// Shortest first, which is also the order a span is matched against them.
+const TIMED_SCOPES = ['hour', 'day', 'week', 'month', 'year'] as const;
+
+export const SCOPES: readonly Scope[] = [...TIMED_SCOPES, 'all'];
 
 const SCOPE_DURATION_MS: Record<Exclude<Scope, 'all'>, number> = {
 	hour: 60 * 60 * 1000,
@@ -608,21 +620,38 @@ export const getPeriodRange = (
 	return {start: end - durationMs, end};
 };
 
+// The shortest scope long enough to hold the span. A hand-picked window keeps
+// its exact bounds; this only decides what the controls call it and how far the
+// pager steps, since what the chart draws is derived from the axis span itself.
+export const scopeForSpan = (spanMs: number): Exclude<Scope, 'all'> =>
+	TIMED_SCOPES.find(scope => SCOPE_DURATION_MS[scope] >= spanMs) ?? 'year';
+
+// Narrow enough for the fixed-width label beside the pager, and dated only when
+// the window spans more than the one day a date would name.
+const compactRangeLabel = (range: PeriodRange): string => {
+	const start = new Date(range.start);
+	const end = new Date(range.end);
+
+	return isSameDay(start, end)
+		? `${formatTimeOfDay(start)} – ${formatTimeOfDay(end)}`
+		: `${start.getMonth() + 1}/${start.getDate()} – ${
+				end.getMonth() + 1
+		  }/${end.getDate()}`;
+};
+
 export const formatPeriodLabel = (
 	scope: Scope,
 	offset: number,
 	range: PeriodRange | null,
+	// A window dragged out on the chart, which no scope's name describes.
+	zoomed = false,
 ): string => {
-	if (scope === 'all' || !range) return 'All time';
-
+	if (!range) return 'All time';
+	if (zoomed) return compactRangeLabel(range);
+	if (scope === 'all') return 'All time';
 	if (offset === 0) return SCOPE_RECENT_LABELS[scope];
 
-	const start = new Date(range.start);
-	const end = new Date(range.end);
-
-	return `${start.getMonth() + 1}/${start.getDate()} – ${
-		end.getMonth() + 1
-	}/${end.getDate()}`;
+	return compactRangeLabel(range);
 };
 
 export const scopeButtonLabel = (scope: Scope): string =>

--- a/source/test/e2e-gui/scrub-dispatch.pw.ts
+++ b/source/test/e2e-gui/scrub-dispatch.pw.ts
@@ -247,3 +247,54 @@ test('a drag across the track zooms the window to it, without scrubbing', async 
 	await returnToLive(page);
 	expect(pageErrors).toEqual([]);
 });
+
+// fractionForTime clamps, so a moment off either end of the window would pin
+// the needle to that edge and read as "the board is parked here" while pointing
+// at a time the window does not contain.
+test('the needle is not drawn for a moment the window does not contain', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	const needle = page.getByTestId('scrubber-needle-grip');
+	const track = page.getByTestId('scrubber-track');
+	const box = await track.boundingBox();
+	if (!box) throw new Error('scrubber track is not on screen');
+
+	// Live, in a window that runs up to the present: the needle stands for now,
+	// which is in view.
+	await expect(needle).toBeVisible();
+
+	const y = box.y + box.height / 2;
+	await page.mouse.click(box.x + box.width * 0.2, y);
+	await expect(
+		page.getByRole('button', {name: 'Resume', exact: true}),
+	).toBeEnabled();
+	await expect(needle).toBeVisible();
+
+	// A stretch well to the right of where the board is parked. Zooming rather
+	// than naming a period keeps this independent of when the seed data was
+	// written: the moment is outside the new window by construction.
+	await page.mouse.move(box.x + box.width * 0.6, y);
+	await page.mouse.down();
+	await page.mouse.move(box.x + box.width * 0.9, y, {steps: 10});
+	await page.mouse.up();
+	await expect(page.getByRole('button', {name: 'Zoom'})).toHaveAttribute(
+		'aria-pressed',
+		'true',
+	);
+
+	await expect(needle).toHaveCount(0);
+
+	// Still in history, so this is the needle standing down rather than the
+	// board quietly resuming.
+	await expect(
+		page.getByRole('button', {name: 'Resume', exact: true}),
+	).toBeEnabled();
+
+	await returnToLive(page);
+	expect(pageErrors).toEqual([]);
+});

--- a/source/test/e2e-gui/scrub-dispatch.pw.ts
+++ b/source/test/e2e-gui/scrub-dispatch.pw.ts
@@ -191,6 +191,19 @@ test('a drag across the track zooms the window to it, without scrubbing', async 
 	await page.goto(appUrl);
 	await expect(page.getByTestId('board-switcher')).toContainText('Default');
 
+	// Off "All", so the period pager is already on the row and the only thing
+	// that can move the scope buttons is the one under test.
+	const week = page.getByRole('button', {name: 'Week', exact: true});
+	await week.click();
+	await expect(week).toHaveAttribute('aria-pressed', 'true');
+
+	const zoom = page.getByRole('button', {name: 'Zoom'});
+	const hour = page.getByRole('button', {name: 'Hour', exact: true});
+	const before = {
+		hour: await hour.boundingBox(),
+		zoom: await zoom.boundingBox(),
+	};
+
 	const track = page.getByTestId('scrubber-track');
 	const box = await track.boundingBox();
 	if (!box) throw new Error('scrubber track is not on screen');
@@ -206,8 +219,16 @@ test('a drag across the track zooms the window to it, without scrubbing', async 
 
 	await page.mouse.up();
 
-	const zoomed = page.getByRole('button', {name: 'Clear zoom'});
-	await expect(zoomed).toBeVisible();
+	// The window is now none of the periods on offer, so the seventh option
+	// stands for it and none of the rest reads as pressed.
+	await expect(zoom).toHaveAttribute('aria-pressed', 'true');
+	await expect(week).toHaveAttribute('aria-pressed', 'false');
+
+	// Zoom holds its width while it stands for nothing, so coming and going
+	// never slides the row out from under the pointer.
+	expect(await zoom.boundingBox()).toEqual(before.zoom);
+	expect(await hour.boundingBox()).toEqual(before.hour);
+	expect(before.zoom?.width).toBeGreaterThan(0);
 
 	const params = new URL(page.url()).searchParams;
 	const from = Number(params.get('from'));
@@ -217,9 +238,10 @@ test('a drag across the track zooms the window to it, without scrubbing', async 
 	await page.waitForTimeout(2000);
 	expect(targets).toEqual([]);
 
-	// And back out again, to the window the drag was made in.
-	await zoomed.click();
-	await expect(zoomed).toBeHidden();
+	// And back out again by naming a period, which is the only way out.
+	await week.click();
+	await expect(zoom).toHaveAttribute('aria-pressed', 'false');
+	await expect(week).toHaveAttribute('aria-pressed', 'true');
 	expect(new URL(page.url()).searchParams.get('from')).toBeNull();
 
 	await returnToLive(page);

--- a/source/test/e2e-gui/scrub-dispatch.pw.ts
+++ b/source/test/e2e-gui/scrub-dispatch.pw.ts
@@ -68,8 +68,9 @@ test('a click on the track asks the server to scrub once', async ({
 	expect(pageErrors).toEqual([]);
 });
 
-// A drag is a scrub, never a native text selection: without user-select off,
-// sweeping the needle could pick up the axis labels and drag them as a ghost.
+// A drag is a gesture on the chart, never a native text selection: without
+// user-select off, sweeping across could pick up the axis labels and drag them
+// as a ghost.
 test('a drag never starts a text selection', async ({
 	page,
 	appUrl,
@@ -100,13 +101,8 @@ test('a drag never starts a text selection', async ({
 	expect(pageErrors).toEqual([]);
 });
 
-// The press dispatches immediately and the moves are throttled, so without the
-// release the last stretch of a drag would never be asked for.
-test('a drag commits the position it ends on', async ({
-	page,
-	appUrl,
-	pageErrors,
-}) => {
+// Watches every scrub the page asks the server for, in order.
+const recordScrubs = async (page: Page): Promise<number[]> => {
 	const targets: number[] = [];
 
 	await page.routeWebSocket(/\/ws/, ws => {
@@ -128,6 +124,18 @@ test('a drag commits the position it ends on', async ({
 		server.onMessage(message => ws.send(message));
 	});
 
+	return targets;
+};
+
+// The press dispatches immediately and the moves are throttled, so without the
+// release the last stretch of a drag would never be asked for.
+test('dragging the needle commits the position it ends on', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	const targets = await recordScrubs(page);
+
 	await page.goto(appUrl);
 	await expect(page.getByTestId('board-switcher')).toContainText('Default');
 
@@ -136,7 +144,19 @@ test('a drag commits the position it ends on', async ({
 	if (!box) throw new Error('scrubber track is not on screen');
 
 	const y = box.y + box.height / 2;
-	await page.mouse.move(box.x + box.width * 0.2, y);
+
+	// The needle parks at the right edge while live, so it has to be put
+	// somewhere draggable first.
+	await page.mouse.click(box.x + box.width * 0.2, y);
+	await expect(
+		page.getByRole('button', {name: 'Resume', exact: true}),
+	).toBeEnabled();
+
+	const grip = page.getByTestId('scrubber-needle-grip');
+	const gripBox = await grip.boundingBox();
+	if (!gripBox) throw new Error('scrubber needle is not on screen');
+
+	await page.mouse.move(gripBox.x + gripBox.width / 2, y);
 	await page.mouse.down();
 	for (const at of [0.4, 0.6, 0.8]) {
 		await page.mouse.move(box.x + box.width * at, y);
@@ -149,6 +169,58 @@ test('a drag commits the position it ends on', async ({
 	// The release lands on the far right, so the last request must be the
 	// largest moment asked for.
 	expect(targets[targets.length - 1]).toBe(Math.max(...targets));
+
+	// A needle drag scrubs and nothing more: the window it was dragged across
+	// is the same one it started in.
+	expect(new URL(page.url()).searchParams.get('from')).toBeNull();
+
+	await returnToLive(page);
+	expect(pageErrors).toEqual([]);
+});
+
+// The gesture the needle drag had to give up. Dragging anywhere else across
+// the track picks a stretch of time and makes it the whole window, which is
+// only unambiguous because it never scrubs on the way.
+test('a drag across the track zooms the window to it, without scrubbing', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	const targets = await recordScrubs(page);
+
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	const track = page.getByTestId('scrubber-track');
+	const box = await track.boundingBox();
+	if (!box) throw new Error('scrubber track is not on screen');
+
+	const y = box.y + box.height / 2;
+	await page.mouse.move(box.x + box.width * 0.3, y);
+	await page.mouse.down();
+	await page.mouse.move(box.x + box.width * 0.7, y, {steps: 10});
+
+	// The stretch is drawn while it is being dragged out, so it can be seen
+	// before it is committed.
+	await expect(page.getByTestId('scrubber-range-selection')).toBeVisible();
+
+	await page.mouse.up();
+
+	const zoomed = page.getByRole('button', {name: 'Clear zoom'});
+	await expect(zoomed).toBeVisible();
+
+	const params = new URL(page.url()).searchParams;
+	const from = Number(params.get('from'));
+	const to = Number(params.get('to'));
+	expect(to).toBeGreaterThan(from);
+
+	await page.waitForTimeout(2000);
+	expect(targets).toEqual([]);
+
+	// And back out again, to the window the drag was made in.
+	await zoomed.click();
+	await expect(zoomed).toBeHidden();
+	expect(new URL(page.url()).searchParams.get('from')).toBeNull();
 
 	await returnToLive(page);
 	expect(pageErrors).toEqual([]);


### PR DESCRIPTION
Closes TVWQZ8S.

Dragging across the timeline used to sweep the needle, checking out every moment it passed over. It now drags out a stretch of time and makes that stretch the window.

### The gesture split

The ticket's own constraint: a range drag and a scrub drag cannot share the track. So time travel keeps the click — press and release on one spot, under a 6px threshold, still scrubs — and its *drag* moves to the needle, which grew an invisible 11px grip over its 1px hairline and an `ew-resize` cursor. The track's cursor is now a crosshair.

Keeping the click was a call I made rather than one the ticket settles: a click cannot collide with a drag, and dropping it would have left no way to enter history without first having a needle to grab.

### The window, and the seventh option

`BoardSelection` gains `zoom: PeriodRange | null`, carried as `from`/`to` in the URL beside `scope`, so a zoomed view is a link like any other. It is deliberately not persisted to localStorage — a stretch of last Tuesday is a moment, not a preference, the same reason `offset` is not.

A zoomed window is none of the periods the scope row lists, so a seventh option, `Zoom`, stands for it and the rest release. Leaving is naming any period — the gesture that button group already means — so there is no separate dismiss control to guess at. `Zoom` holds its width while it stands for nothing, faded the way the pager's ▶ sits out a period it cannot reach, so the row never slides under the pointer as a zoom comes and goes; its title carries the drag, since a button nobody can press has to say why.

While zoomed, ◀ ▶ slide the window by its own width rather than by whole periods (clamped so it cannot pass the present), and ▶ is disabled once it reaches now.

### What the ticket asked for that the code did not need

The ticket asked for the rendering to be inferred from the scope the selection falls within. It turns out the chart already derives its bucket count, bar width, segment unit and hour axis from `axis.span`, so the rendering follows a hand-picked window without being told. That left the inference only *naming* things — and with `Zoom` doing the naming and the exit naming the next scope explicitly, `scopeForSpan` had no caller left, so it is gone rather than kept alive to satisfy the line.

### Feedback while dragging

The stretch is drawn as it is dragged out, and the hover highlights and hint stand down for it so they are not competing over the same pixels. The hint says the interval and what releasing will do.

### Tests

- `formatPeriodLabel` for a zoomed window, including the clock-rather-than-two-identical-dates case that the paged-back label was already getting wrong inside one day.
- `applySelectionPatch` / URL / storage round-trips for the new field; that naming any scope clears a zoom, the one already held included; and that a window which is not two moments in order is refused rather than building an axis over NaN.
- Three Playwright specs: dragging the needle commits the position it ends on without changing the window; a drag across the track zooms without dispatching a single scrub, flips `Zoom` to pressed and `Week` to not, and leaves again by naming a period; and `Zoom` and its neighbours hold their exact bounding boxes across the whole thing, so the row does not jump.

Full unit suite (952) and GUI e2e suite (59) green. Also checked by hand in a browser against a throwaway project with a week of backdated activity.
