### PR TITLE
Move the created-at line into the ticket panel header

### DIFF
--- a/source/gui/client/components/IssueDetails.tsx
+++ b/source/gui/client/components/IssueDetails.tsx
@@ -312,22 +312,6 @@ export const IssueDetails = ({
 
 				const overviewPane = issue && (
 					<>
-						{/* 0 when the id carries no time. Better to say nothing than to
-							    date the ticket to 1970. */}
-						{issue.createdAt > 0 && (
-							<div
-								data-testid="issue-created-at"
-								title={formatAbsolute(issue.createdAt)}
-								style={{
-									fontSize: TEXT.meta,
-									color: GUI_THEME.dim,
-									marginBottom: 14,
-								}}
-							>
-								Created {timeAgo(issue.createdAt)}
-							</div>
-						)}
-
 						<Section
 							first={true}
 							title="Description"
@@ -681,16 +665,35 @@ export const IssueDetails = ({
 								}
 							>
 								<FormHeader>
-									<span
-										style={{
-											color: GUI_THEME.secondary,
-											fontSize: TEXT.label,
-											textTransform: 'uppercase',
-											letterSpacing: '0.08em',
-										}}
+									<div
+										style={{display: 'flex', alignItems: 'baseline', gap: 10}}
 									>
-										{issue.ref && <CopyRef refValue={issue.ref} />}
-									</span>
+										<span
+											style={{
+												color: GUI_THEME.secondary,
+												fontSize: TEXT.label,
+												textTransform: 'uppercase',
+												letterSpacing: '0.08em',
+											}}
+										>
+											{issue.ref && <CopyRef refValue={issue.ref} />}
+										</span>
+
+										{/* 0 when the id carries no time. Better to say nothing
+										    than to date the ticket to 1970. */}
+										{issue.createdAt > 0 && (
+											<span
+												data-testid="issue-created-at"
+												title={formatAbsolute(issue.createdAt)}
+												style={{
+													fontSize: TEXT.meta,
+													color: GUI_THEME.dim,
+												}}
+											>
+												Created {timeAgo(issue.createdAt)}
+											</span>
+										)}
+									</div>
 
 									<div style={{display: 'flex', alignItems: 'center', gap: 2}}>
 										<FullscreenToggleButton

--- a/source/test/e2e-gui/issue-history.pw.ts
+++ b/source/test/e2e-gui/issue-history.pw.ts
@@ -38,7 +38,7 @@ test('the log tab lists the ticket’s own events', async ({
 	expect(pageErrors).toEqual([]);
 });
 
-test('the overview names when the ticket was created', async ({page}) => {
+test('the panel header names when the ticket was created', async ({page}) => {
 	const title = `Created ${Date.now()}`;
 	await openFirstTicket(page, title);
 
@@ -50,6 +50,11 @@ test('the overview names when the ticket was created', async ({page}) => {
 		'title',
 		new RegExp(String(new Date().getFullYear())),
 	);
+
+	// It lives in the header beside the ref, not in the Overview pane, so it
+	// survives a tab change.
+	await page.getByRole('button', {name: /^Log/}).click();
+	await expect(created).toBeVisible();
 });
 
 test('the log tab survives a reload on its own url', async ({page}) => {


### PR DESCRIPTION
Closes 4YRGC3C.

"Created X ago" sat at the top of the Overview pane, so it vanished the moment you switched to Log, Comments or Commits. It now sits in the panel's `FormHeader` on the same line as the ref, visible on every tab.

Behaviour is unchanged otherwise: still hidden when `createdAt` is 0 (an id carrying no time), still relative text from `timeAgo`, still the exact timestamp on hover via `title`.

The existing e2e test was named for the Overview pane; renamed, and extended to switch tabs and assert the line is still visible — which is the property the move actually buys.

Full pre-push gate green (lint, typecheck, unit, e2e, collaboration, 58 GUI browser tests).