### PR TITLE
E9G5S4V Enter confirms a description edit, Shift+Enter writes the newline

### DIFF
--- a/source/gui/client/components/IssueDetails.tsx
+++ b/source/gui/client/components/IssueDetails.tsx
@@ -335,13 +335,22 @@ export const IssueDetails = ({
 										placeholder=""
 										onChange={event => setDescription(event.target.value)}
 										onKeyDown={event => {
-											if (event.key === 'Escape') cancelDescription();
-											if (
-												(event.metaKey || event.ctrlKey) &&
-												event.key === 'Enter'
-											) {
-												saveDescription();
-											}
+											if (event.key === 'Escape') return cancelDescription();
+											if (event.key !== 'Enter') return;
+
+											// Enter confirms, so Shift+Enter is what a paragraph
+											// break costs now. Cmd/Ctrl+Enter still confirms too,
+											// which is what the comment boxes take.
+											if (event.shiftKey) return;
+
+											// An IME is mid-word: Enter is choosing a candidate,
+											// not finishing the description. Committing here would
+											// close the editor on a half-typed character.
+											if (event.nativeEvent.isComposing) return;
+
+											// Or the newline lands in the value on its way out.
+											event.preventDefault();
+											saveDescription();
 										}}
 										style={{
 											font: 'inherit',

--- a/source/test/e2e-gui/description-keys.pw.ts
+++ b/source/test/e2e-gui/description-keys.pw.ts
@@ -1,0 +1,106 @@
+import type {Page} from '@playwright/test';
+import {expect, test} from './fixtures.js';
+
+const openTicket = async (page: Page, appUrl: string) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	await page.getByTitle('Add issue').first().click();
+	await page.getByPlaceholder('issue name').fill(`Keys ${Date.now()}`);
+	await page.getByPlaceholder('issue name').press('Enter');
+	await expect(page).toHaveURL(/\/issue\//);
+};
+
+const startEditing = async (page: Page) => {
+	await page.getByRole('button', {name: 'edit'}).first().click();
+
+	return page.getByRole('textbox').last();
+};
+
+// The editor closing is what says the edit was confirmed rather than typed
+// into: the "edit" button is only rendered while it is shut.
+const editorClosed = (page: Page) =>
+	expect(page.getByRole('button', {name: 'edit'}).first()).toBeVisible();
+
+// Deliberately a reload rather than reopening the editor. A save comes back as
+// a state broadcast, and the effect that reacts to it closes any open editor —
+// so reopening straight after saving is a race the loaded machine loses.
+const survivesAReload = async (page: Page, ...lines: string[]) => {
+	await page.reload();
+	for (const line of lines) {
+		await expect(page.locator('aside')).toContainText(line);
+	}
+};
+
+test('Enter confirms a description edit', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await openTicket(page, appUrl);
+
+	const box = await startEditing(page);
+	await box.fill('one line');
+	await box.press('Enter');
+
+	await editorClosed(page);
+	await survivesAReload(page, 'one line');
+
+	expect(pageErrors).toEqual([]);
+});
+
+// The paragraph break has to go somewhere now that Enter is spent on
+// confirming, and the descriptions on this board are mostly multi-paragraph.
+test('Shift+Enter writes a newline instead of confirming', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await openTicket(page, appUrl);
+
+	const box = await startEditing(page);
+	await box.fill('first');
+	await box.press('Shift+Enter');
+	await box.press('Shift+Enter');
+	await box.pressSequentially('second');
+
+	// Still open, and holding both paragraphs: nothing has been saved yet, so
+	// this reads the editor's own value.
+	await expect(box).toHaveValue('first\n\nsecond');
+
+	await box.press('Enter');
+	await editorClosed(page);
+	await survivesAReload(page, 'first', 'second');
+
+	expect(pageErrors).toEqual([]);
+});
+
+// The key the comment boxes take, kept so the two do not disagree for anyone
+// who already had it in their fingers.
+test('Cmd/Ctrl+Enter still confirms', async ({page, appUrl, pageErrors}) => {
+	await openTicket(page, appUrl);
+
+	const box = await startEditing(page);
+	await box.fill('via the modifier');
+	await box.press('ControlOrMeta+Enter');
+
+	await editorClosed(page);
+	await survivesAReload(page, 'via the modifier');
+
+	expect(pageErrors).toEqual([]);
+});
+
+// Nothing is saved here, so there is no broadcast to race: reopening is safe
+// and is the only way to see that the draft was dropped rather than kept.
+test('Escape still abandons the edit', async ({page, appUrl, pageErrors}) => {
+	await openTicket(page, appUrl);
+
+	const box = await startEditing(page);
+	await box.fill('thrown away');
+	await box.press('Escape');
+	await editorClosed(page);
+
+	await expect(await startEditing(page)).toHaveValue('');
+
+	expect(pageErrors).toEqual([]);
+});


### PR DESCRIPTION
Closes E9G5S4V.

Cmd/Ctrl+Enter already saved a description, and nothing anywhere in the GUI said so. Meanwhile Enter — the key the tag, assignee and title fields all confirm on — quietly wrote a newline. Enter now confirms, and the paragraph break moves to Shift+Enter.

| key | before | after |
|---|---|---|
| Enter | newline | **confirm** |
| Shift+Enter | newline | newline |
| Cmd/Ctrl+Enter | confirm | confirm |
| Escape | cancel | cancel |

Cmd/Ctrl+Enter is deliberately kept, so anyone who already had it in their fingers is not broken.

### Two things worth flagging

**Enter is ignored while an IME is composing** (`event.nativeEvent.isComposing`). Enter picks a candidate mid-word for CJK input; without the guard, making Enter commit would close the editor on a half-typed character. This hazard only appears once Enter becomes the confirm key, so it is new with this change.

**The description now disagrees with the comment boxes below it**, which stay on Cmd/Ctrl+Enter. That was a conscious trade — descriptions are what the ticket names, comments are not. Say the word if you want the comment composer and comment editor moved to match; it is the same handler three more times.

No TUI impact: descriptions there are edited by spawning `$EDITOR` on a temp file (`edit.cmd.ts` → `openEditorOnText`), sharing no keyboard code with the React editors.

### Tests

`description-keys.pw.ts`, four cases. The two that describe the new behaviour are **verified red** without the change; the two that guard the kept behaviour stay green, which is the split you want:

| test | without the fix |
|---|---|
| Enter confirms a description edit | **fails** |
| Shift+Enter writes a newline instead of confirming | **fails** |
| Cmd/Ctrl+Enter still confirms | passes (guard) |
| Escape still abandons the edit | passes (guard) |

One note on how they are written. My first draft verified a save by reopening the editor and reading the textarea back, and it passed 12/12 alone but failed under the pre-push gate. That was not contention: a save comes back as a state broadcast, and the effect at `IssueDetails.tsx:205` closes any open editor when it lands — so reopening straight after saving races it. The specs now verify through a **page reload** instead, which cannot race, and they hold 16/16 under `--repeat-each=4`.

The full pre-push gate is green: lint, typecheck, unit (944), containerised e2e (14) and collab (11), and the GUI browser suite (70).
