### PR TITLE
Collapsible lanes, and one shared comment card

### DIFF
--- a/source/gui/client/components/IssueComments.tsx
+++ b/source/gui/client/components/IssueComments.tsx
@@ -6,6 +6,7 @@ import {IconComment} from './IconComment';
 import {ActionRow, Empty, Textarea} from './FormPrimitives';
 import {GuiComment, GuiUser} from '../lib/gui-state.model';
 import {timeAgo} from '../lib/gui-format.helper';
+import {COMMENT_CARD_STYLE} from '../lib/comment-card.style';
 import {
 	DiffLocation,
 	diffLocationFromMeta,
@@ -145,19 +146,8 @@ export const IssueComments = ({
 				<Empty>No comments</Empty>
 			) : (
 				<div style={{display: 'flex', flexDirection: 'column', gap: 12}}>
-					{/* Same card as the annotation a comment gets inside a diff
-					    (DiffCommentAnnotation), so the two read as one thing. */}
 					{ordered.map(comment => (
-						<div
-							key={comment.id}
-							style={{
-								border: `1px solid ${GUI_THEME.line}`,
-								borderLeft: `2px solid ${GUI_THEME.accent}`,
-								borderRadius: 6,
-								padding: '8px 10px',
-								background: GUI_THEME.tertiary,
-							}}
-						>
+						<div key={comment.id} style={COMMENT_CARD_STYLE}>
 							{/* Only the header carries the icon; the body runs the card's
 							    full width underneath. */}
 							<div

--- a/source/gui/client/components/IssueCommits.tsx
+++ b/source/gui/client/components/IssueCommits.tsx
@@ -10,6 +10,7 @@ import {
 	GuiRefCommitEntry,
 } from '../lib/gui-state.model';
 import {CONTENT_FONT, GUI_THEME, TEXT} from '../lib/gui-theme';
+import {COMMENT_CARD_STYLE} from '../lib/comment-card.style';
 import {
 	DiffCommentMeta,
 	encodeDiffCommentMarker,
@@ -434,12 +435,8 @@ const DiffCommentAnnotation = ({
 			onMouseEnter={() => onHover(true)}
 			onMouseLeave={() => onHover(false)}
 			style={{
+				...COMMENT_CARD_STYLE,
 				margin: '4px 0',
-				padding: '8px 10px',
-				border: `1px solid ${GUI_THEME.line}`,
-				borderLeft: `2px solid ${GUI_THEME.accent}`,
-				borderRadius: 6,
-				background: GUI_THEME.tertiary,
 				fontSize: TEXT.ui,
 			}}
 		>

--- a/source/gui/client/components/IssueDetails.tsx
+++ b/source/gui/client/components/IssueDetails.tsx
@@ -45,6 +45,7 @@ import {Section} from './Section';
 import {Tabs, TabItem} from './Tabs';
 import {IssueHistory} from './IssueHistory';
 import {formatAbsolute, timeAgo} from '../lib/gui-format.helper';
+import {usePersistedFlag} from '../lib/scrubber';
 
 type IssueDetailsTab = 'overview' | 'comments' | 'history' | 'code';
 
@@ -55,40 +56,133 @@ export const LANE_VIEW_WIDTH = 1400;
 const LANE_GAP = 20;
 const LANE_COUNT = 4;
 // Commits holds diffs, so it takes half the row; the other three share the rest.
-const LANE_COLUMNS =
-	'minmax(0, 1fr) minmax(0, 1fr) minmax(0, 3fr) minmax(0, 1fr)';
-const COMMITS_LANE_SHARE = 3 / 6;
+const LANE_SHARES = {
+	overview: 1,
+	comments: 1,
+	commits: 3,
+	log: 1,
+} as const;
+type LaneKey = keyof typeof LANE_SHARES;
+const LANE_KEYS = Object.keys(LANE_SHARES) as LaneKey[];
 
+// Wide enough for the upright label and a comfortable click target.
+const COLLAPSED_LANE_WIDTH = 28;
+
+const LANE_LABEL_STYLE = {
+	color: GUI_THEME.secondary,
+	fontSize: TEXT.label,
+	textTransform: 'uppercase',
+	letterSpacing: '0.08em',
+} as const;
+
+/**
+ * One column of the lanes view, collapsible to a rail so the lanes that stay
+ * open — the diff, usually — get the width back.
+ *
+ * The toggles are labelled "Collapse …"/"Expand …" rather than by the lane
+ * name: `fullscreen-lanes.pw.ts` proves the tabs are gone in this view by
+ * counting buttons named after a lane, and a header button named "Comments"
+ * would read as a tab to it.
+ */
 const Lane = ({
 	title,
 	count,
+	collapsed,
+	canCollapse,
+	onToggle,
 	children,
 }: {
 	title: string;
 	count?: number;
+	collapsed: boolean;
+	canCollapse: boolean;
+	onToggle: () => void;
 	children: React.ReactNode;
-}) => (
-	<div
-		data-testid={`lane-${title.toLowerCase()}`}
-		style={{display: 'flex', flexDirection: 'column', minHeight: 0}}
-	>
+}) => {
+	const label = `${title}${typeof count === 'number' ? ` (${count})` : ''}`;
+	const testId = `lane-${title.toLowerCase()}`;
+	const headerStyle = {
+		...LANE_LABEL_STYLE,
+		textAlign: 'left',
+		padding: 0,
+		paddingBottom: 10,
+		marginBottom: 14,
+		// Longhand throughout: mixing `border` with `borderBottom` makes React
+		// warn about shorthand/longhand conflicts on every rerender.
+		borderTop: 'none',
+		borderLeft: 'none',
+		borderRight: 'none',
+		borderBottom: `1px solid ${GUI_THEME.line}`,
+		background: 'transparent',
+		fontFamily: 'inherit',
+	} as const;
+
+	if (collapsed) {
+		return (
+			<div
+				data-testid={testId}
+				data-collapsed="true"
+				style={{display: 'flex', minHeight: 0}}
+			>
+				<button
+					type="button"
+					aria-label={`Expand ${title}`}
+					title={`Expand ${title}`}
+					onClick={onToggle}
+					style={{
+						...LANE_LABEL_STYLE,
+						flex: 1,
+						display: 'flex',
+						justifyContent: 'center',
+						alignItems: 'flex-start',
+						paddingTop: 2,
+						background: 'transparent',
+						borderTop: 'none',
+						borderLeft: 'none',
+						borderBottom: 'none',
+						borderRight: `1px solid ${GUI_THEME.line}`,
+						fontFamily: 'inherit',
+						cursor: 'pointer',
+					}}
+				>
+					{/* Bottom-to-top, so the label reads upward from the panel floor
+					    rather than upside down. */}
+					<span
+						style={{writingMode: 'vertical-rl', transform: 'rotate(180deg)'}}
+					>
+						{label}
+					</span>
+				</button>
+			</div>
+		);
+	}
+
+	return (
 		<div
-			style={{
-				color: GUI_THEME.secondary,
-				fontSize: TEXT.label,
-				textTransform: 'uppercase',
-				letterSpacing: '0.08em',
-				paddingBottom: 10,
-				marginBottom: 14,
-				borderBottom: `1px solid ${GUI_THEME.line}`,
-			}}
+			data-testid={testId}
+			data-collapsed="false"
+			style={{display: 'flex', flexDirection: 'column', minHeight: 0}}
 		>
-			{title}
-			{typeof count === 'number' && ` (${count})`}
+			{canCollapse ? (
+				<button
+					type="button"
+					aria-label={`Collapse ${title}`}
+					title={`Collapse ${title}`}
+					onClick={onToggle}
+					style={{...headerStyle, cursor: 'pointer'}}
+				>
+					{label}
+				</button>
+			) : (
+				// The last open lane has nowhere to collapse to. A plain heading
+				// rather than a dead button: nothing to activate, and no control
+				// named after a lane for the tab count in fullscreen-lanes to find.
+				<div style={headerStyle}>{label}</div>
+			)}
+			<div style={{flex: 1, minHeight: 0, overflowY: 'auto'}}>{children}</div>
 		</div>
-		<div style={{flex: 1, minHeight: 0, overflowY: 'auto'}}>{children}</div>
-	</div>
-);
+	);
+};
 
 export const IssueDetails = ({
 	whoAmI,
@@ -188,6 +282,38 @@ export const IssueDetails = ({
 	// vs. unified diffs — initialized from the same persisted value Aside
 	// itself reads, so the first render already picks the right layout.
 	const [panelWidth, setPanelWidth] = useState(readStoredAsideWidth);
+	// Read synchronously rather than in an effect: entering fullscreen has to
+	// lay the lanes out in the same commit, which aside-stacking.pw.ts proves.
+	const [overviewCollapsed, setOverviewCollapsed] = usePersistedFlag(
+		'epiq.lane.overview.collapsed',
+		false,
+	);
+	const [commentsCollapsed, setCommentsCollapsed] = usePersistedFlag(
+		'epiq.lane.comments.collapsed',
+		false,
+	);
+	const [commitsCollapsed, setCommitsCollapsed] = usePersistedFlag(
+		'epiq.lane.commits.collapsed',
+		false,
+	);
+	const [logCollapsed, setLogCollapsed] = usePersistedFlag(
+		'epiq.lane.log.collapsed',
+		false,
+	);
+	const laneCollapsed: Record<LaneKey, boolean> = {
+		overview: overviewCollapsed,
+		comments: commentsCollapsed,
+		commits: commitsCollapsed,
+		log: logCollapsed,
+	};
+	const setLaneCollapsed: Record<LaneKey, (next: boolean) => void> = {
+		overview: setOverviewCollapsed,
+		comments: setCommentsCollapsed,
+		commits: setCommitsCollapsed,
+		log: setLogCollapsed,
+	};
+	// Collapsing the last one would leave four rails and nothing to read.
+	const openLaneCount = LANE_KEYS.filter(key => !laneCollapsed[key]).length;
 	const panelRef = useRef<HTMLElement | null>(null);
 	const titleTextareaRef = useRef<HTMLTextAreaElement | null>(null);
 
@@ -305,9 +431,35 @@ export const IssueDetails = ({
 		<Aside ref={panelRef} onWidthChange={setPanelWidth}>
 			{({isFullscreen, toggleFullscreen}) => {
 				const laneView = isFullscreen && panelWidth >= LANE_VIEW_WIDTH;
+
+				// A collapsed lane costs a fixed rail; the rest of the width is split
+				// between the lanes still open, so the diff actually receives what
+				// collapsing its neighbours gave up.
+				const openShares = LANE_KEYS.filter(key => !laneCollapsed[key]).reduce(
+					(total, key) => total + LANE_SHARES[key],
+					0,
+				);
+				const railTotal =
+					LANE_KEYS.filter(key => laneCollapsed[key]).length *
+					COLLAPSED_LANE_WIDTH;
+				const laneRoom =
+					panelWidth -
+					ASIDE_PADDING * 2 -
+					LANE_GAP * (LANE_COUNT - 1) -
+					railTotal;
+
+				const laneColumns = LANE_KEYS.map(key =>
+					laneCollapsed[key]
+						? `${COLLAPSED_LANE_WIDTH}px`
+						: `minmax(0, ${LANE_SHARES[key]}fr)`,
+				).join(' ');
+
+				// Drives the diff's split/unified choice, so it has to track the
+				// width the Commits lane actually ends up with.
 				const commitsWidth = laneView
-					? (panelWidth - ASIDE_PADDING * 2 - LANE_GAP * (LANE_COUNT - 1)) *
-					  COMMITS_LANE_SHARE
+					? laneCollapsed.commits || openShares === 0
+						? 0
+						: laneRoom * (LANE_SHARES.commits / openShares)
 					: panelWidth;
 
 				const overviewPane = issue && (
@@ -773,22 +925,33 @@ export const IssueDetails = ({
 									<div
 										style={{
 											display: 'grid',
-											gridTemplateColumns: LANE_COLUMNS,
+											gridTemplateColumns: laneColumns,
 											gap: LANE_GAP,
 											flex: 1,
 											minHeight: 0,
 										}}
 									>
-										<Lane title="Overview">{overviewPane}</Lane>
-										<Lane title="Comments" count={comments.length}>
-											{commentsPane}
-										</Lane>
-										<Lane title="Commits" count={commitsCount}>
-											{commitsPane}
-										</Lane>
-										<Lane title="Log" count={history.length}>
-											{historyPane}
-										</Lane>
+										{(
+											[
+												['overview', 'Overview', undefined, overviewPane],
+												['comments', 'Comments', comments.length, commentsPane],
+												['commits', 'Commits', commitsCount, commitsPane],
+												['log', 'Log', history.length, historyPane],
+											] as const
+										).map(([key, title, count, pane]) => (
+											<Lane
+												key={key}
+												title={title}
+												count={count}
+												collapsed={laneCollapsed[key]}
+												canCollapse={laneCollapsed[key] || openLaneCount > 1}
+												onToggle={() =>
+													setLaneCollapsed[key](!laneCollapsed[key])
+												}
+											>
+												{pane}
+											</Lane>
+										))}
 									</div>
 								) : (
 									<>

--- a/source/gui/client/lib/comment-card.style.ts
+++ b/source/gui/client/lib/comment-card.style.ts
@@ -1,0 +1,20 @@
+import {CSSProperties} from 'react';
+import {GUI_THEME} from './gui-theme';
+
+/**
+ * A comment card, wherever it appears: the Comments lane and the annotation a
+ * comment gets inside a diff. The two are meant to read as one thing, so the
+ * card lives here rather than being spelled out in both — the accent left edge
+ * is what marks it as somebody's writing rather than the app's own chrome.
+ *
+ * The horizontal padding is the wider half of the pair: in the lanes view the
+ * comments column is the narrowest one, and text set hard against the border
+ * was the first thing to look cramped.
+ */
+export const COMMENT_CARD_STYLE: CSSProperties = {
+	border: `1px solid ${GUI_THEME.line}`,
+	borderLeft: `2px solid ${GUI_THEME.accent}`,
+	borderRadius: 6,
+	padding: '10px 14px',
+	background: GUI_THEME.tertiary,
+};

--- a/source/test/e2e-gui/lane-collapse.pw.ts
+++ b/source/test/e2e-gui/lane-collapse.pw.ts
@@ -1,0 +1,109 @@
+import type {Page} from '@playwright/test';
+import {expect, test} from './fixtures.js';
+
+// The lanes only appear on a panel at least LANE_VIEW_WIDTH wide.
+test.use({viewport: {width: 1600, height: 900}});
+
+const openLanes = async (page: Page, appUrl: string) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	await page.getByTitle('Add issue').first().click();
+	await page.getByPlaceholder('issue name').fill(`Lanes ${Date.now()}`);
+	await page.getByPlaceholder('issue name').press('Enter');
+
+	await page.getByRole('button', {name: 'Fullscreen'}).click();
+	await expect(page.getByTestId('lane-commits')).toBeVisible();
+};
+
+const laneWidth = async (page: Page, name: string): Promise<number> =>
+	(await page.getByTestId(`lane-${name}`).boundingBox())?.width ?? 0;
+
+// Four even-ish lanes leave the diff a quarter of the panel. Collapsing the
+// ones you are not reading is what hands that width to the commits lane.
+test('collapsing a lane gives its width to the ones still open', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await openLanes(page, appUrl);
+
+	const before = await laneWidth(page, 'commits');
+	await expect(page.getByTestId('lane-overview')).toHaveAttribute(
+		'data-collapsed',
+		'false',
+	);
+
+	await page.getByRole('button', {name: 'Collapse Overview'}).click();
+	await expect(page.getByTestId('lane-overview')).toHaveAttribute(
+		'data-collapsed',
+		'true',
+	);
+
+	await expect
+		.poll(async () => (await laneWidth(page, 'commits')) > before)
+		.toBe(true);
+
+	// The rail is still the lane, and it says how to get back.
+	await page.getByRole('button', {name: 'Expand Overview'}).click();
+	await expect(page.getByTestId('lane-overview')).toHaveAttribute(
+		'data-collapsed',
+		'false',
+	);
+
+	expect(pageErrors).toEqual([]);
+});
+
+test('a collapsed lane stays collapsed across a reload', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await openLanes(page, appUrl);
+
+	await page.getByRole('button', {name: 'Collapse Comments'}).click();
+	await expect(page.getByTestId('lane-comments')).toHaveAttribute(
+		'data-collapsed',
+		'true',
+	);
+
+	await page.reload();
+	await page.getByRole('button', {name: 'Fullscreen'}).click();
+
+	await expect(page.getByTestId('lane-comments')).toHaveAttribute(
+		'data-collapsed',
+		'true',
+	);
+
+	expect(pageErrors).toEqual([]);
+});
+
+// Collapsing the last one would leave four rails and nothing to read, so the
+// final open lane stops offering the control at all.
+test('the last open lane cannot be collapsed', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await openLanes(page, appUrl);
+
+	for (const name of ['Overview', 'Comments', 'Log']) {
+		await page.getByRole('button', {name: `Collapse ${name}`}).click();
+	}
+
+	await expect(page.getByTestId('lane-commits')).toHaveAttribute(
+		'data-collapsed',
+		'false',
+	);
+	await expect(
+		page.getByRole('button', {name: 'Collapse Commits'}),
+	).toHaveCount(0);
+
+	// Reopening any other lane hands the control back.
+	await page.getByRole('button', {name: 'Expand Log'}).click();
+	await expect(
+		page.getByRole('button', {name: 'Collapse Commits'}),
+	).toHaveCount(1);
+
+	expect(pageErrors).toEqual([]);
+});


### PR DESCRIPTION
Closes RVZSAKH and V2VP6R5.

**RVZSAKH — collapse a lane to a rail.** The four lanes split the panel 1:1:3:1, so a diff got a quarter of it and wrapped badly. Clicking a lane header now collapses it to a thin rail labelled bottom-to-top; clicking the rail restores it. The width goes to whatever is still open, so collapsing Overview and Comments gives the diff most of the panel.

- State persists in localStorage (`epiq.lane.*.collapsed`) through the existing `usePersistedFlag`, so lanes stay as you left them.
- Read synchronously, not in an effect: `aside-stacking.pw.ts` proves the lanes must lay out in the same commit as the fullscreen toggle.
- `commitsWidth` now derives from the width the Commits lane actually receives, so collapsing its neighbours can flip the diff to split view.
- The last open lane renders as a plain heading rather than a disabled button — nothing to activate, and no control named after a lane for `fullscreen-lanes.pw.ts`'s tab count to trip over.

Chosen over a one-click "focus this lane": one affordance per lane, and every in-between state is reachable.

**V2VP6R5 — one comment card.** The card was spelled out twice, identically, in `IssueComments` and in `DiffCommentAnnotation` — the exact per-component drift the ticket is about. It now lives in one `COMMENT_CARD_STYLE`, with horizontal padding raised from 10px to 14px: the comments lane is the narrowest column, and it was where text set hard against the border showed first.

Tests: `lane-collapse.pw.ts` covers the width handover, persistence across a reload, and the last-lane guard. The existing lanes, comments and diff-composer suites still pass.

Full pre-push gate green.