### PR TITLE
CRCVVA7 drop the scrubber's "Now" over a window that does not reach the present

### DIFF
--- a/source/gui/client/components/ScrubberParts.tsx
+++ b/source/gui/client/components/ScrubberParts.tsx
@@ -732,7 +732,13 @@ export const ScrubberControls = ({
 		</div>
 
 		{/* Present while live too, as the status of the board rather than a way
-		    back to it, so entering history never resizes the row. */}
+		    back to it, so entering history never resizes the row.
+
+		    "Now" only over a window that runs up to the present, though. It sits
+		    at the end of the row, above the end of the track, so it reads as
+		    naming that end — and over a window paged back or dragged out, that
+		    end is not now. "Resume" is unaffected: it is an action, not a claim
+		    about the far end. The slot holds its width either way. */}
 		<button
 			onClick={onReturnToLive}
 			disabled={!isScrubbing}
@@ -758,7 +764,7 @@ export const ScrubberControls = ({
 				flexShrink: 0,
 			}}
 		>
-			{isScrubbing ? 'Resume' : 'Now'}
+			{isScrubbing ? 'Resume' : atLatest ? 'Now' : ''}
 		</button>
 	</div>
 );

--- a/source/test/e2e-gui/now-label.pw.ts
+++ b/source/test/e2e-gui/now-label.pw.ts
@@ -1,0 +1,49 @@
+import {expect, test} from './fixtures.js';
+
+// The label sits at the end of the controls row, directly above the end of the
+// track, so it reads as naming that end. Over a window that does not run up to
+// the present it would be naming it wrongly.
+test('the "Now" label is absent over a window that does not reach the present', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	const label = page.getByRole('button', {name: 'Now', exact: true});
+	await expect(label).toBeVisible();
+	const slot = await label.boundingBox();
+
+	// Paged back a whole period, so the window now ends where the one before it
+	// began — not at the present.
+	await page.getByRole('button', {name: 'Week', exact: true}).click();
+	await expect(label).toBeVisible();
+	await page.getByTitle('Earlier').click();
+	await expect(label).toHaveCount(0);
+
+	// Forward again, onto a window that does reach the present. The slot comes
+	// back exactly where it was, so losing the word never moved the row.
+	await page.getByTitle('Later').click();
+	await expect(label).toBeVisible();
+	expect(await label.boundingBox()).toEqual(slot);
+
+	// The other way to a past window: drag one out on the chart.
+	const track = page.getByTestId('scrubber-track');
+	const box = await track.boundingBox();
+	if (!box) throw new Error('scrubber track is not on screen');
+
+	const y = box.y + box.height / 2;
+	await page.mouse.move(box.x + box.width * 0.2, y);
+	await page.mouse.down();
+	await page.mouse.move(box.x + box.width * 0.6, y, {steps: 10});
+	await page.mouse.up();
+
+	await expect(page.getByRole('button', {name: 'Zoom'})).toHaveAttribute(
+		'aria-pressed',
+		'true',
+	);
+	await expect(label).toHaveCount(0);
+
+	expect(pageErrors).toEqual([]);
+});


### PR DESCRIPTION
Closes CRCVVA7.

The status label at the end of the scrubber controls read "Now" whenever the board was live. It sits directly above the end of the track, so it reads as naming that end — and over a window that has been paged back with the period arrows, or dragged out as a zoom, that end is not the present. The label was saying otherwise.

It now appears only while `atLatest`, the flag the pager already uses to decide whether there is anywhere later to page to. Two things deliberately unchanged:

- **"Resume" stays**, wherever the board is parked, past window included. It is an action, not a claim about the far end, and it is the only way back to live.
- **The slot keeps its width.** The label empties rather than unmounting, so losing the word never shifts the row — the same reason the button was made present-while-live in the first place.

### Tests

`now-label.pw.ts` walks both routes to a past window, since the bug predates the zoom:

- live over a week that runs up to now → the label is there
- paged back one period → gone. **Verified red** here without the fix: `toHaveCount(0)` got 1.
- paged forward again → back, and its bounding box is identical to before, which is the no-shift guarantee
- a range dragged out on the chart → gone

Full unit suite (944) and GUI e2e (64) green. Also driven by hand against a throwaway project across all four states, including scrubbed-over-a-past-window to confirm "Resume" survives:

```
week, up to now      -> Now: 1 Resume: 0
paged back a week    -> Now: 0 Resume: 0
forward again        -> Now: 1 Resume: 0
scrubbed             -> Now: 0 Resume: 1
scrubbed + past win. -> Now: 0 Resume: 1
```
