### PR TITLE
KZK01SD let the scatter tell a click on a dot from a drag that starts on one

### DIFF
--- a/source/gui/client/components/ScrubberLayout.tsx
+++ b/source/gui/client/components/ScrubberLayout.tsx
@@ -69,7 +69,7 @@ export type ScrubberChartHandlers = {
 	onCommitTrackMouseLeave: () => void;
 	onScatterPointEnter: (point: ScatterPoint) => void;
 	onScatterPointLeave: () => void;
-	onInspectCommit: (sha: string) => void;
+	onPressCommit: (sha: string | null) => void;
 };
 
 export type ScrubberChart = {
@@ -269,7 +269,7 @@ export const ScrubberLayout = ({
 									highlightId={chart.highlightEventId}
 									onPointEnter={on.onScatterPointEnter}
 									onPointLeave={on.onScatterPointLeave}
-									onInspectCommit={on.onInspectCommit}
+									onPressCommit={on.onPressCommit}
 								/>
 							)}
 						</div>

--- a/source/gui/client/components/ScrubberParts.tsx
+++ b/source/gui/client/components/ScrubberParts.tsx
@@ -1347,7 +1347,7 @@ export const ScatterCanvas = ({
 	highlightId,
 	onPointEnter,
 	onPointLeave,
-	onInspectCommit,
+	onPressCommit,
 }: {
 	layers: readonly ScatterLayer[];
 	animate: boolean;
@@ -1355,7 +1355,10 @@ export const ScatterCanvas = ({
 	highlightId: string | null;
 	onPointEnter: (point: ScatterPoint) => void;
 	onPointLeave: () => void;
-	onInspectCommit: (sha: string) => void;
+	// The commit a press landed on, or null for anywhere else. Reported rather
+	// than acted on: the track holds the pointer capture, so it is the one that
+	// can tell this press apart from the start of a range drag.
+	onPressCommit: (sha: string | null) => void;
 }) => {
 	const canvasRef = useRef<HTMLCanvasElement | null>(null);
 	const sizeRef = useRef({width: 0, height: 0});
@@ -1570,15 +1573,15 @@ export const ScatterCanvas = ({
 				hoveredRef.current = null;
 				onPointLeave();
 			}}
-			// Only over a commit: anywhere else the press has to reach the track
-			// and begin a scrub.
-			onPointerDown={event => {
-				if (hitTest(event)?.commitSha) event.stopPropagation();
-			}}
-			onClick={event => {
-				const sha = hitTest(event)?.commitSha;
-				if (sha) onInspectCommit(sha);
-			}}
+			// Never stopped, not even over a commit: every press has to reach the
+			// track, or a range drag that begins on a dot never begins at all — and
+			// on a busy scatter most of them do. What the press turns out to mean is
+			// settled on release, by how far it travelled.
+			//
+			// There is deliberately no onClick here. The track takes pointer
+			// capture, which retargets the compatibility mouse events with it, so a
+			// click on the canvas is not the canvas's to hear.
+			onPointerDown={event => onPressCommit(hitTest(event)?.commitSha ?? null)}
 		/>
 	);
 };

--- a/source/gui/client/components/TimeScrubber.tsx
+++ b/source/gui/client/components/TimeScrubber.tsx
@@ -136,6 +136,11 @@ export const TimeScrubber = ({
 	// Set by the needle's own press, which fires before the track's: it says
 	// this drag moves the needle rather than dragging out a range.
 	const grabbedNeedleRef = useRef(false);
+	// Likewise from the scatter, naming the commit a press landed on. A click on
+	// a dot opens its diff instead of time travelling; a drag from one is a range
+	// like any other. Cleared at the end of every gesture, so a press that never
+	// crosses the canvas cannot inherit it.
+	const pressedCommitRef = useRef<string | null>(null);
 
 	const [collapsed, setCollapsed] = usePersistedFlag(
 		COLLAPSED_STORAGE_KEY,
@@ -529,6 +534,9 @@ export const TimeScrubber = ({
 	const endDrag = () => {
 		grabbedNeedleRef.current = false;
 
+		const pressedCommit = pressedCommitRef.current;
+		pressedCommitRef.current = null;
+
 		if (dragFraction !== null) {
 			dispatchScrub(dragFraction, true);
 			setDragFraction(null);
@@ -542,9 +550,17 @@ export const TimeScrubber = ({
 
 		const trackWidth = trackRef.current?.clientWidth ?? 0;
 
-		// Pressed and released on one spot: a click, which still scrubs. Only a
-		// drag wide enough to have been aimed is read as a range.
+		// Pressed and released on one spot: a click. Only a drag wide enough to
+		// have been aimed is read as a range.
 		if (Math.abs(to - from) * trackWidth < MIN_RANGE_DRAG_PX) {
+			// A click that began on a commit dot was aimed at the commit, so it
+			// opens the diff rather than time travelling. The dot pressed decides
+			// it, not whatever the release happens to land on.
+			if (pressedCommit !== null) {
+				onInspectCommit(pressedCommit);
+				return;
+			}
+
 			dispatchScrub(from, true);
 			return;
 		}
@@ -826,7 +842,9 @@ export const TimeScrubber = ({
 					onCommitTrackMouseLeave: () => setHoveredCommitBucketIndex(null),
 					onScatterPointEnter,
 					onScatterPointLeave,
-					onInspectCommit,
+					onPressCommit: sha => {
+						pressedCommitRef.current = sha;
+					},
 				},
 			}}
 		/>

--- a/source/test/e2e-gui/scatter-gesture.pw.ts
+++ b/source/test/e2e-gui/scatter-gesture.pw.ts
@@ -1,0 +1,151 @@
+import {execFileSync} from 'node:child_process';
+import type {Locator, Page} from '@playwright/test';
+import {expect, test} from './fixtures.js';
+import {COMMIT_CACHE_MS, commitLinkedFile} from './linked-commit.js';
+
+// A dot is painted on a canvas, so there is no node to aim at and no
+// bounding box to read. Its x is pinned instead by handing the scrubber a
+// window centred on the commit — the dot then sits at the middle of the track
+// by construction — and its y, which is the commit's time of day, is found by
+// sweeping the canvas's own height until the hint opens. The hint is matched on
+// this commit's own subject, so a sibling test's dot cannot answer for it.
+const findCommitDot = async (page: Page, canvas: Locator, hint: Locator) => {
+	const box = await canvas.boundingBox();
+	if (!box) throw new Error('scatter canvas is not on screen');
+
+	const x = box.x + box.width / 2;
+
+	for (let offset = 2; offset < box.height; offset += 3) {
+		await page.mouse.move(x, box.y + offset);
+		if (await hint.isVisible()) return {x, y: box.y + offset};
+	}
+
+	throw new Error('no commit dot found down the middle of the scatter');
+};
+
+// Board, ticket, and one commit linked to it, with the scrubber left showing
+// the scatter over a two-minute window centred on that commit.
+const seedCommitOnScatter = async (
+	page: Page,
+	appUrl: string,
+	repoRoot: string,
+) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	const stamp = Date.now();
+	await page.getByTitle('Add issue').first().click();
+	await page.getByPlaceholder('issue name').fill(`Scatter ${stamp}`);
+	await page.getByPlaceholder('issue name').press('Enter');
+	await expect(page.locator('aside')).toContainText(`Scatter ${stamp}`);
+
+	const ref = (
+		await page.locator('aside button[title^="Copy "]').first().textContent()
+	)?.trim();
+	expect(ref).toBeTruthy();
+
+	// The worker's repo is shared by every test in this file, so the file and
+	// the subject both carry the stamp: a repeated path has nothing to commit,
+	// and a repeated subject would let one test's dot answer for another's.
+	const subject = `notes ${stamp}`;
+	const sha = commitLinkedFile(
+		repoRoot,
+		ref!,
+		subject,
+		`notes-${stamp}.txt`,
+		`line for ${stamp}\n`,
+	);
+	const committedAt =
+		Number(
+			execFileSync('git', ['show', '-s', '--format=%ct', sha], {
+				cwd: repoRoot,
+			})
+				.toString()
+				.trim(),
+		) * 1000;
+
+	// The server caches the commit timeline, so the page has to outlive that
+	// before a reload can see the commit at all.
+	await page.waitForTimeout(COMMIT_CACHE_MS);
+
+	const url = new URL(page.url());
+	url.searchParams.set('layout', 'real');
+	url.searchParams.set('from', String(committedAt - 60_000));
+	url.searchParams.set('to', String(committedAt + 60_000));
+	await page.goto(url.toString());
+
+	const canvas = page.getByTestId('scatter-canvas');
+	await expect(canvas).toHaveAttribute('data-entrance', 'done');
+
+	const hint = page.getByText(subject, {exact: false}).last();
+	const dot = await findCommitDot(page, canvas, hint);
+
+	return {dot, sha, window: {from: url.searchParams.get('from')!}};
+};
+
+const windowOf = (page: Page) => new URL(page.url()).searchParams.get('from');
+const commitOf = (page: Page) => new URL(page.url()).searchParams.get('commit');
+
+// The press used to be stopped over a commit so it could not scrub, which also
+// kept it from ever reaching the track — so a drag begun on a dot did nothing
+// at all. On a busy scatter that is most of the canvas.
+test('a drag that begins on a commit dot still zooms', async ({
+	page,
+	appUrl,
+	repoRoot,
+	pageErrors,
+}) => {
+	const {dot, window} = await seedCommitOnScatter(page, appUrl, repoRoot);
+
+	await page.mouse.move(dot.x, dot.y);
+	await page.mouse.down();
+	await page.mouse.move(dot.x + 220, dot.y, {steps: 10});
+	await page.mouse.up();
+
+	await expect.poll(async () => windowOf(page)).not.toBe(window.from);
+	expect(commitOf(page)).toBeNull();
+
+	expect(pageErrors).toEqual([]);
+});
+
+// Not a fault that was ever reachable: the track takes pointer capture, and
+// that retargets the compatibility mouse events with it, so a click never
+// reaches the canvas to be hit-tested at the release. This holds the pair of
+// facts the design now rests on — capture on the track, no onClick on the
+// canvas — since dropping either would open a commit nobody aimed at.
+test('a drag that ends on a commit dot does not open its diff', async ({
+	page,
+	appUrl,
+	repoRoot,
+	pageErrors,
+}) => {
+	const {dot, window} = await seedCommitOnScatter(page, appUrl, repoRoot);
+
+	await page.mouse.move(dot.x - 220, dot.y);
+	await page.mouse.down();
+	await page.mouse.move(dot.x, dot.y, {steps: 10});
+	await page.mouse.up();
+
+	await expect.poll(async () => windowOf(page)).not.toBe(window.from);
+	expect(commitOf(page)).toBeNull();
+
+	expect(pageErrors).toEqual([]);
+});
+
+// The other half of telling the two apart: a press that goes nowhere is still
+// aimed at the dot under it, and still opens the commit rather than scrubbing.
+test('a click on a commit dot opens its diff', async ({
+	page,
+	appUrl,
+	repoRoot,
+	pageErrors,
+}) => {
+	const {dot, sha} = await seedCommitOnScatter(page, appUrl, repoRoot);
+
+	await page.mouse.click(dot.x, dot.y);
+
+	await expect.poll(async () => commitOf(page)).toBe(sha);
+	expect(new URL(page.url()).searchParams.get('tab')).toBe('code');
+
+	expect(pageErrors).toEqual([]);
+});


### PR DESCRIPTION
Closes KZK01SD. Follow-up to TVWQZ8S.

Drag-to-zoom worked on the Volume bars and badly on the Events scatter. You diagnosed it: the canvas could not tell a deliberate click from a drag.

### What was wrong

`ScatterCanvas.onPointerDown` called `stopPropagation()` whenever the press landed on a commit dot. That existed to stop a press on a dot from scrubbing — but it also stopped the press from ever reaching the track, so a drag begun on a dot never started a range at all. On a busy scatter that is most of the canvas, which is exactly why the bars felt fine and the scatter did not.

It also left the gesture half-owned. With the press stopped the track never took pointer capture, so the canvas's own `onClick` fired — hit-testing the *release* position and opening whatever commit happened to sit under it rather than the one that was pressed.

### The fix

The press is never stopped. The canvas reports which commit it landed on (`onPressCommit`), and the track — which holds the pointer capture — settles the gesture on release by distance travelled, the same `MIN_RANGE_DRAG_PX` the track already used: under it a click, over it a range. A click that began on a dot opens that commit rather than time travelling, so the press keeps the meaning `stopPropagation` used to give it.

Two things fall out. The commit opened is the one *pressed*, not whatever the release lands on. And the canvas has no `onClick` left at all, which is correct rather than incidental: pointer capture retargets the compatibility mouse events to the capture target, so a click on the canvas was never the canvas's to hear.

### One hypothesis that did not survive

I expected a second, independent fault — that a range drag ending over a dot would zoom *and* open that dot's diff. I wrote the test for it and it passed against the unfixed code, because pointer capture had already retargeted the click away from the canvas. So it was never reachable. The test is kept, re-described as what it actually is: a guard on the pair of facts the design now rests on, since dropping either would open a commit nobody aimed at.

### Tests

`scatter-gesture.pw.ts`, three cases. A dot is painted on a canvas with no node to aim at, so its x is pinned by handing the scrubber a `from`/`to` window centred on the commit — putting the dot at the middle of the track by construction — and its y found by sweeping the canvas height until that commit's own hint opens.

- a drag that begins on a commit dot still zooms — **verified red** without the fix
- a click on a commit dot opens its diff — guards the path this change rewrites
- a drag that ends on a commit dot does not open its diff — the invariant guard described above

Full unit suite (952) and GUI e2e (63) green. Also driven by hand against a throwaway project: three separate drags each begun on a real dot, all three zoom, none opens a diff.

### Not done here

`ScatterDot` in `ScrubberParts.tsx` is exported and never used — dead since the scatter moved to a canvas, and invisible to lint because it is exported. Left alone as unrelated scope; happy to remove it separately.
