### PR TITLE
Highlight the whole row in the manage-and-delete modals

### DIFF
--- a/source/gui/client/components/ManageContributorsModal.tsx
+++ b/source/gui/client/components/ManageContributorsModal.tsx
@@ -1,6 +1,7 @@
 import {useState} from 'react';
 import {GuiContributor} from '../lib/gui-state.model';
 import {GUI_THEME} from '../lib/gui-theme';
+import {manageRowStyle} from '../lib/manage-row.style';
 import {Button} from './Button';
 import {IconLock} from './IconLock';
 import {IconTrash} from './IconTrash';
@@ -19,6 +20,7 @@ export const ManageContributorsModal = ({
 	// Two-step: the first click arms one row, the second commits it. Arming by
 	// id rather than a boolean so moving to another row cancels the first.
 	const [armedId, setArmedId] = useState<string | null>(null);
+	const [hoveredId, setHoveredId] = useState<string | null>(null);
 
 	// Everyone is listed, including those that can't be removed: omitting them
 	// would just look like a missing name.
@@ -84,14 +86,18 @@ export const ManageContributorsModal = ({
 						return (
 							<div
 								key={contributor.id}
-								style={{
-									display: 'flex',
-									alignItems: 'center',
-									justifyContent: 'space-between',
-									gap: 8,
-									padding: '6px 8px',
-									borderRadius: 6,
-								}}
+								data-testid="manage-contributor-row"
+								data-armed={armed ? 'true' : 'false'}
+								onMouseEnter={() => setHoveredId(contributor.id)}
+								onMouseLeave={() =>
+									setHoveredId(current =>
+										current === contributor.id ? null : current,
+									)
+								}
+								style={manageRowStyle({
+									armed,
+									hovered: hoveredId === contributor.id,
+								})}
 							>
 								<span
 									style={{

--- a/source/gui/client/components/ManageTagsModal.tsx
+++ b/source/gui/client/components/ManageTagsModal.tsx
@@ -1,6 +1,7 @@
 import {useState} from 'react';
 import {GuiTag} from '../lib/gui-state.model';
 import {GUI_THEME} from '../lib/gui-theme';
+import {manageRowStyle} from '../lib/manage-row.style';
 import {Button} from './Button';
 import {IconTrash} from './IconTrash';
 
@@ -14,6 +15,7 @@ export const ManageTagsModal = ({tags, onDelete, onClose}: Props) => {
 	// Two-step: the first click arms one row, the second commits it. Arming by
 	// id rather than a boolean so moving to another row cancels the first.
 	const [armedId, setArmedId] = useState<string | null>(null);
+	const [hoveredId, setHoveredId] = useState<string | null>(null);
 
 	const sorted = [...tags].sort((a, b) => a.name.localeCompare(b.name));
 
@@ -72,18 +74,18 @@ export const ManageTagsModal = ({tags, onDelete, onClose}: Props) => {
 				>
 					{sorted.map(tag => {
 						const armed = armedId === tag.id;
+						const hovered = hoveredId === tag.id;
 
 						return (
 							<div
 								key={tag.id}
-								style={{
-									display: 'flex',
-									alignItems: 'center',
-									justifyContent: 'space-between',
-									gap: 8,
-									padding: '6px 8px',
-									borderRadius: 6,
-								}}
+								data-testid="manage-tag-row"
+								data-armed={armed ? 'true' : 'false'}
+								onMouseEnter={() => setHoveredId(tag.id)}
+								onMouseLeave={() =>
+									setHoveredId(current => (current === tag.id ? null : current))
+								}
+								style={manageRowStyle({armed, hovered})}
 							>
 								<span style={{fontSize: 12, color: tag.color}}>{tag.name}</span>
 

--- a/source/gui/client/lib/manage-row.style.ts
+++ b/source/gui/client/lib/manage-row.style.ts
@@ -1,0 +1,37 @@
+import {CSSProperties} from 'react';
+import {GUI_THEME} from './gui-theme';
+
+// Armed rows say "destructive": the confirm button's own red, translucent
+// enough that the name's own colour still reads against it.
+const ARMED_BACKGROUND = 'rgba(255, 135, 135, 0.14)';
+
+/**
+ * One row of a manage-and-delete modal. The tag and contributor modals are the
+ * same row twice, so the styling lives here rather than in both — a highlight
+ * added to one and not the other is exactly how they would drift apart.
+ *
+ * Hover takes `GUI_THEME.line`, the fill Dropdown and KebabMenu already use for
+ * the row under the pointer; armed has to outrank it, since the confirm button
+ * sits at the far end of the row from the name it would delete.
+ */
+export const manageRowStyle = ({
+	armed,
+	hovered,
+}: {
+	armed: boolean;
+	hovered: boolean;
+}): CSSProperties => ({
+	display: 'flex',
+	alignItems: 'center',
+	justifyContent: 'space-between',
+	gap: 8,
+	padding: '6px 8px',
+	borderRadius: 6,
+	background: armed
+		? ARMED_BACKGROUND
+		: hovered
+		? GUI_THEME.line
+		: 'transparent',
+	// An inset ring rather than a border, so arming a row does not reflow it.
+	boxShadow: armed ? `inset 0 0 0 1px ${GUI_THEME.red}` : undefined,
+});

--- a/source/test/e2e-gui/manage-tags.pw.ts
+++ b/source/test/e2e-gui/manage-tags.pw.ts
@@ -1,0 +1,66 @@
+import type {Page} from '@playwright/test';
+import {expect, test} from './fixtures.js';
+
+// Adding a tag closes the add row again, so each one starts by reopening it.
+const addTag = async (page: Page, name: string) => {
+	await page
+		.locator('aside section')
+		.filter({has: page.getByText('Tags', {exact: true})})
+		.getByRole('button', {name: '+', exact: true})
+		.click();
+	await page.getByPlaceholder('tag name').fill(name);
+	await page.getByPlaceholder('tag name').press('Enter');
+	await expect(page.locator('aside')).toContainText(name);
+};
+
+// Arming a delete used to show up only on the confirm button, at the far end of
+// a 460px row from the name it belongs to — so the modal never said which tag
+// was about to go. The row itself carries the state now.
+test('arming a delete highlights the whole tag row', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	const stamp = Date.now();
+	const first = `atag${stamp}`;
+	const second = `btag${stamp}`;
+
+	await page.getByTitle('Add issue').first().click();
+	await page.getByPlaceholder('issue name').fill(`Tags ${stamp}`);
+	await page.getByPlaceholder('issue name').press('Enter');
+	await expect(page.locator('aside')).toContainText(`Tags ${stamp}`);
+
+	await addTag(page, first);
+	await addTag(page, second);
+
+	// Reopen the add row once more: that is where the manage entry point lives.
+	await page
+		.locator('aside section')
+		.filter({has: page.getByText('Tags', {exact: true})})
+		.getByRole('button', {name: '+', exact: true})
+		.click();
+	await page.getByRole('button', {name: 'manage tags…'}).click();
+
+	const armed = page.locator(
+		'[data-testid="manage-tag-row"][data-armed="true"]',
+	);
+	await expect(armed).toHaveCount(0);
+
+	await page.getByTitle(`Delete "${first}"`).click();
+
+	// Exactly one row is armed, it names the tag that was clicked, and it is
+	// painted rather than left to the button at the other end of the row.
+	await expect(armed).toHaveCount(1);
+	await expect(armed).toContainText(first);
+	await expect(armed).not.toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
+
+	// Arming another row moves the highlight rather than lighting a second.
+	await page.getByTitle(`Delete "${second}"`).click();
+	await expect(armed).toHaveCount(1);
+	await expect(armed).toContainText(second);
+
+	expect(pageErrors).toEqual([]);
+});


### PR DESCRIPTION
Closes DFJ6Z2Q.

Deleting a tag is two-step: the first click arms a row, the second confirms. But arming only recoloured the trash button at the far end of a 460px row, so nothing lit up beside the name it would delete — the modal never said which tag was about to go.

The row carries the state now: an armed row gets a translucent red fill and an inset red ring spanning name to button, and any row under the pointer gets `GUI_THEME.line`, the same fill `Dropdown` and `KebabMenu` already use. The ring is inset rather than a border so arming a row does not reflow the list.

**Beyond the ticket, deliberately:** `ManageContributorsModal` is a near-verbatim clone of this row — same container, same two-step arming, same trash button. Highlighting only the tag rows would have left the two visibly diverged, so the row styling moved into a shared `manageRowStyle` helper and both modals use it.

Test: `manage-tags.pw.ts` asserts exactly one row is armed, that it names the tag that was clicked, that it is actually painted, and that arming another row moves the highlight rather than lighting a second. Verified red without the change. This modal had no test coverage at all before.

Full pre-push gate green.