### PR TITLE
7YCCZB7 put an image into a comment or a description: a button, a drop, a paste

### DIFF
--- a/source/gui/api/api-server.ts
+++ b/source/gui/api/api-server.ts
@@ -321,11 +321,14 @@ export const startGuiServer = async (input: {
 						});
 					}
 
-					return sendJson(
-						res,
-						200,
-						await getGuiState({repoRoot: project.repoRoot}),
-					);
+					// The state, plus the attachment just made. Its markdown is
+					// built here anyway, and the client needs it to leave a
+					// reference at the cursor — finding it again on the client would
+					// mean picking the new one out of the whole state.
+					return sendJson(res, 200, {
+						...(await getGuiState({repoRoot: project.repoRoot})),
+						attachment: result.value,
+					});
 				});
 			} catch (error) {
 				return sendJson(res, 400, {

--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -1379,7 +1379,15 @@ export const App = () => {
 		});
 	};
 
-	const uploadIssueAttachments = async (issueId: string, files: File[]) => {
+	// Returns one markdown reference per file that made it, so a composer can
+	// leave them at the cursor. A rejected file contributes nothing and the
+	// error is reported through attachmentUploadStatus as before.
+	const uploadIssueAttachments = async (
+		issueId: string,
+		files: File[],
+	): Promise<string[]> => {
+		const inserted: string[] = [];
+
 		for (const file of files) {
 			setAttachmentUploadStatus({state: 'uploading', name: file.name});
 
@@ -1387,7 +1395,7 @@ export const App = () => {
 
 			if ('error' in compressed) {
 				setAttachmentUploadStatus({state: 'error', message: compressed.error});
-				return;
+				return inserted;
 			}
 
 			try {
@@ -1410,21 +1418,27 @@ export const App = () => {
 						state: 'error',
 						message: payload?.message ?? 'Upload failed',
 					});
-					return;
+					return inserted;
 				}
 
 				const nextState = getResultValue<GuiState>(payload);
 				if (nextState) setState(nextState);
+
+				const markdown = (payload as {attachment?: {markdown?: string}})
+					?.attachment?.markdown;
+				if (markdown) inserted.push(markdown);
 			} catch (error) {
 				setAttachmentUploadStatus({
 					state: 'error',
 					message: error instanceof Error ? error.message : 'Upload failed',
 				});
-				return;
+				return inserted;
 			}
 		}
 
 		setAttachmentUploadStatus({state: 'idle'});
+
+		return inserted;
 	};
 
 	const deleteIssueAttachment = async (

--- a/source/gui/client/components/AddImageButton.tsx
+++ b/source/gui/client/components/AddImageButton.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import {Button} from './Button';
+import {IconImage} from './IconImage';
+import {IMAGE_FILE_ACCEPT} from '../lib/image-insert';
+
+/**
+ * The picker, as an icon and the hidden input it opens. Three surfaces take
+ * images — a description, a comment, and the attachments list — and all three
+ * want the same control, so it lives here rather than three times over.
+ *
+ * The label is a title and an aria-label rather than text: the button sits in
+ * rows next to `save` and `cancel`, where a third word competes with the two
+ * that decide something.
+ */
+export const AddImageButton = ({
+	testId,
+	busy = false,
+	onPick,
+	inputRef,
+	onInputChange,
+}: {
+	testId: string;
+	busy?: boolean;
+	onPick: () => void;
+	inputRef: React.RefObject<HTMLInputElement | null>;
+	onInputChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+}) => (
+	<>
+		<Button
+			variant="ghost"
+			disabled={busy}
+			title={busy ? 'Adding the image…' : 'Add an image'}
+			aria-label="Add an image"
+			onClick={onPick}
+			style={{
+				display: 'inline-flex',
+				alignItems: 'center',
+				// Squared off, so the icon sits centred rather than in a word-shaped
+				// box, and dimmed while the upload is in flight.
+				padding: '4px 6px',
+				opacity: busy ? 0.5 : 1,
+			}}
+		>
+			<IconImage size={14} />
+		</Button>
+
+		<input
+			data-testid={testId}
+			ref={inputRef}
+			type="file"
+			accept={IMAGE_FILE_ACCEPT}
+			multiple
+			hidden
+			onChange={onInputChange}
+		/>
+	</>
+);

--- a/source/gui/client/components/FormPrimitives.tsx
+++ b/source/gui/client/components/FormPrimitives.tsx
@@ -19,10 +19,14 @@ export const Input = (props: React.InputHTMLAttributes<HTMLInputElement>) => (
 	/>
 );
 
-export const Textarea = (
-	props: React.TextareaHTMLAttributes<HTMLTextAreaElement>,
-) => (
+// Forwards its ref: inserting an image at the cursor has to read
+// selectionStart off the element, which only the owner of the ref can do.
+export const Textarea = React.forwardRef<
+	HTMLTextAreaElement,
+	React.TextareaHTMLAttributes<HTMLTextAreaElement>
+>((props, ref) => (
 	<textarea
+		ref={ref}
 		maxLength={props.maxLength ?? 1500}
 		{...props}
 		style={{
@@ -41,7 +45,9 @@ export const Textarea = (
 			...props.style,
 		}}
 	/>
-);
+));
+
+Textarea.displayName = 'Textarea';
 
 export const ActionRow = ({children}: {children: React.ReactNode}) => (
 	<div

--- a/source/gui/client/components/IconImage.tsx
+++ b/source/gui/client/components/IconImage.tsx
@@ -1,0 +1,21 @@
+// A framed picture: a hill and a sun inside a border. Stroked rather than
+// filled, like IconBars and IconChevron, so it sits at the same weight as the
+// other controls in a row.
+export const IconImage = ({size = 16}: {size?: number}) => (
+	<svg
+		width={size}
+		height={size}
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		strokeWidth="1.8"
+		strokeLinecap="round"
+		strokeLinejoin="round"
+		aria-hidden="true"
+	>
+		<rect x="3" y="4.5" width="18" height="15" rx="2.5" />
+		<circle cx="8.5" cy="10" r="1.6" />
+		<path d="M4 16.5l4.5-4a1.6 1.6 0 0 1 2.2 0l4 3.6" />
+		<path d="M14.5 13.5l1.8-1.6a1.6 1.6 0 0 1 2.2 0L20.5 13" />
+	</svg>
+);

--- a/source/gui/client/components/IssueAttachments.tsx
+++ b/source/gui/client/components/IssueAttachments.tsx
@@ -1,16 +1,57 @@
 import React, {useEffect, useRef, useState} from 'react';
 import {GUI_THEME, TEXT} from '../lib/gui-theme';
 import {GuiAttachment} from '../lib/gui-state.model';
-import {Button} from './Button';
 import {Empty} from './FormPrimitives';
 import {Section} from './Section';
 import {getAttachmentUrl} from '../../../lib/media/attachment-url.js';
-import {IMAGE_FILE_ACCEPT, imageFilesFrom} from '../lib/image-insert';
+import {imageFilesFrom} from '../lib/image-insert';
+import {AddImageButton} from './AddImageButton';
 
 export type AttachmentUploadStatus =
 	| {state: 'idle'}
 	| {state: 'uploading'; name: string}
 	| {state: 'error'; message: string};
+
+// It sits on top of whatever was uploaded, so it cannot borrow contrast from
+// what is behind it. The dark fill carries it over a pale photo, the light ring
+// carries it over a dark one, and the shadow lifts it off a busy one — a 16px
+// dim × in the corner disappeared into all three.
+const DeleteAttachmentButton = ({onDelete}: {onDelete: () => void}) => {
+	const [hovered, setHovered] = useState(false);
+
+	return (
+		<button
+			type="button"
+			title="Delete attachment"
+			aria-label="Delete attachment"
+			onMouseEnter={() => setHovered(true)}
+			onMouseLeave={() => setHovered(false)}
+			onClick={onDelete}
+			style={{
+				position: 'absolute',
+				top: 3,
+				right: 3,
+				width: 18,
+				height: 18,
+				lineHeight: '16px',
+				padding: 0,
+				border: `1px solid ${
+					hovered ? GUI_THEME.red : 'rgba(255, 255, 255, 0.5)'
+				}`,
+				borderRadius: 4,
+				background: hovered ? GUI_THEME.red : 'rgba(4, 5, 8, 0.85)',
+				// Full strength rather than the dim secondary: this is the one mark
+				// that has to survive whatever it is sitting on.
+				color: '#fff',
+				fontSize: TEXT.label,
+				boxShadow: '0 1px 4px rgba(0, 0, 0, 0.65)',
+				cursor: 'pointer',
+			}}
+		>
+			×
+		</button>
+	);
+};
 
 export const IssueAttachments = ({
 	issueId,
@@ -71,27 +112,17 @@ export const IssueAttachments = ({
 			}`}
 			action={
 				canUpload && (
-					<>
-						<Button
-							variant="ghost"
-							onClick={() => fileInputRef.current?.click()}
-						>
-							add image
-						</Button>
-						<input
-							data-testid="attachment-image-input"
-							ref={fileInputRef}
-							type="file"
-							accept={IMAGE_FILE_ACCEPT}
-							multiple
-							hidden
-							onChange={event => {
-								upload(imageFilesFrom(event.target.files));
-								// Or re-picking the same file fires no change event.
-								event.target.value = '';
-							}}
-						/>
-					</>
+					<AddImageButton
+						testId="attachment-image-input"
+						busy={uploadStatus.state === 'uploading'}
+						onPick={() => fileInputRef.current?.click()}
+						inputRef={fileInputRef}
+						onInputChange={event => {
+							upload(imageFilesFrom(event.target.files));
+							// Or re-picking the same file fires no change event.
+							event.target.value = '';
+						}}
+					/>
 				)
 			}
 		>
@@ -187,28 +218,9 @@ export const IssueAttachments = ({
 								</button>
 
 								{attachment.canDelete && !readonly && onDeleteAttachment && (
-									<button
-										type="button"
-										title="Delete attachment"
-										onClick={() => onDeleteAttachment(issueId, attachment.id)}
-										style={{
-											position: 'absolute',
-											top: 2,
-											right: 2,
-											width: 16,
-											height: 16,
-											lineHeight: '14px',
-											padding: 0,
-											border: `1px solid ${GUI_THEME.line}`,
-											borderRadius: 3,
-											background: 'rgba(4, 5, 8, 0.75)',
-											color: GUI_THEME.secondary,
-											fontSize: TEXT.label,
-											cursor: 'pointer',
-										}}
-									>
-										×
-									</button>
+									<DeleteAttachmentButton
+										onDelete={() => onDeleteAttachment(issueId, attachment.id)}
+									/>
 								)}
 							</div>
 						))}

--- a/source/gui/client/components/IssueAttachments.tsx
+++ b/source/gui/client/components/IssueAttachments.tsx
@@ -1,8 +1,11 @@
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import {GUI_THEME, TEXT} from '../lib/gui-theme';
 import {GuiAttachment} from '../lib/gui-state.model';
+import {Button} from './Button';
 import {Empty} from './FormPrimitives';
 import {Section} from './Section';
+import {getAttachmentUrl} from '../../../lib/media/attachment-url.js';
+import {IMAGE_FILE_ACCEPT, imageFilesFrom} from '../lib/image-insert';
 
 export type AttachmentUploadStatus =
 	| {state: 'idle'}
@@ -27,6 +30,7 @@ export const IssueAttachments = ({
 	const [dragging, setDragging] = useState(false);
 	const [lightbox, setLightbox] = useState<GuiAttachment | null>(null);
 	const [broken, setBroken] = useState<Record<string, boolean>>({});
+	const fileInputRef = useRef<HTMLInputElement | null>(null);
 
 	useEffect(() => {
 		setLightbox(null);
@@ -47,17 +51,17 @@ export const IssueAttachments = ({
 
 	const canUpload = !readonly && Boolean(onUploadFiles);
 
+	const upload = (files: File[]) => {
+		if (files.length > 0) onUploadFiles?.(issueId, files);
+	};
+
 	const handleDrop = (event: React.DragEvent) => {
 		event.preventDefault();
 		setDragging(false);
 
 		if (!canUpload) return;
 
-		const files = Array.from(event.dataTransfer.files).filter(file =>
-			file.type.startsWith('image/'),
-		);
-
-		if (files.length > 0) onUploadFiles?.(issueId, files);
+		upload(imageFilesFrom(event.dataTransfer.files));
 	};
 
 	return (
@@ -65,6 +69,31 @@ export const IssueAttachments = ({
 			title={`Attachments${
 				attachments.length ? ` (${attachments.length})` : ''
 			}`}
+			action={
+				canUpload && (
+					<>
+						<Button
+							variant="ghost"
+							onClick={() => fileInputRef.current?.click()}
+						>
+							add image
+						</Button>
+						<input
+							data-testid="attachment-image-input"
+							ref={fileInputRef}
+							type="file"
+							accept={IMAGE_FILE_ACCEPT}
+							multiple
+							hidden
+							onChange={event => {
+								upload(imageFilesFrom(event.target.files));
+								// Or re-picking the same file fires no change event.
+								event.target.value = '';
+							}}
+						/>
+					</>
+				)
+			}
 		>
 			<div
 				onDragOver={event => {
@@ -141,7 +170,7 @@ export const IssueAttachments = ({
 										</span>
 									) : (
 										<img
-											src={`/media/${attachment.fileName}`}
+											src={getAttachmentUrl(attachment.fileName)}
 											alt={attachment.name}
 											loading="lazy"
 											onError={() =>
@@ -240,7 +269,7 @@ export const IssueAttachments = ({
 					}}
 				>
 					<img
-						src={`/media/${lightbox.fileName}`}
+						src={getAttachmentUrl(lightbox.fileName)}
 						alt={lightbox.name}
 						style={{
 							maxWidth: '90vw',

--- a/source/gui/client/components/IssueComments.tsx
+++ b/source/gui/client/components/IssueComments.tsx
@@ -19,7 +19,8 @@ import {
 } from './IssueCommits';
 import {MarkdownContent} from './MarkdownContent';
 import {MAX_COMMENT_LENGTH} from '../../../lib/utils/text.limits.js';
-import {IMAGE_FILE_ACCEPT, useImageInsert} from '../lib/image-insert';
+import {useImageInsert} from '../lib/image-insert';
+import {AddImageButton} from './AddImageButton';
 
 // A diff-selection comment's quoted code is rendered through the same
 // highlighter the diff view uses, rather than as a markdown fence — the whole
@@ -293,25 +294,19 @@ export const IssueComments = ({
 							font: 'inherit',
 							fontFamily: CONTENT_FONT,
 							fontSize: TEXT.prose,
+							...composerImages.dropStyle,
 						}}
 					/>
 
 					<ActionRow>
 						{composerImages.enabled && (
-							<>
-								<Button variant="ghost" onClick={composerImages.pickFiles}>
-									{composerImages.busy ? 'adding…' : 'add image'}
-								</Button>
-								<input
-									data-testid="comment-image-input"
-									ref={composerImages.inputRef}
-									type="file"
-									accept={IMAGE_FILE_ACCEPT}
-									multiple
-									hidden
-									onChange={composerImages.onInputChange}
-								/>
-							</>
+							<AddImageButton
+								testId="comment-image-input"
+								busy={composerImages.busy}
+								onPick={composerImages.pickFiles}
+								inputRef={composerImages.inputRef}
+								onInputChange={composerImages.onInputChange}
+							/>
 						)}
 
 						{/* Hidden until halfway, so a one-liner is not nagged. */}

--- a/source/gui/client/components/IssueComments.tsx
+++ b/source/gui/client/components/IssueComments.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import {useRef, useState} from 'react';
 import {CONTENT_FONT, GUI_THEME, TEXT} from '../lib/gui-theme';
 import {Button} from './Button';
 import {CodeSnippet} from './CodeSnippet';
@@ -19,6 +19,7 @@ import {
 } from './IssueCommits';
 import {MarkdownContent} from './MarkdownContent';
 import {MAX_COMMENT_LENGTH} from '../../../lib/utils/text.limits.js';
+import {IMAGE_FILE_ACCEPT, useImageInsert} from '../lib/image-insert';
 
 // A diff-selection comment's quoted code is rendered through the same
 // highlighter the diff view uses, rather than as a markdown fence — the whole
@@ -85,6 +86,8 @@ type Props = {
 	onDeleteComment?: (issueId: string, commentId: string) => void;
 	onEditComment?: (issueId: string, commentId: string, body: string) => void;
 	onOpenDiffLocation?: (location: DiffLocation) => void;
+	// Resolves to one markdown reference per stored file, left at the cursor.
+	onUploadImages?: (issueId: string, files: File[]) => Promise<string[]>;
 };
 
 export const IssueComments = ({
@@ -96,8 +99,17 @@ export const IssueComments = ({
 	onDeleteComment,
 	onEditComment,
 	onOpenDiffLocation,
+	onUploadImages,
 }: Props) => {
 	const [body, setBody] = useState('');
+	const composerRef = useRef<HTMLTextAreaElement | null>(null);
+
+	const composerImages = useImageInsert({
+		issueId,
+		setValue: setBody,
+		textareaRef: composerRef,
+		onUploadImages: readonly ? undefined : onUploadImages,
+	});
 	// The comment being rewritten, if any. A diff-linked comment only exposes
 	// its note here; the marker and quoted snippet ride along untouched.
 	const [editing, setEditing] = useState<{id: string; text: string} | null>(
@@ -263,9 +275,14 @@ export const IssueComments = ({
 						// Uncapped: maxLength drops a long paste's tail silently. The
 						// counter and disabled button refuse it visibly instead.
 						maxLength={Number.MAX_SAFE_INTEGER}
+						ref={composerRef}
 						value={body}
 						placeholder="write a comment"
 						onChange={event => setBody(event.target.value)}
+						onDragOver={composerImages.onDragOver}
+						onDragLeave={composerImages.onDragLeave}
+						onDrop={composerImages.onDrop}
+						onPaste={composerImages.onPaste}
 						onKeyDown={event => {
 							if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
 								addComment();
@@ -280,6 +297,23 @@ export const IssueComments = ({
 					/>
 
 					<ActionRow>
+						{composerImages.enabled && (
+							<>
+								<Button variant="ghost" onClick={composerImages.pickFiles}>
+									{composerImages.busy ? 'adding…' : 'add image'}
+								</Button>
+								<input
+									data-testid="comment-image-input"
+									ref={composerImages.inputRef}
+									type="file"
+									accept={IMAGE_FILE_ACCEPT}
+									multiple
+									hidden
+									onChange={composerImages.onInputChange}
+								/>
+							</>
+						)}
+
 						{/* Hidden until halfway, so a one-liner is not nagged. */}
 						{length > MAX_COMMENT_LENGTH / 2 && (
 							<span

--- a/source/gui/client/components/IssueDetails.tsx
+++ b/source/gui/client/components/IssueDetails.tsx
@@ -47,7 +47,8 @@ import {IssueHistory} from './IssueHistory';
 import {formatAbsolute, timeAgo} from '../lib/gui-format.helper';
 import {usePersistedFlag} from '../lib/scrubber';
 import {MAX_DESCRIPTION_LENGTH} from '../../../lib/utils/text.limits.js';
-import {IMAGE_FILE_ACCEPT, useImageInsert} from '../lib/image-insert';
+import {useImageInsert} from '../lib/image-insert';
+import {AddImageButton} from './AddImageButton';
 
 type IssueDetailsTab = 'overview' | 'comments' | 'history' | 'code';
 
@@ -533,28 +534,19 @@ export const IssueDetails = ({
 											fontSize: TEXT.prose,
 											maxHeight: 320,
 											overflowY: 'auto',
+											...descriptionImages.dropStyle,
 										}}
 									/>
 
 									<ActionRow>
 										{descriptionImages.enabled && (
-											<>
-												<Button
-													variant="ghost"
-													onClick={descriptionImages.pickFiles}
-												>
-													{descriptionImages.busy ? 'adding…' : 'add image'}
-												</Button>
-												<input
-													data-testid="description-image-input"
-													ref={descriptionImages.inputRef}
-													type="file"
-													accept={IMAGE_FILE_ACCEPT}
-													multiple
-													hidden
-													onChange={descriptionImages.onInputChange}
-												/>
-											</>
+											<AddImageButton
+												testId="description-image-input"
+												busy={descriptionImages.busy}
+												onPick={descriptionImages.pickFiles}
+												inputRef={descriptionImages.inputRef}
+												onInputChange={descriptionImages.onInputChange}
+											/>
 										)}
 										<Button onClick={saveDescription}>save</Button>
 										<Button variant="ghost" onClick={cancelDescription}>

--- a/source/gui/client/components/IssueDetails.tsx
+++ b/source/gui/client/components/IssueDetails.tsx
@@ -46,6 +46,8 @@ import {Tabs, TabItem} from './Tabs';
 import {IssueHistory} from './IssueHistory';
 import {formatAbsolute, timeAgo} from '../lib/gui-format.helper';
 import {usePersistedFlag} from '../lib/scrubber';
+import {MAX_DESCRIPTION_LENGTH} from '../../../lib/utils/text.limits.js';
+import {IMAGE_FILE_ACCEPT, useImageInsert} from '../lib/image-insert';
 
 type IssueDetailsTab = 'overview' | 'comments' | 'history' | 'code';
 
@@ -256,7 +258,9 @@ export const IssueDetails = ({
 	diffFocus?: CommitFocus | null;
 	attachments: GuiAttachment[];
 	attachmentUploadStatus: AttachmentUploadStatus;
-	onUploadAttachments?: (issueId: string, files: File[]) => void;
+	// Resolves to one markdown reference per stored file, so a composer can
+	// leave them at the cursor.
+	onUploadAttachments?: (issueId: string, files: File[]) => Promise<string[]>;
 	onDeleteAttachment?: (issueId: string, attachmentId: string) => void;
 	commits: GuiRefCommitEntry[];
 	commitsLoading: boolean;
@@ -316,6 +320,7 @@ export const IssueDetails = ({
 	const openLaneCount = LANE_KEYS.filter(key => !laneCollapsed[key]).length;
 	const panelRef = useRef<HTMLElement | null>(null);
 	const titleTextareaRef = useRef<HTMLTextAreaElement | null>(null);
+	const descriptionRef = useRef<HTMLTextAreaElement | null>(null);
 
 	const resizeTitleTextarea = () => {
 		const el = titleTextareaRef.current;
@@ -340,6 +345,14 @@ export const IssueDetails = ({
 	}, [issue?.id, issue?.title, issue?.description]);
 
 	const disabled = !issue || issue.readonly;
+
+	// Below `disabled`, which it reads: a readonly ticket takes no images.
+	const descriptionImages = useImageInsert({
+		issueId: issue?.id ?? '',
+		setValue: setDescription,
+		textareaRef: descriptionRef,
+		onUploadImages: disabled ? undefined : onUploadAttachments,
+	});
 
 	// No count until the list has arrived: 0 would misread as "no commits".
 	const commitsCount =
@@ -482,10 +495,20 @@ export const IssueDetails = ({
 							{editingDescription ? (
 								<>
 									<Textarea
+										ref={descriptionRef}
 										value={description}
 										autoFocus
 										placeholder=""
+										// The primitive's default is 1500, which silently dropped
+										// the tail of anything longer — and seven descriptions on
+										// this board are already past it, written from the TUI or
+										// over MCP where no such cap applies.
+										maxLength={MAX_DESCRIPTION_LENGTH}
 										onChange={event => setDescription(event.target.value)}
+										onDragOver={descriptionImages.onDragOver}
+										onDragLeave={descriptionImages.onDragLeave}
+										onDrop={descriptionImages.onDrop}
+										onPaste={descriptionImages.onPaste}
 										onKeyDown={event => {
 											if (event.key === 'Escape') return cancelDescription();
 											if (event.key !== 'Enter') return;
@@ -514,6 +537,25 @@ export const IssueDetails = ({
 									/>
 
 									<ActionRow>
+										{descriptionImages.enabled && (
+											<>
+												<Button
+													variant="ghost"
+													onClick={descriptionImages.pickFiles}
+												>
+													{descriptionImages.busy ? 'adding…' : 'add image'}
+												</Button>
+												<input
+													data-testid="description-image-input"
+													ref={descriptionImages.inputRef}
+													type="file"
+													accept={IMAGE_FILE_ACCEPT}
+													multiple
+													hidden
+													onChange={descriptionImages.onInputChange}
+												/>
+											</>
+										)}
 										<Button onClick={saveDescription}>save</Button>
 										<Button variant="ghost" onClick={cancelDescription}>
 											cancel
@@ -785,6 +827,7 @@ export const IssueDetails = ({
 						onDeleteComment={onDeleteComment}
 						onEditComment={onEditComment}
 						onOpenDiffLocation={onOpenDiffLocation}
+						onUploadImages={issue.readonly ? undefined : onUploadAttachments}
 					/>
 				);
 

--- a/source/gui/client/lib/image-insert.test.ts
+++ b/source/gui/client/lib/image-insert.test.ts
@@ -1,0 +1,79 @@
+import {describe, expect, it} from 'vitest';
+import {imageFilesFrom, spliceImageMarkdown} from './image-insert';
+import {
+	getAttachmentMarkdown,
+	getAttachmentUrl,
+} from '../../../lib/media/attachment-url.js';
+
+const md = getAttachmentMarkdown('shot.png', 'a'.repeat(64) + '.webp');
+
+describe('spliceImageMarkdown', () => {
+	it('drops the reference straight in when the body is empty', () => {
+		expect(spliceImageMarkdown('', 0, md)).toEqual({
+			value: md,
+			caret: md.length,
+		});
+	});
+
+	it('gives the image its own line when it lands mid-paragraph', () => {
+		const {value} = spliceImageMarkdown('beforeafter', 6, md);
+
+		expect(value).toBe(`before\n${md}\nafter`);
+	});
+
+	it('disturbs nothing else about the text it splits', () => {
+		// The space is the tail's, and stays the tail's.
+		expect(spliceImageMarkdown('before after', 6, md).value).toBe(
+			`before\n${md}\n after`,
+		);
+	});
+
+	it('adds no newline where one is already there', () => {
+		const {value} = spliceImageMarkdown('before\n\nafter', 7, md);
+
+		expect(value).toBe(`before\n${md}\nafter`);
+	});
+
+	it('leaves the caret after what it inserted, ready to keep typing', () => {
+		const {value, caret} = spliceImageMarkdown('a', 1, md);
+
+		expect(value.slice(0, caret)).toBe(`a\n${md}`);
+	});
+
+	// The upload is a round trip, so the body can have been typed into — or
+	// cleared — by the time the reference arrives.
+	it('clamps a caret that no longer fits the body', () => {
+		expect(spliceImageMarkdown('ab', 999, md).value).toBe(`ab\n${md}`);
+		expect(spliceImageMarkdown('ab', -5, md).value).toBe(`${md}\nab`);
+	});
+});
+
+describe('imageFilesFrom', () => {
+	const file = (type: string) => ({type} as File);
+
+	it('keeps only images, whatever else was dropped', () => {
+		expect(
+			imageFilesFrom([
+				file('image/png'),
+				file('text/plain'),
+				file('image/webp'),
+			]),
+		).toHaveLength(2);
+	});
+
+	it('shrugs off nothing at all', () => {
+		expect(imageFilesFrom(null)).toEqual([]);
+		expect(imageFilesFrom(undefined)).toEqual([]);
+	});
+});
+
+// The client builds no URL of its own; it inserts what the server handed back.
+// This pins the shape both sides agree on.
+describe('the reference the server hands back', () => {
+	it('points at the route that serves the blob', () => {
+		expect(getAttachmentUrl('deadbeef.png')).toBe('/media/deadbeef.png');
+		expect(getAttachmentMarkdown('a shot', 'deadbeef.png')).toBe(
+			'![a shot](/media/deadbeef.png)',
+		);
+	});
+});

--- a/source/gui/client/lib/image-insert.ts
+++ b/source/gui/client/lib/image-insert.ts
@@ -4,10 +4,15 @@
 // a content-hashed URL nobody is going to type by hand.
 
 import {useCallback, useRef, useState} from 'react';
+import {GUI_THEME} from './gui-theme';
 
 // What the blob store accepts. The real check is the magic bytes server-side;
 // this only keeps the file picker from offering what would be refused.
 export const IMAGE_FILE_ACCEPT = 'image/png,image/jpeg,image/gif,image/webp';
+
+// The dashed accent the Attachments section already shows while an image is
+// over it, so the two drop targets read as the same thing.
+const DROP_TARGET_TINT = 'rgba(118, 212, 255, 0.08)';
 
 export const imageFilesFrom = (
 	files: ArrayLike<File> | null | undefined,
@@ -107,6 +112,17 @@ export const useImageInsert = ({
 		dragging,
 		busy,
 		inputRef,
+		// What the textarea wears while an image is over it, so a drag has
+		// somewhere visible to land rather than being a guess.
+		// The shorthand, not borderColor/borderStyle: the Textarea primitive sets
+		// `border`, and React warns that mixing the two on one element can drop
+		// whichever loses the race.
+		dropStyle: dragging
+			? {
+					border: `1px dashed ${GUI_THEME.accent}`,
+					background: DROP_TARGET_TINT,
+			  }
+			: undefined,
 		pickFiles: () => inputRef.current?.click(),
 		onInputChange: (event: React.ChangeEvent<HTMLInputElement>) => {
 			void insert(imageFilesFrom(event.target.files));

--- a/source/gui/client/lib/image-insert.ts
+++ b/source/gui/client/lib/image-insert.ts
@@ -1,0 +1,146 @@
+// Getting an image into a body being written: the picker, the drop and the
+// paste all end here, upload, and leave the markdown reference at the cursor.
+// Without that last step the affordance is worthless — the reference points at
+// a content-hashed URL nobody is going to type by hand.
+
+import {useCallback, useRef, useState} from 'react';
+
+// What the blob store accepts. The real check is the magic bytes server-side;
+// this only keeps the file picker from offering what would be refused.
+export const IMAGE_FILE_ACCEPT = 'image/png,image/jpeg,image/gif,image/webp';
+
+export const imageFilesFrom = (
+	files: ArrayLike<File> | null | undefined,
+): File[] =>
+	files === null || files === undefined
+		? []
+		: Array.from(files).filter(file => file.type.startsWith('image/'));
+
+// An image reads as its own block, so it is put on one. Only ever adds the
+// newlines that are missing, so inserting into a blank body stays blank-clean
+// and inserting mid-paragraph does not glue the picture to a word.
+export const spliceImageMarkdown = (
+	body: string,
+	caret: number,
+	markdown: string,
+): {value: string; caret: number} => {
+	const at = Math.max(0, Math.min(caret, body.length));
+	const before = body.slice(0, at);
+	const after = body.slice(at);
+
+	const lead = before === '' || before.endsWith('\n') ? '' : '\n';
+	const tail = after === '' || after.startsWith('\n') ? '' : '\n';
+	const block = `${lead}${markdown}${tail}`;
+
+	return {value: `${before}${block}${after}`, caret: at + block.length};
+};
+
+/**
+ * Wires a textarea up to accept images. Returns the handlers to spread onto it
+ * plus `pickFiles` for a button to call.
+ *
+ * `onUploadImages` resolves to one markdown reference per file it managed to
+ * store, so a rejected file simply contributes nothing.
+ */
+export const useImageInsert = ({
+	issueId,
+	setValue,
+	textareaRef,
+	onUploadImages,
+}: {
+	issueId: string;
+	setValue: (update: (current: string) => string) => void;
+	textareaRef: React.RefObject<HTMLTextAreaElement | null>;
+	onUploadImages?: (issueId: string, files: File[]) => Promise<string[]>;
+}) => {
+	const [dragging, setDragging] = useState(false);
+	const [busy, setBusy] = useState(false);
+	const inputRef = useRef<HTMLInputElement | null>(null);
+
+	const enabled = Boolean(onUploadImages);
+
+	const insert = useCallback(
+		async (files: File[]) => {
+			if (!onUploadImages || files.length === 0) return;
+
+			// Read now: the upload is a round trip, and by the time it lands the
+			// textarea may have been typed in or blurred.
+			const area = textareaRef.current;
+			const caret = area ? area.selectionStart : Number.MAX_SAFE_INTEGER;
+
+			setBusy(true);
+			let markdown: string[] = [];
+			try {
+				markdown = await onUploadImages(issueId, files);
+			} finally {
+				setBusy(false);
+			}
+
+			if (markdown.length === 0) return;
+
+			let nextCaret = caret;
+			// Functional, so whatever was typed during the upload survives; the
+			// caret is only clamped, which is the most that can be honoured.
+			setValue(current => {
+				const spliced = spliceImageMarkdown(
+					current,
+					caret,
+					markdown.join('\n'),
+				);
+				nextCaret = spliced.caret;
+				return spliced.value;
+			});
+
+			// After the value lands, or the browser puts the caret at the end.
+			requestAnimationFrame(() => {
+				const target = textareaRef.current;
+				if (!target) return;
+				target.focus();
+				target.setSelectionRange(nextCaret, nextCaret);
+			});
+		},
+		[issueId, onUploadImages, setValue, textareaRef],
+	);
+
+	return {
+		enabled,
+		dragging,
+		busy,
+		inputRef,
+		pickFiles: () => inputRef.current?.click(),
+		onInputChange: (event: React.ChangeEvent<HTMLInputElement>) => {
+			void insert(imageFilesFrom(event.target.files));
+			// Or picking the same file twice in a row fires no change event.
+			event.target.value = '';
+		},
+		onDragOver: (event: React.DragEvent) => {
+			if (!enabled) return;
+			event.preventDefault();
+			setDragging(true);
+		},
+		onDragLeave: () => setDragging(false),
+		onDrop: (event: React.DragEvent) => {
+			if (!enabled) return;
+			event.preventDefault();
+			setDragging(false);
+			void insert(imageFilesFrom(event.dataTransfer.files));
+		},
+		onPaste: (event: React.ClipboardEvent) => {
+			if (!enabled) return;
+
+			const files = imageFilesFrom(
+				Array.from(event.clipboardData.items)
+					.filter(item => item.kind === 'file')
+					.map(item => item.getAsFile())
+					.filter((file): file is File => file !== null),
+			);
+
+			if (files.length === 0) return;
+
+			// Only once there is an image to take: a plain text paste has to go
+			// through untouched.
+			event.preventDefault();
+			void insert(files);
+		},
+	};
+};

--- a/source/lib/media/attachment-url.ts
+++ b/source/lib/media/attachment-url.ts
@@ -1,0 +1,20 @@
+// Import-free so the browser client can reach it, like text.limits.ts. These
+// three facts have to agree across the GUI, the server route that answers a
+// blob and the markdown an attachment is referenced by, and media-store.ts —
+// where they used to live — cannot be imported here: it pulls in node:crypto
+// and node:fs, which the client bundle has no answer for.
+
+// Where the GUI serves blobs from. Kept beside the markdown builder so the
+// reference and the route that answers it stay one fact.
+export const ATTACHMENT_URL_PREFIX = '/media/';
+
+export const getAttachmentUrl = (fileName: string): string =>
+	`${ATTACHMENT_URL_PREFIX}${fileName}`;
+
+/**
+ * The markdown that renders an attachment inline wherever a body is drawn as
+ * markdown — a comment or a description. Handed back by the API that created
+ * the attachment so a caller never has to build the path itself.
+ */
+export const getAttachmentMarkdown = (name: string, fileName: string): string =>
+	`![${name}](${getAttachmentUrl(fileName)})`;

--- a/source/lib/media/media-store.ts
+++ b/source/lib/media/media-store.ts
@@ -25,20 +25,14 @@ export const getAttachmentFileName = (
 export const isValidAttachmentFileName = (fileName: string): boolean =>
 	BLOB_FILE_PATTERN.test(fileName);
 
-// Where the GUI serves blobs from. Kept beside the filename so the markdown
-// an attachment is referenced by and the route that answers it are one fact.
-export const ATTACHMENT_URL_PREFIX = '/media/';
-
-export const getAttachmentUrl = (fileName: string): string =>
-	`${ATTACHMENT_URL_PREFIX}${fileName}`;
-
-/**
- * The markdown that renders an attachment inline wherever a body is drawn as
- * markdown — a comment or a description. Handed back by the API that created
- * the attachment so a caller never has to build the path itself.
- */
-export const getAttachmentMarkdown = (name: string, fileName: string): string =>
-	`![${name}](${getAttachmentUrl(fileName)})`;
+// Re-exported, not defined here: the client needs them too and cannot import
+// this module, which reaches for node:crypto and node:fs. Callers already
+// importing them from here are unaffected.
+export {
+	ATTACHMENT_URL_PREFIX,
+	getAttachmentUrl,
+	getAttachmentMarkdown,
+} from './attachment-url.js';
 
 /**
  * Determines the image type from the file's magic bytes. Extensions and

--- a/source/lib/utils/text.limits.ts
+++ b/source/lib/utils/text.limits.ts
@@ -7,7 +7,11 @@
 export const MAX_COMMENT_LENGTH = 4000;
 
 export const MAX_TITLE_LENGTH = 300;
-export const MAX_DESCRIPTION_LENGTH = 100_000;
+
+// Room for a long ticket without room for a document. The longest description
+// on this board is ~4.5k, so this is several times the real ceiling while
+// being small enough that one accepted string cannot bloat every clone's log.
+export const MAX_DESCRIPTION_LENGTH = 20_000;
 export const MAX_TAG_NAME_LENGTH = 60;
 export const MAX_ASSIGNEE_NAME_LENGTH = 80;
 export const MAX_ATTACHMENT_NAME_LENGTH = 200;

--- a/source/test/e2e-gui/insert-image.pw.ts
+++ b/source/test/e2e-gui/insert-image.pw.ts
@@ -1,0 +1,113 @@
+import type {Page} from '@playwright/test';
+import {expect, test} from './fixtures.js';
+
+// A real 64x64 PNG. The store sniffs magic bytes rather than trusting the
+// name, so this has to be a genuine one — and it has to have real dimensions,
+// or the rendered <img> is a pixel wide and proves nothing.
+const PNG_BASE64 =
+	'iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAABMElEQVR4nNXCsSoGAABG0W8wGAwGg8FgMBgMBoPBYDBIkiTpJkmSJEmSJEmSJEmSJEl/kiRJkiRJMhgMBoPBYDAYDAaDwXPc00l4dC/iQT3F3KunhDv1lHKrnjJu1FPOtXoquFJPJZfqqeJCPdWcq6eGM/XUcqqeOk7UU8+xeho4Uk8jh+pp4kA9zRTU08q+etrZU08nu+rpZkc9PWyrp48t9QywqZ4hNtQzwrp6xlhTzwSr6pliRT0zLKtnjiX1LLConiUW1LPCvHrWmFPPBrPq2WJGPTtMq2ePKfUUmFTPIRPqOWZcPaeMqeecUfVcMqKea4bVc8uQeu4ZVM8jA+p5ol89z/Sp54Ve9bzSo543UM873er5oEs9n3Sq54sO9XzTrp4f2tTzS6t6/mhR/wcnahFL3vsGUgAAAABJRU5ErkJggg==';
+
+const pngFile = {
+	name: 'shot.png',
+	mimeType: 'image/png',
+	buffer: Buffer.from(PNG_BASE64, 'base64'),
+};
+
+const openTicket = async (page: Page, appUrl: string, label: string) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	await page.getByTitle('Add issue').first().click();
+	await page.getByPlaceholder('issue name').fill(`${label} ${Date.now()}`);
+	await page.getByPlaceholder('issue name').press('Enter');
+	await expect(page).toHaveURL(/\/issue\//);
+};
+
+// The reference the server hands back, which is what has to reach the body.
+const MEDIA_REF = /!\[[^\]]*\]\(\/media\/[a-f0-9]{64}\.(png|jpg|gif|webp)\)/;
+
+test('the description editor takes an image and leaves the reference at the cursor', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await openTicket(page, appUrl, 'Desc image');
+
+	await page.getByRole('button', {name: 'edit'}).first().click();
+	const box = page.getByRole('textbox').last();
+	await box.fill('before');
+
+	// The picker is hidden, so the file goes to the input the button clicks —
+	// by testid, since the Attachments section has one of its own on this tab.
+	await page.getByTestId('description-image-input').setInputFiles(pngFile);
+
+	await expect(box).toHaveValue(MEDIA_REF, {timeout: 15_000});
+	// Inserted after what was already typed, on a line of its own.
+	expect((await box.inputValue()).startsWith('before\n![')).toBe(true);
+
+	// And it survives the save, rendering as a real image.
+	await page.getByRole('button', {name: 'save', exact: true}).click();
+	const image = page.locator('aside a[href^="/media/"] img').first();
+	await expect(image).toBeVisible();
+
+	// Not a broken one, and not the attachments thumbnail either: the route
+	// answers with the real 64x64 bitmap. Typed structurally rather than as an
+	// HTMLImageElement, which this tsconfig has no DOM lib to supply.
+	const naturalWidth = await image.evaluate(
+		node => (node as unknown as {naturalWidth: number}).naturalWidth,
+	);
+	expect(naturalWidth).toBe(64);
+
+	expect(pageErrors).toEqual([]);
+});
+
+test('the comment composer takes an image too', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await openTicket(page, appUrl, 'Comment image');
+
+	await page.getByRole('button', {name: /^Comments/}).click();
+	const composer = page.getByPlaceholder('write a comment');
+	await composer.fill('look at this');
+
+	await page.getByTestId('comment-image-input').setInputFiles(pngFile);
+	await expect(composer).toHaveValue(MEDIA_REF, {timeout: 15_000});
+
+	await page.getByRole('button', {name: 'comment', exact: true}).click();
+
+	const image = page.locator('aside a[href^="/media/"] img').first();
+	await expect(image).toBeVisible();
+
+	expect(pageErrors).toEqual([]);
+});
+
+// Dropping onto the composer, rather than onto the Attachments section that
+// already accepted one.
+test('dropping an image on the comment composer inserts it', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await openTicket(page, appUrl, 'Drop image');
+
+	await page.getByRole('button', {name: /^Comments/}).click();
+	const composer = page.getByPlaceholder('write a comment');
+
+	// A source string for the same reason: DataTransfer and File are DOM
+	// values, which this tsconfig does not carry.
+	const handle = await page.evaluateHandle(`(() => {
+		const bytes = Uint8Array.from(atob('${PNG_BASE64}'), c => c.charCodeAt(0));
+		const transfer = new DataTransfer();
+		transfer.items.add(new File([bytes], 'dropped.png', {type: 'image/png'}));
+		return transfer;
+	})()`);
+
+	await composer.dispatchEvent('dragover', {dataTransfer: handle});
+	await composer.dispatchEvent('drop', {dataTransfer: handle});
+
+	await expect(composer).toHaveValue(MEDIA_REF, {timeout: 15_000});
+
+	expect(pageErrors).toEqual([]);
+});

--- a/source/test/e2e-gui/insert-image.pw.ts
+++ b/source/test/e2e-gui/insert-image.pw.ts
@@ -105,9 +105,18 @@ test('dropping an image on the comment composer inserts it', async ({
 	})()`);
 
 	await composer.dispatchEvent('dragover', {dataTransfer: handle});
+
+	// The composer says it will take it, rather than leaving the drag to guess.
+	// toHaveCSS resolves the computed value, so no DOM types are needed here.
+	await expect(composer).toHaveCSS('border-style', 'dashed');
+	await expect(composer).toHaveCSS('border-color', 'rgb(118, 212, 255)');
+
 	await composer.dispatchEvent('drop', {dataTransfer: handle});
 
 	await expect(composer).toHaveValue(MEDIA_REF, {timeout: 15_000});
+
+	// And stands down once the image has landed.
+	await expect(composer).not.toHaveCSS('border-style', 'dashed');
 
 	expect(pageErrors).toEqual([]);
 });


### PR DESCRIPTION
Closes 7YCCZB7. Follow-up to BP59K8E.

BP59K8E taught comment and description bodies to *render* an image and gave an agent an MCP path to attach one. A person had neither: the only upload anywhere was a drop onto the Attachments section, and the reference still had to be typed by hand against a sha256 URL.

Three gestures now do it, on the comment composer and the description editor alike — **a button, a drop onto the textarea, and a paste**. Each uploads and leaves the `![alt](/media/…)` reference **at the cursor**, on its own line, which is the part that makes the affordance worth having. The Attachments section gets the same file picker, so dropping is no longer the only way in there either.

### What moved underneath

**The server already built the reference and threw it away.** `addIssueAttachment` returns `markdown`; the upload route replied with the state alone. It now carries the attachment alongside, so the client inserts what the server made rather than rebuilding a content-hashed path it would have to keep in step with the route.

**The two pure helpers move to `lib/media/attachment-url.ts`**, import-free like `text.limits.ts`. `media-store.ts` reaches for `node:crypto` and `node:fs`, so the client could never import them from there — which is why two GUI call sites had inlined `/media/`. Those now use the helper, and `media-store.ts` re-exports it so nothing else changes.

`Textarea` forwards its ref, because inserting at the cursor means reading `selectionStart` off the element.

### The description length cap, per your call

The editor capped input at the `Textarea` default of **1500** while the model allowed **100,000**, so a long body lost its tail silently — and **seven descriptions on this board are already past 1500**, written from the TUI or over MCP where no such cap applies. It is now one number, **20,000**, honoured by both: ~4.4× the longest real description here (4,503), 5× the comment cap, and far below the injection surface of 100k. Nothing existing is orphaned.

### Tests

- `image-insert.test.ts` — the splice: own line only where one is missing, caret left after the insert, a stale caret clamped (the upload is a round trip, so the body may have been typed into meanwhile), and the reference shape both sides agree on.
- `insert-image.pw.ts` — three browser cases: the description editor via the button, the comment composer via the button, and a drop onto the composer. Each asserts the reference reaches the body, and the description one follows through to a rendered image the route actually answers.

**One thing I got wrong, and how it is pinned now.** My first assertion was `aside img[src^="/media/"]`, and it passed while the description body rendered no image at all — it had matched the *Attachments thumbnail* on the same panel. The 1×1 PNG fixture hid it further, since a one-pixel `<img>` satisfies both `toBeVisible()` and `naturalWidth > 0`. It is now scoped to `aside a[href^="/media/"] img` (the markdown renderer wraps in an anchor; the thumbnail sits in a button) with a real 64×64 fixture and `expect(naturalWidth).toBe(64)`. The manual browser pass is what caught it, not the test.

Full pre-push gate green: lint, typecheck, unit (962), containerised e2e (16) and collab (11), GUI browser (75).

---

### Follow-up in `2bc63656`, from review

- **The picker is an icon**, not a third word beside `save` and `cancel`. One `AddImageButton` across all three surfaces rather than the same markup three times.
- **The drop now says so.** It worked, but silently: the hook tracked `dragging` and nothing wore it. Both composers take the dashed accent the Attachments list already showed. Set as the `border` shorthand — my first attempt used `borderColor` + `borderStyle`, and the e2e caught the React warning about mixing shorthand and longhand on one element.
- **The delete on an attachment survives the image.** It already existed, but a 16px dim `×` vanishes into a busy picture. It cannot borrow contrast from what it sits on, so it brings its own: dark fill for a pale image, light ring for a dark one, shadow for a noisy one, full-strength glyph, 18px, red on hover. Checked against a 96×96 image of pure high-contrast noise, not a smooth gradient.
