### PR TITLE
Collapse a lane from its own button, and animate the change

### DIFF
--- a/source/gui/client/components/IconCollapseLane.tsx
+++ b/source/gui/client/components/IconCollapseLane.tsx
@@ -1,0 +1,19 @@
+// A panel squeezed shut: chevrons pressing inward against the edge it collapses
+// to. The mirrored pair (IconExpandLane) pushes back out.
+export const IconCollapseLane = ({size = 16}: {size?: number}) => (
+	<svg
+		width={size}
+		height={size}
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		strokeWidth="2"
+		strokeLinecap="round"
+		strokeLinejoin="round"
+		aria-hidden="true"
+	>
+		<polyline points="5 7 9 12 5 17" />
+		<line x1="12" y1="5" x2="12" y2="19" />
+		<polyline points="19 7 15 12 19 17" />
+	</svg>
+);

--- a/source/gui/client/components/IconExpandLane.tsx
+++ b/source/gui/client/components/IconExpandLane.tsx
@@ -1,0 +1,19 @@
+// The mirror of IconCollapseLane: chevrons pushing outward from the bar, for
+// the rail that is already collapsed.
+export const IconExpandLane = ({size = 16}: {size?: number}) => (
+	<svg
+		width={size}
+		height={size}
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		strokeWidth="2"
+		strokeLinecap="round"
+		strokeLinejoin="round"
+		aria-hidden="true"
+	>
+		<polyline points="9 7 5 12 9 17" />
+		<line x1="12" y1="5" x2="12" y2="19" />
+		<polyline points="15 7 19 12 15 17" />
+	</svg>
+);

--- a/source/gui/client/components/IssueDetails.tsx
+++ b/source/gui/client/components/IssueDetails.tsx
@@ -22,6 +22,8 @@ import {ManageTagsModal} from './ManageTagsModal';
 import {CopyRef} from './CopyRef';
 import {FormHeader} from './FormHeader';
 import {FullscreenToggleButton} from './FullscreenToggleButton';
+import {IconCollapseLane} from './IconCollapseLane';
+import {IconExpandLane} from './IconExpandLane';
 import {
 	ActionRow,
 	AddRow,
@@ -67,6 +69,8 @@ const LANE_KEYS = Object.keys(LANE_SHARES) as LaneKey[];
 
 // Wide enough for the upright label and a comfortable click target.
 const COLLAPSED_LANE_WIDTH = 28;
+// Long enough to read as a movement, short enough not to be waited on.
+const LANE_COLLAPSE_MS = 180;
 
 const LANE_LABEL_STYLE = {
 	color: GUI_THEME.secondary,
@@ -74,6 +78,54 @@ const LANE_LABEL_STYLE = {
 	textTransform: 'uppercase',
 	letterSpacing: '0.08em',
 } as const;
+
+// Same footprint and hover as FullscreenToggleButton, which is the other
+// icon-only control in this panel.
+const LaneIconButton = ({
+	label,
+	icon,
+	onClick,
+	style,
+	children,
+}: {
+	label: string;
+	icon: React.ReactNode;
+	onClick: () => void;
+	style?: React.CSSProperties;
+	children?: React.ReactNode;
+}) => (
+	<button
+		type="button"
+		aria-label={label}
+		title={label}
+		onClick={onClick}
+		style={{
+			display: 'inline-flex',
+			alignItems: 'center',
+			flexShrink: 0,
+			background: 'transparent',
+			border: 'none',
+			padding: 4,
+			borderRadius: 4,
+			cursor: 'pointer',
+			color: GUI_THEME.dim,
+			fontFamily: 'inherit',
+			transition: 'color 120ms ease, background 120ms ease',
+			...style,
+		}}
+		onMouseEnter={event => {
+			event.currentTarget.style.background = 'rgba(255,255,255,0.04)';
+			event.currentTarget.style.color = GUI_THEME.accent;
+		}}
+		onMouseLeave={event => {
+			event.currentTarget.style.background = 'transparent';
+			event.currentTarget.style.color = GUI_THEME.dim;
+		}}
+	>
+		{icon}
+		{children}
+	</button>
+);
 
 /**
  * One column of the lanes view, collapsible to a rail so the lanes that stay
@@ -101,58 +153,45 @@ const Lane = ({
 }) => {
 	const label = `${title}${typeof count === 'number' ? ` (${count})` : ''}`;
 	const testId = `lane-${title.toLowerCase()}`;
-	const headerStyle = {
-		...LANE_LABEL_STYLE,
-		textAlign: 'left',
-		padding: 0,
-		paddingBottom: 10,
-		marginBottom: 14,
-		// Longhand throughout: mixing `border` with `borderBottom` makes React
-		// warn about shorthand/longhand conflicts on every rerender.
-		borderTop: 'none',
-		borderLeft: 'none',
-		borderRight: 'none',
-		borderBottom: `1px solid ${GUI_THEME.line}`,
-		background: 'transparent',
-		fontFamily: 'inherit',
-	} as const;
 
 	if (collapsed) {
 		return (
 			<div
 				data-testid={testId}
 				data-collapsed="true"
-				style={{display: 'flex', minHeight: 0}}
+				style={{display: 'flex', minHeight: 0, overflow: 'hidden'}}
 			>
-				<button
-					type="button"
-					aria-label={`Expand ${title}`}
-					title={`Expand ${title}`}
+				{/* The whole rail is the target here, unlike the open header: at 28px
+				    there is no room to aim at anything smaller, and re-opening a lane
+				    by accident costs nothing. */}
+				<LaneIconButton
+					label={`Expand ${title}`}
 					onClick={onToggle}
+					icon={<IconExpandLane size={12} />}
 					style={{
-						...LANE_LABEL_STYLE,
 						flex: 1,
-						display: 'flex',
-						justifyContent: 'center',
-						alignItems: 'flex-start',
-						paddingTop: 2,
-						background: 'transparent',
-						borderTop: 'none',
-						borderLeft: 'none',
-						borderBottom: 'none',
+						flexDirection: 'column',
+						gap: 8,
+						alignItems: 'center',
+						justifyContent: 'flex-start',
+						paddingTop: 8,
+						borderRadius: 0,
 						borderRight: `1px solid ${GUI_THEME.line}`,
-						fontFamily: 'inherit',
-						cursor: 'pointer',
 					}}
 				>
 					{/* Bottom-to-top, so the label reads upward from the panel floor
 					    rather than upside down. */}
 					<span
-						style={{writingMode: 'vertical-rl', transform: 'rotate(180deg)'}}
+						style={{
+							...LANE_LABEL_STYLE,
+							writingMode: 'vertical-rl',
+							transform: 'rotate(180deg)',
+							whiteSpace: 'nowrap',
+						}}
 					>
 						{label}
 					</span>
-				</button>
+				</LaneIconButton>
 			</div>
 		);
 	}
@@ -163,22 +202,31 @@ const Lane = ({
 			data-collapsed="false"
 			style={{display: 'flex', flexDirection: 'column', minHeight: 0}}
 		>
-			{canCollapse ? (
-				<button
-					type="button"
-					aria-label={`Collapse ${title}`}
-					title={`Collapse ${title}`}
-					onClick={onToggle}
-					style={{...headerStyle, cursor: 'pointer'}}
-				>
-					{label}
-				</button>
-			) : (
-				// The last open lane has nowhere to collapse to. A plain heading
-				// rather than a dead button: nothing to activate, and no control
-				// named after a lane for the tab count in fullscreen-lanes to find.
-				<div style={headerStyle}>{label}</div>
-			)}
+			<div
+				style={{
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'space-between',
+					gap: 8,
+					paddingBottom: 6,
+					marginBottom: 14,
+					borderBottom: `1px solid ${GUI_THEME.line}`,
+				}}
+			>
+				<span style={{...LANE_LABEL_STYLE, minWidth: 0}}>{label}</span>
+
+				{/* Only the button collapses the lane. The header used to do it
+				    wholesale, which was far too easy to trigger by aiming at nothing
+				    in particular. The last open lane has nowhere to collapse to, so
+				    it shows no control at all. */}
+				{canCollapse && (
+					<LaneIconButton
+						label={`Collapse ${title}`}
+						onClick={onToggle}
+						icon={<IconCollapseLane size={12} />}
+					/>
+				)}
+			</div>
 			<div style={{flex: 1, minHeight: 0, overflowY: 'auto'}}>{children}</div>
 		</div>
 	);
@@ -448,19 +496,26 @@ export const IssueDetails = ({
 					LANE_GAP * (LANE_COUNT - 1) -
 					railTotal;
 
-				const laneColumns = LANE_KEYS.map(key =>
+				// Every track in pixels, including the open ones. A track going from
+				// `minmax(0, 1fr)` to `28px` changes type, and CSS cannot interpolate
+				// across types — it snaps, whatever transition is set. Sizing both
+				// states in the same unit is what lets the collapse animate at all.
+				// Floored, so rounding can only leave a sliver of the row unused
+				// rather than overflow it.
+				const laneWidth = (key: LaneKey): number =>
 					laneCollapsed[key]
-						? `${COLLAPSED_LANE_WIDTH}px`
-						: `minmax(0, ${LANE_SHARES[key]}fr)`,
-				).join(' ');
+						? COLLAPSED_LANE_WIDTH
+						: Math.floor(
+								(laneRoom * LANE_SHARES[key]) / Math.max(openShares, 1),
+						  );
 
-				// Drives the diff's split/unified choice, so it has to track the
-				// width the Commits lane actually ends up with.
-				const commitsWidth = laneView
-					? laneCollapsed.commits || openShares === 0
-						? 0
-						: laneRoom * (LANE_SHARES.commits / openShares)
-					: panelWidth;
+				const laneColumns = LANE_KEYS.map(key => `${laneWidth(key)}px`).join(
+					' ',
+				);
+
+				// The width the Commits lane is actually given, which is what the
+				// diff's split/unified choice has to follow.
+				const commitsWidth = laneView ? laneWidth('commits') : panelWidth;
 
 				const overviewPane = issue && (
 					<>
@@ -929,6 +984,7 @@ export const IssueDetails = ({
 											gap: LANE_GAP,
 											flex: 1,
 											minHeight: 0,
+											transition: `grid-template-columns ${LANE_COLLAPSE_MS}ms ease`,
 										}}
 									>
 										{(

--- a/source/test/e2e-gui/lane-collapse.pw.ts
+++ b/source/test/e2e-gui/lane-collapse.pw.ts
@@ -19,6 +19,60 @@ const openLanes = async (page: Page, appUrl: string) => {
 const laneWidth = async (page: Page, name: string): Promise<number> =>
 	(await page.getByTestId(`lane-${name}`).boundingBox())?.width ?? 0;
 
+// Clicking the header used to collapse the lane wholesale, which was far too
+// easy to do by aiming at nothing in particular.
+test('only the button collapses a lane, not the header', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await openLanes(page, appUrl);
+
+	await page.getByTestId('lane-overview').getByText('Overview').click();
+	await expect(page.getByTestId('lane-overview')).toHaveAttribute(
+		'data-collapsed',
+		'false',
+	);
+
+	await page.getByRole('button', {name: 'Collapse Overview'}).click();
+	await expect(page.getByTestId('lane-overview')).toHaveAttribute(
+		'data-collapsed',
+		'true',
+	);
+
+	expect(pageErrors).toEqual([]);
+});
+
+// A track going from `minmax(0, 1fr)` to `28px` changes type, and CSS cannot
+// interpolate across types — it snaps however the transition is written. The
+// widths are computed in pixels precisely so the collapse can animate, and
+// a single `fr` creeping back in would silently kill it.
+test('the lane tracks are sized so the collapse can animate', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await openLanes(page, appUrl);
+
+	// A string body, like the other DOM reads in this suite: the tests compile
+	// under the root tsconfig, which carries no DOM lib.
+	const style = await page.evaluate<{columns: string; transition: string}>(`
+		(() => {
+			const lane = document.querySelector('[data-testid="lane-commits"]');
+			const computed = getComputedStyle(lane.parentElement);
+			return {
+				columns: computed.gridTemplateColumns,
+				transition: computed.transitionProperty,
+			};
+		})()
+	`);
+
+	expect(style.columns).not.toContain('fr');
+	expect(style.transition).toContain('grid-template-columns');
+
+	expect(pageErrors).toEqual([]);
+});
+
 // Four even-ish lanes leave the diff a quarter of the panel. Collapsing the
 // ones you are not reading is what hands that width to the commits lane.
 test('collapsing a lane gives its width to the ones still open', async ({


### PR DESCRIPTION
Closes NVTDXD7. Follow-up to RVZSAKH on how the collapse feels.

**A real button.** Clicking anywhere on "COMMENTS (1)" used to collapse the lane — far too easy to trigger by aiming at nothing in particular, and a behaviour the header's appearance never advertised. The header is plain text again, with a small icon button at its right end, matching `FullscreenToggleButton`'s footprint and hover. The last open lane shows no control at all.

Icon is the conventional squeeze pair: `>|<` to collapse, `<|>` on the rail to expand.

**The animation needed a layout change, not just a transition.** A track going from `minmax(0, 1fr)` to `28px` changes type, and CSS cannot interpolate across types — it snaps no matter what transition is set. I probed this in Chromium first:

- `1fr → 28px`: mid-flight value equals the end value. Snaps.
- `minmax(0,1fr) → 28px`: mid-flight equals the *start* value. Also discrete.
- `200px → 28px`: mid-flight `119.094px`. Interpolates.

So the lane widths are now computed in pixels for open lanes too, from the width already being derived for the diff's split/unified choice — which makes `commitsWidth` literally the width the lane gets, rather than a parallel calculation. Floored, so rounding can only leave a sliver unused rather than overflow the row.

The rail keeps its whole surface clickable, deliberately: at 28px there is nothing smaller to aim at, and re-opening a lane by accident costs nothing.

Tests: two new cases in `lane-collapse.pw.ts` — clicking the header does *not* collapse, and the tracks carry no `fr` with the transition set (the invariant that keeps the animation alive). Both verified red against the previous behaviour.

Full pre-push gate green.