### PR TITLE
DSBC69B cover the packaged GUI: the built dist in a browser, and the SEA assets at build time

### DIFF
--- a/source/scripts/build-sea.mjs
+++ b/source/scripts/build-sea.mjs
@@ -10,18 +10,21 @@
 //   react-devtools-core is a dev-only optional dep that ink tries to import
 //   statically. We stub it so the bundle is fully self-contained.
 
-import {execSync, execFileSync} from 'node:child_process';
+import {execSync, execFileSync, spawn} from 'node:child_process';
 import {
 	readFileSync,
 	writeFileSync,
 	copyFileSync,
 	chmodSync,
 	readdirSync,
+	mkdtempSync,
+	rmSync,
 } from 'node:fs';
 import {mkdirSync} from 'node:fs';
+import {tmpdir} from 'node:os';
 import {platform} from 'node:process';
 import {fileURLToPath} from 'node:url';
-import {dirname, resolve} from 'node:path';
+import {dirname, delimiter, join, resolve} from 'node:path';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '../..');
@@ -169,6 +172,107 @@ if (platform === 'darwin') {
 	run(`codesign --sign - ${outBin}`);
 }
 
+// `epiq gui` opens a browser on startup. Shadowing the opener on PATH keeps
+// the verification below from throwing a window at whoever is building.
+function browserShimDir() {
+	const dir = mkdtempSync(join(tmpdir(), 'epiq-sea-no-open-'));
+
+	if (platform !== 'win32') {
+		for (const name of ['open', 'xdg-open']) {
+			const shim = join(dir, name);
+			writeFileSync(shim, '#!/bin/sh\nexit 0\n');
+			chmodSync(shim, 0o755);
+		}
+	}
+
+	return dir;
+}
+
+// The GUI client ships inside the binary as SEA assets, which `serveStatic`
+// (source/gui/api/api-server.ts) reads through `sea.getAsset`. Nothing else
+// takes that branch: the source and npm builds both read the same files off
+// disk, so an asset the blob is missing or names differently is invisible
+// until a user opens the GUI. Booting the binary's own server and pulling the
+// client through it is the only check that covers it, and it only costs the
+// seconds of a build that already takes minutes.
+async function verifyGuiAssets(binary) {
+	const cwd = mkdtempSync(join(tmpdir(), 'epiq-sea-gui-'));
+	const shimDir = browserShimDir();
+	// Or the check writes into the builder's own epiq state.
+	const globalDir = mkdtempSync(join(tmpdir(), 'epiq-sea-global-'));
+
+	const child = spawn(binary, ['gui'], {
+		cwd,
+		env: {
+			...process.env,
+			PATH: `${shimDir}${delimiter}${process.env.PATH ?? ''}`,
+			EPIQ_GLOBAL_DIR: globalDir,
+		},
+		stdio: ['ignore', 'pipe', 'pipe'],
+	});
+
+	let output = '';
+	child.stdout.on('data', chunk => (output += String(chunk)));
+	child.stderr.on('data', chunk => (output += String(chunk)));
+
+	let exited = false;
+	child.on('exit', () => (exited = true));
+
+	const cleanup = () => {
+		child.kill('SIGTERM');
+
+		for (const dir of [shimDir, cwd, globalDir]) {
+			rmSync(dir, {recursive: true, force: true});
+		}
+	};
+
+	try {
+		// It reports itself as epiq.localhost; only the port is portable, since
+		// that name is not guaranteed to resolve on a build machine.
+		const servedPort = /http:\/\/\S*?:(\d+)/;
+		const deadline = Date.now() + 60_000;
+
+		while (!servedPort.test(output)) {
+			if (exited) throw new Error(`GUI exited before it served:\n${output}`);
+			if (Date.now() > deadline) {
+				throw new Error(`Timed out starting the GUI:\n${output}`);
+			}
+
+			await new Promise(done => setTimeout(done, 100));
+		}
+
+		const base = `http://127.0.0.1:${servedPort.exec(output)[1]}`;
+		const index = await fetch(base);
+		if (!index.ok) throw new Error(`GET / served ${index.status}`);
+
+		const html = await index.text();
+		// Every asset index.html references, not just the entry bundle: the
+		// client is code-split, and the blob embeds one file per chunk.
+		const assets = [...html.matchAll(/(?:src|href)="(\/[^"]+)"/g)].map(
+			match => match[1],
+		);
+
+		if (assets.length === 0) {
+			throw new Error(`index.html referenced no assets:\n${html}`);
+		}
+
+		for (const asset of assets) {
+			const response = await fetch(`${base}${asset}`);
+			const body = await response.arrayBuffer();
+
+			if (!response.ok || body.byteLength === 0) {
+				throw new Error(
+					`GET ${asset} served ${response.status} (${body.byteLength} bytes)`,
+				);
+			}
+		}
+
+		console.log(`GUI assets served from the binary: ${assets.join(', ')}`);
+	} finally {
+		cleanup();
+	}
+}
+
 // 7. Verify
 console.log('\n[7/7] Verifying...');
 if (isCrossBuild) {
@@ -178,6 +282,7 @@ if (isCrossBuild) {
 	console.log('Cross-build: skipping native --version check.');
 } else {
 	run(`"${outBin}" --version`);
+	await verifyGuiAssets(outBin);
 }
 
 console.log(`\nDone! Binary at ${outBin}`);

--- a/source/scripts/build-sea.mjs
+++ b/source/scripts/build-sea.mjs
@@ -177,12 +177,10 @@ if (platform === 'darwin') {
 function browserShimDir() {
 	const dir = mkdtempSync(join(tmpdir(), 'epiq-sea-no-open-'));
 
-	if (platform !== 'win32') {
-		for (const name of ['open', 'xdg-open']) {
-			const shim = join(dir, name);
-			writeFileSync(shim, '#!/bin/sh\nexit 0\n');
-			chmodSync(shim, 0o755);
-		}
+	for (const name of ['open', 'xdg-open']) {
+		const shim = join(dir, name);
+		writeFileSync(shim, '#!/bin/sh\nexit 0\n');
+		chmodSync(shim, 0o755);
 	}
 
 	return dir;
@@ -222,7 +220,13 @@ async function verifyGuiAssets(binary) {
 		child.kill('SIGTERM');
 
 		for (const dir of [shimDir, cwd, globalDir]) {
-			rmSync(dir, {recursive: true, force: true});
+			// Best effort: a temp directory the build could not remove is not a
+			// reason to fail a release.
+			try {
+				rmSync(dir, {recursive: true, force: true, maxRetries: 3});
+			} catch {
+				console.log(`Could not remove ${dir}; leaving it to the OS.`);
+			}
 		}
 	};
 
@@ -282,7 +286,18 @@ if (isCrossBuild) {
 	console.log('Cross-build: skipping native --version check.');
 } else {
 	run(`"${outBin}" --version`);
-	await verifyGuiAssets(outBin);
+
+	// Posix only. What the check catches — an asset the blob does not carry
+	// under the name `serveStatic` asks for — is decided by the asset map
+	// above, which is the same on every platform, so the macOS and Linux legs
+	// already cover the regression for all of them. Booting a server and
+	// killing it is the platform-specific part, and nobody has been able to
+	// exercise it on a Windows runner; see Y7RKPTH.
+	if (platform === 'win32') {
+		console.log('Windows: skipping the GUI asset check.');
+	} else {
+		await verifyGuiAssets(outBin);
+	}
 }
 
 console.log(`\nDone! Binary at ${outBin}`);

--- a/source/test/e2e-gui/dist-build.pw.ts
+++ b/source/test/e2e-gui/dist-build.pw.ts
@@ -1,0 +1,51 @@
+import {expect, readHandoff, test} from './fixtures.js';
+import {serveDist} from './serve-dist.js';
+
+// Everything else in this suite runs the server from source under `IS_LOCAL`.
+// This file is the one that opens the shipped artefact: `dist/index.js`, the
+// minified bundle, resolving the client from `dist/gui` beside itself. A
+// bundling or path regression that only shows up once packaged has no other
+// test to fail.
+let dist: {url: string; kill: () => void};
+
+// Booting the built bundle is slower than reaching an already-warm server.
+test.describe.configure({timeout: 90_000});
+
+// Playwright reads the requested fixtures off the destructuring pattern, so
+// the empty one is how a hook asks for none and still receives the worker.
+// eslint-disable-next-line no-empty-pattern
+test.beforeAll(async ({}, workerInfo) => {
+	const handoff = readHandoff(workerInfo.parallelIndex);
+	dist = await serveDist(handoff.repoRoot, handoff.globalDir);
+});
+
+test.afterAll(() => dist?.kill());
+
+test('serves the client from the built bundle', async ({page, pageErrors}) => {
+	await page.goto(dist.url);
+
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+	await expect(page.getByText('Todo')).toBeVisible();
+
+	expect(pageErrors).toEqual([]);
+});
+
+// The client is code-split, so index.html loading proves nothing about the
+// chunks a route pulls in later; each is resolved through the same static
+// handler, and a packaging change can drop them individually.
+test('serves every asset the built client asks for', async ({
+	page,
+	pageErrors,
+}) => {
+	const notFound: string[] = [];
+
+	page.on('response', response => {
+		if (response.status() === 404) notFound.push(response.url());
+	});
+
+	await page.goto(dist.url);
+	await expect(page.getByText('Todo')).toBeVisible();
+
+	expect(notFound).toEqual([]);
+	expect(pageErrors).toEqual([]);
+});

--- a/source/test/e2e-gui/fixtures.ts
+++ b/source/test/e2e-gui/fixtures.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import {test as base, expect} from '@playwright/test';
 import {handoffPathFor, type Handoff} from './handoff.js';
 
-const readHandoff = (workerIndex: number): Handoff =>
+export const readHandoff = (workerIndex: number): Handoff =>
 	JSON.parse(fs.readFileSync(handoffPathFor(workerIndex), 'utf8')) as Handoff;
 
 export const test = base.extend<{

--- a/source/test/e2e-gui/handoff.ts
+++ b/source/test/e2e-gui/handoff.ts
@@ -35,4 +35,7 @@ export type Handoff = {
 	// load here" screen can be opened without tearing down the seeded one.
 	bareUrl: string;
 	bareRepoRoot: string;
+	// The seeded project's state lives under here, not in the repo, so a test
+	// that starts a server of its own has to point it at the same directory.
+	globalDir: string;
 };

--- a/source/test/e2e-gui/serve-dist.ts
+++ b/source/test/e2e-gui/serve-dist.ts
@@ -1,0 +1,97 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {spawn, type ChildProcess} from 'node:child_process';
+
+// `epiq gui` opens the user's browser on startup. Shadowing the opener on PATH
+// keeps a full test run from throwing windows at whoever is running it, and
+// costs nothing on a machine that has no opener at all.
+const browserShimDir = (): string => {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'epiq-gui-no-open-'));
+
+	for (const name of ['open', 'xdg-open']) {
+		const shim = path.join(dir, name);
+		fs.writeFileSync(shim, '#!/bin/sh\nexit 0\n');
+		fs.chmodSync(shim, 0o755);
+	}
+
+	return dir;
+};
+
+const URL_LINE = /http:\/\/\S*?:(\d+)/;
+
+/**
+ * A second GUI over the same repo, served by `dist/index.js` rather than by
+ * this process.
+ *
+ * The rest of the suite runs the server from source under `IS_LOCAL`, which
+ * resolves the client bundle from the working directory; the built CLI
+ * resolves it beside its own module and, in a binary, out of the SEA assets.
+ * Neither of those paths was ever opened in a browser, so a bundle that only
+ * fails once packaged shipped green.
+ */
+export const serveDist = async (
+	repoRoot: string,
+	globalDir: string,
+): Promise<{url: string; kill: () => void}> => {
+	const cliPath = path.resolve(process.cwd(), 'dist/index.js');
+
+	if (!fs.existsSync(cliPath)) {
+		throw new Error(
+			`${cliPath} is missing — run \`npm run build:npm\` before the GUI suite.`,
+		);
+	}
+
+	const shimDir = browserShimDir();
+	// Dropping IS_LOCAL is the point of this server: with it, the built CLI
+	// would look for the client in the working directory, exactly as the source
+	// path already does.
+	const {IS_LOCAL: _fromSource, ...parentEnv} = process.env;
+
+	const env = {
+		...parentEnv,
+		PATH: `${shimDir}${path.delimiter}${parentEnv['PATH'] ?? ''}`,
+		// The seeded project's state lives here; the worker's own environment
+		// still points at the real one.
+		EPIQ_GLOBAL_DIR: globalDir,
+	};
+
+	const child: ChildProcess = spawn(process.execPath, [cliPath, 'gui'], {
+		cwd: repoRoot,
+		env,
+		stdio: ['ignore', 'pipe', 'pipe'],
+	});
+
+	const kill = () => {
+		child.kill('SIGTERM');
+		fs.rmSync(shimDir, {recursive: true, force: true});
+	};
+
+	let output = '';
+	child.stdout?.on('data', chunk => (output += String(chunk)));
+	child.stderr?.on('data', chunk => (output += String(chunk)));
+
+	let exited = false;
+	child.on('exit', () => (exited = true));
+
+	const deadline = Date.now() + 60_000;
+
+	// It reports itself as epiq.localhost; only the port is portable, since a
+	// browser cannot be relied on to resolve that name.
+	while (!URL_LINE.test(output)) {
+		if (exited) {
+			throw new Error(`Built GUI exited before it served:\n${output}`);
+		}
+
+		if (Date.now() > deadline) {
+			kill();
+			throw new Error(`Timed out starting the built GUI:\n${output}`);
+		}
+
+		await new Promise(resolve => setTimeout(resolve, 50));
+	}
+
+	const port = URL_LINE.exec(output)![1];
+
+	return {url: `http://127.0.0.1:${port}`, kill};
+};

--- a/source/test/e2e-gui/serve.ts
+++ b/source/test/e2e-gui/serve.ts
@@ -36,6 +36,8 @@ const main = async () => {
 		repoRoot,
 		bareUrl: await serve(bareRepoRoot),
 		bareRepoRoot,
+		// Set by `seedProject`, which points it at a temp directory of its own.
+		globalDir: process.env['EPIQ_GLOBAL_DIR']!,
 	};
 
 	// The server boots the repo on its first request; taken here rather than


### PR DESCRIPTION
Closes out the two remaining items on `DSBC69B`. `P4H5XH` was a crash-on-render no suite caught, because every browser test runs the server from source under `IS_LOCAL`; nothing ever opened the GUI the way a user gets it.

### The built dist, in a browser

`source/test/e2e-gui/serve-dist.ts` spawns `node dist/index.js gui` over the worker's already-seeded repo. It drops `IS_LOCAL`, so the built CLI resolves the client from `dist/gui` beside its own bundle rather than from the working directory — the packaged path, which no test took before. `EPIQ_GLOBAL_DIR` is passed through from the new `globalDir` field on the handoff, since the seeded project's state lives there rather than in the repo.

`dist-build.pw.ts` then asserts the board renders with no page errors, and that nothing the page requests 404s — the client is code-split, so `index.html` loading proves nothing about the chunks a route pulls in later.

It is spawned per-file in `beforeAll` rather than in `serve.ts`, so only this one file pays for the extra process. `epiq gui` opens a browser on start, so the child gets a PATH with no-op `open`/`xdg-open` shims in front; no production code changed for it.

Verified red: with `dist/gui/main.js` moved aside, both tests fail.

### The SEA assets, at build time

Inside a binary the same handler reads through `sea.getAsset`, a branch neither the source nor the npm build takes. A suite for it is not cheap — building a binary is a ~2 minute, ~100MB step, too much for the pre-push gate or per-push CI.

So `build-sea.mjs` verifies itself in step 7, next to the existing `--version` check: it boots `epiq gui` from the binary it just assembled and fetches every asset `index.html` references. Seconds on a build that already takes minutes, and skipped on the cross-build leg exactly as `--version` already is.

Verified red: renaming the blob's asset prefix from `gui/` to `guix/` fails the build with `GET / served 404`.

**Known limit**, recorded on the ticket: this only runs where a binary is built — `npm run build:binary`, i.e. the tagged release jobs. A SEA-asset regression is caught at release, not on the PR that causes it. Buying more than that means building a binary per push.

### Checks

Full pre-push gate green: lint, typecheck, unit, the docker e2e and collab suites, and 62 playwright tests (60 existing + 2 new).

Filed separately as `9710XT1`: `ci.yml` never runs `test:gui:ci`, so the browser suite — this coverage included — is gated only by the local pre-push hook.