### PR TITLE
Reuse a GUI already serving this project

### DIFF
--- a/source/gui/api/api-server.ts
+++ b/source/gui/api/api-server.ts
@@ -18,6 +18,14 @@ import {
 	getGuiState,
 } from '../../mcp/epiq-api.js';
 import {getTimeTravelStatus, runExclusive} from '../../mcp/epiq-time-travel.js';
+import {EPIQ_VERSION} from '../../version.js';
+import {
+	canonicalRepoRoot,
+	GuiInstance,
+	INSTANCE_APP,
+	INSTANCE_PATH,
+	PREFERRED_GUI_PORT,
+} from './instance.js';
 import {startGuiAutoSync} from './lib/api-autosync.js';
 import {refuseCrossSiteRequest} from './lib/origin-guard.js';
 import {GuiProject} from './lib/gui-project.js';
@@ -162,7 +170,7 @@ const serveStatic = async (urlPathname: string, res: http.ServerResponse) => {
 
 const listen = async (
 	server: http.Server,
-	preferredPort = 3710,
+	preferredPort = PREFERRED_GUI_PORT,
 ): Promise<number> =>
 	new Promise((resolve, reject) => {
 		const tryListen = (port: number) => {
@@ -231,6 +239,19 @@ export const startGuiServer = async (input: {
 				isError: true,
 				message: refusal.message,
 			});
+		}
+
+		// Who is on this port. Answered before anything expensive, so a probe
+		// costs a socket and nothing else — and deliberately without reading the
+		// board, since the asker may well be a different epiq that only wants to
+		// know whether to hand this one the browser.
+		if (req.method === 'GET' && url.pathname === INSTANCE_PATH) {
+			return sendJson(res, 200, {
+				app: INSTANCE_APP,
+				repoRoot: canonicalRepoRoot(project.repoRoot),
+				version: EPIQ_VERSION,
+				pid: process.pid,
+			} satisfies GuiInstance);
 		}
 
 		if (url.pathname === '/api/state') {

--- a/source/gui/api/instance.ts
+++ b/source/gui/api/instance.ts
@@ -1,0 +1,77 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+// The port a GUI asks for first. A second epiq on the same machine only lands
+// somewhere else because this one was taken, which is the whole reason an
+// instance needs to be identifiable.
+export const PREFERRED_GUI_PORT = 3710;
+
+export const INSTANCE_PATH = '/api/instance';
+export const INSTANCE_APP = 'epiq';
+
+export type GuiInstance = {
+	app: typeof INSTANCE_APP;
+	repoRoot: string;
+	version: string;
+	pid: number;
+};
+
+/**
+ * Two paths naming the same project have to compare equal, so a symlinked
+ * checkout or a trailing slash cannot make one epiq look like a different one.
+ * Falls back to `resolve` when the path cannot be read — better a comparison
+ * that might miss than a throw on the boot path.
+ */
+export const canonicalRepoRoot = (repoRoot: string): string => {
+	try {
+		return fs.realpathSync(path.resolve(repoRoot));
+	} catch {
+		return path.resolve(repoRoot);
+	}
+};
+
+const isGuiInstance = (value: unknown): value is GuiInstance => {
+	const candidate = value as Partial<GuiInstance> | null;
+
+	return (
+		typeof candidate === 'object' &&
+		candidate !== null &&
+		candidate.app === INSTANCE_APP &&
+		typeof candidate.repoRoot === 'string' &&
+		typeof candidate.version === 'string' &&
+		typeof candidate.pid === 'number'
+	);
+};
+
+/**
+ * Who holds `port`, or null for "nobody I can use".
+ *
+ * Null covers every unhappy answer alike — nothing listening, something that
+ * is not epiq, a hang, a body that is not the shape above — because the caller
+ * does the same thing in all of them: carry on and start its own server. The
+ * timeout matters: a foreign server that accepts the socket and never replies
+ * would otherwise stall the boot it was meant to speed up.
+ */
+export const probeGuiInstance = async (
+	port: number,
+	timeoutMs = 500,
+): Promise<GuiInstance | null> => {
+	const abort = new AbortController();
+	const timer = setTimeout(() => abort.abort(), timeoutMs);
+
+	try {
+		const response = await fetch(`http://127.0.0.1:${port}${INSTANCE_PATH}`, {
+			signal: abort.signal,
+		});
+
+		if (!response.ok) return null;
+
+		const body: unknown = await response.json();
+
+		return isGuiInstance(body) ? body : null;
+	} catch {
+		return null;
+	} finally {
+		clearTimeout(timer);
+	}
+};

--- a/source/gui/init.ts
+++ b/source/gui/init.ts
@@ -11,6 +11,11 @@ import {
 import {patchSettingsState} from '../lib/state/settings.state.js';
 import {openBrowser} from './open-browser.js';
 import {startGuiServer} from './api/api-server.js';
+import {
+	canonicalRepoRoot,
+	PREFERRED_GUI_PORT,
+	probeGuiInstance,
+} from './api/instance.js';
 
 export const startGui = async (input: {
 	repoRoot: string;
@@ -24,6 +29,29 @@ export const startGui = async (input: {
 
 	const settings = loadSettingsFromConfig();
 	if (isSuccess(settings)) patchSettingsState(settings.value);
+
+	// An epiq already serving this project on the usual port is the one to open,
+	// not something to start a rival to. A second server would land on an
+	// ephemeral port, and since browser storage is scoped to the whole origin —
+	// port included — that new origin arrives with none of the panel widths,
+	// board selection or lane state the first one has been keeping.
+	//
+	// Only this exact case is reused. A different project, or anything that
+	// isn't epiq, falls through to the existing fallback: taking a port from
+	// either of them is a decision for TYR7186, not a side effect of booting.
+	const running = await probeGuiInstance(PREFERRED_GUI_PORT);
+
+	if (running && running.repoRoot === canonicalRepoRoot(input.repoRoot)) {
+		const url = `http://127.0.0.1:${PREFERRED_GUI_PORT}`;
+
+		console.log(
+			`Epiq GUI already running for this project at ${chalk.cyan(url)}`,
+		);
+
+		openBrowser(url);
+
+		return succeeded('Reused running GUI', {url});
+	}
 
 	const serverResult = await startGuiServer({...input, boardId: ''});
 

--- a/source/test/e2e-gui/instance-endpoint.pw.ts
+++ b/source/test/e2e-gui/instance-endpoint.pw.ts
@@ -1,0 +1,24 @@
+import fs from 'node:fs';
+import {expect, test} from './fixtures.js';
+
+// The endpoint a second epiq probes to decide whether to open this server or
+// start its own. It has to answer before the board is touched, and name the
+// project in the same canonical form the prober compares against.
+test('the server names itself and its project', async ({
+	request,
+	appUrl,
+	repoRoot,
+}) => {
+	const response = await request.get(`${appUrl}/api/instance`);
+	expect(response.ok()).toBe(true);
+
+	const body = await response.json();
+
+	expect(body.app).toBe('epiq');
+	expect(typeof body.version).toBe('string');
+	expect(typeof body.pid).toBe('number');
+	// Canonical: the fixture's path may reach the same directory by a symlink
+	// (/var vs /private/var on macOS), and a prober comparing strings has to
+	// still match.
+	expect(body.repoRoot).toBe(fs.realpathSync(repoRoot));
+});

--- a/source/test/gui-instance.test.ts
+++ b/source/test/gui-instance.test.ts
@@ -1,0 +1,124 @@
+import http from 'node:http';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {afterEach, describe, expect, it} from 'vitest';
+import {
+	canonicalRepoRoot,
+	INSTANCE_PATH,
+	probeGuiInstance,
+} from '../gui/api/instance.js';
+
+const servers: http.Server[] = [];
+
+const serve = async (
+	handler: http.RequestListener,
+): Promise<{port: number}> => {
+	const server = http.createServer(handler);
+	servers.push(server);
+
+	await new Promise<void>(resolve =>
+		server.listen(0, '127.0.0.1', () => resolve()),
+	);
+
+	const address = server.address();
+	if (!address || typeof address === 'string') throw new Error('no port');
+
+	return {port: address.port};
+};
+
+const respondWith = (status: number, body: unknown): http.RequestListener =>
+	function respond(req, res) {
+		if (req.url !== INSTANCE_PATH) {
+			res.writeHead(404).end();
+			return;
+		}
+
+		res.writeHead(status, {'content-type': 'application/json'});
+		res.end(JSON.stringify(body));
+	};
+
+const validBody = {
+	app: 'epiq',
+	repoRoot: '/tmp/project',
+	version: '1.6.1',
+	pid: 4242,
+};
+
+afterEach(async () => {
+	await Promise.all(
+		servers.splice(0).map(
+			server =>
+				new Promise<void>(resolve => {
+					server.closeAllConnections?.();
+					server.close(() => resolve());
+				}),
+		),
+	);
+});
+
+describe('probeGuiInstance', () => {
+	it('identifies an epiq holding the port', async () => {
+		const {port} = await serve(respondWith(200, validBody));
+
+		expect(await probeGuiInstance(port)).toEqual(validBody);
+	});
+
+	// Every unusable answer collapses to null, because the caller does the same
+	// thing for all of them: start its own server.
+	it('returns null for a server that is not epiq', async () => {
+		const {port} = await serve(respondWith(200, {app: 'vite', repoRoot: '/x'}));
+
+		expect(await probeGuiInstance(port)).toBeNull();
+	});
+
+	it('returns null for a body missing fields', async () => {
+		const {port} = await serve(respondWith(200, {app: 'epiq'}));
+
+		expect(await probeGuiInstance(port)).toBeNull();
+	});
+
+	it('returns null for a non-200', async () => {
+		const {port} = await serve(respondWith(500, validBody));
+
+		expect(await probeGuiInstance(port)).toBeNull();
+	});
+
+	it('returns null when nothing is listening', async () => {
+		// Bound then released, so the port is real and free rather than guessed.
+		const {port} = await serve(respondWith(200, validBody));
+		await new Promise<void>(resolve => servers[0]!.close(() => resolve()));
+
+		expect(await probeGuiInstance(port)).toBeNull();
+	});
+
+	// A server that accepts the socket and never answers would otherwise stall
+	// the boot this is meant to speed up.
+	it('gives up on a server that never replies', async () => {
+		const {port} = await serve(() => {});
+
+		const started = Date.now();
+		expect(await probeGuiInstance(port, 150)).toBeNull();
+		expect(Date.now() - started).toBeLessThan(3000);
+	});
+});
+
+describe('canonicalRepoRoot', () => {
+	it('resolves a symlinked path to the same string as the real one', () => {
+		const base = fs.mkdtempSync(path.join(os.tmpdir(), 'epiq-instance-'));
+		const real = path.join(base, 'project');
+		const link = path.join(base, 'link');
+		fs.mkdirSync(real);
+		fs.symlinkSync(real, link);
+
+		expect(canonicalRepoRoot(link)).toBe(canonicalRepoRoot(real));
+		// A trailing slash names the same project too.
+		expect(canonicalRepoRoot(`${real}/`)).toBe(canonicalRepoRoot(real));
+	});
+
+	it('falls back to an absolute path when the directory is not there', () => {
+		const missing = path.join(os.tmpdir(), 'epiq-not-here-9f3a');
+
+		expect(canonicalRepoRoot(missing)).toBe(path.resolve(missing));
+	});
+});

--- a/source/test/gui-reuse.test.ts
+++ b/source/test/gui-reuse.test.ts
@@ -1,0 +1,94 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {succeeded} from '../lib/model/result-types.js';
+
+vi.mock('../gui/api/instance.js', async importOriginal => ({
+	// Keep the real canonicalRepoRoot: pairing a probe result with it is the
+	// part worth testing, and stubbing it would test nothing.
+	...(await importOriginal<typeof import('../gui/api/instance.js')>()),
+	probeGuiInstance: vi.fn(),
+}));
+
+vi.mock('../gui/api/api-server.js', () => ({startGuiServer: vi.fn()}));
+vi.mock('../gui/open-browser.js', () => ({openBrowser: vi.fn()}));
+vi.mock('../lib/config/actor-env.js', () => ({
+	resolveEnvActor: () => succeeded('actor', null),
+}));
+vi.mock('../lib/config/user-config.js', () => ({
+	loadSettingsFromConfig: () => succeeded('settings', {}),
+}));
+vi.mock('../lib/state/settings.state.js', () => ({
+	patchSettingsState: vi.fn(),
+}));
+
+import {startGuiServer} from '../gui/api/api-server.js';
+import {
+	canonicalRepoRoot,
+	PREFERRED_GUI_PORT,
+	probeGuiInstance,
+} from '../gui/api/instance.js';
+import {startGui} from '../gui/init.js';
+import {openBrowser} from '../gui/open-browser.js';
+
+const REPO = process.cwd();
+
+const instance = (repoRoot: string) => ({
+	app: 'epiq' as const,
+	repoRoot: canonicalRepoRoot(repoRoot),
+	version: '1.6.1',
+	pid: 1,
+});
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	vi.mocked(startGuiServer).mockResolvedValue(
+		succeeded('started', {
+			url: 'http://127.0.0.1:9999',
+			server: null as never,
+		}),
+	);
+});
+
+describe('startGui', () => {
+	// The point of the whole thing: a second server would get an ephemeral port,
+	// and browser storage is scoped to the origin, so its panel widths and lane
+	// state would start empty.
+	it('opens the running GUI instead of starting a second one', async () => {
+		vi.mocked(probeGuiInstance).mockResolvedValue(instance(REPO));
+
+		const result = await startGui({repoRoot: REPO});
+
+		expect(startGuiServer).not.toHaveBeenCalled();
+		expect(openBrowser).toHaveBeenCalledWith(
+			`http://127.0.0.1:${PREFERRED_GUI_PORT}`,
+		);
+		expect(result.value?.url).toBe(`http://127.0.0.1:${PREFERRED_GUI_PORT}`);
+	});
+
+	// Taking the port from another project's board is a decision for TYR7186,
+	// not something booting should do on its own.
+	it('starts its own server when the port serves a different project', async () => {
+		vi.mocked(probeGuiInstance).mockResolvedValue(instance('/somewhere/else'));
+
+		await startGui({repoRoot: REPO});
+
+		expect(startGuiServer).toHaveBeenCalledOnce();
+		expect(openBrowser).toHaveBeenCalledWith('http://127.0.0.1:9999');
+	});
+
+	it('starts its own server when the port holds something that is not epiq', async () => {
+		vi.mocked(probeGuiInstance).mockResolvedValue(null);
+
+		await startGui({repoRoot: REPO});
+
+		expect(startGuiServer).toHaveBeenCalledOnce();
+	});
+
+	// A symlinked checkout is the same project, and must not read as a rival.
+	it('reuses when the paths differ only by a symlink or trailing slash', async () => {
+		vi.mocked(probeGuiInstance).mockResolvedValue(instance(REPO));
+
+		await startGui({repoRoot: `${REPO}/`});
+
+		expect(startGuiServer).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
Closes 3D55SCB. Step 1 of TYR7186 — the non-destructive half. Nothing is killed and no prompt is added.

When 3710 was taken, `startGui` started a second server on an ephemeral port. Browser storage is scoped to the whole origin, port included, so that new origin arrived with none of the panel widths, board selection or lane state the first one had been keeping — and since the fallback port is `listen(0)`, it was a *different* empty origin every launch.

Most of the time the occupant is an epiq serving the same project, where the right answer is not to start a rival at all:

- **`GET /api/instance`** returns `{app, repoRoot, version, pid}`, so the holder of a port can be identified by asking rather than inferred from `lsof`. Answered before the board is touched, so a probe costs a socket.
- **`startGui` probes 3710 first.** Same project → open the browser at the running server and stop. Anything else → today's fallback, untouched.

`repoRoot` is compared canonically (`realpathSync` + `resolve`), so a symlinked checkout or a trailing slash still reads as the same project — on macOS the `/var` vs `/private/var` pair makes this load-bearing rather than theoretical.

The probe collapses every unusable answer to null — nothing listening, not epiq, wrong shape, non-200, no reply — because the caller does the same thing in all of them. It has a 500ms timeout so a foreign server that accepts the socket and never answers cannot stall the boot this is meant to speed up.

`startGuiServer` is unchanged, so the e2e suites that call it directly still get isolated servers.

Deliberately still on the fallback: an epiq serving a *different* project, and a non-epiq occupant. Taking a port from either is TYR7186's decision, not a side effect of booting.

Tests: `gui-instance.test.ts` (probe across all six answers, canonicalisation incl. symlink), `gui-reuse.test.ts` (the reuse decision — verified red without the change), `instance-endpoint.pw.ts` (the live endpoint names its project canonically).

Full pre-push gate green; 965 unit tests.