### PR TITLE
756310J confirm a bulk tag on the server, after clearing the product of losing one

### DIFF
--- a/source/test/e2e-gui/bulk.pw.ts
+++ b/source/test/e2e-gui/bulk.pw.ts
@@ -21,6 +21,14 @@ const panel = `
 })()
 `;
 
+// The board as the server has it, not as the client is drawing it. `addIssueTag`
+// updates GUI state optimistically and then fire-and-forgets over the socket,
+// so anything read off the panel is true before the write has landed.
+type ServedIssue = {title: string; tags: {name: string}[]};
+type ServedState = {
+	value?: {boards?: {swimlanes?: {issues?: ServedIssue[]}[]}[]};
+};
+
 test.setTimeout(180_000);
 
 test('picking several tickets opens a bulk overview', async ({
@@ -76,6 +84,30 @@ test('picking several tickets opens a bulk overview', async ({
 	await expect(page.locator('aside')).toContainText('bulky', {
 		timeout: 30_000,
 	});
+
+	// Confirmed by the server before navigating away. The panel above is the
+	// client's optimistic copy, so waiting only on it would let the reload race
+	// the writes — and a write that never landed would then read as a rendering
+	// fault on a board that is in fact correct.
+	await expect
+		.poll(
+			async () => {
+				const response = await page.request.get(`${appUrl}/api/state`);
+				const body = (await response.json()) as ServedState;
+
+				return (body.value?.boards ?? [])
+					.flatMap(board => board.swimlanes ?? [])
+					.flatMap(swimlane => swimlane.issues ?? [])
+					.filter(
+						issue =>
+							issue.title.startsWith(`${tag}-`) &&
+							issue.tags.some(each => each.name === 'bulky'),
+					).length;
+			},
+			{timeout: 30_000},
+		)
+		.toBe(2);
+
 	await page.goto(boardUrl);
 	await expect(
 		page


### PR DESCRIPTION
`bulk.pw.ts:26` intermittently failed asserting both tickets carry the bulk-applied tag — `Expected: 2 Received: 1`, sixty polls stuck at one, so the second ticket was genuinely untagged rather than slow to render. That reads like data loss, so it was worth settling.

### The product does not lose the write

I drove the real GUI websocket exactly as the client does — two `issue:tag:add` messages for a brand-new tag name, sent in the same tick, one per selected ticket — then read the server's own state back:

- **20/20 rounds** clean: both tickets tagged, no failed results, no duplicate tag nodes.
- **20/20 again with the repo's index left dirty**, the way a failed `commitLinkedFile` left it (`git add` succeeded, `git commit` did not). That was the best remaining mechanism and it does not do it.

Also ruled out by reading: `issue:tag:add` **is** in `MUTATING_MESSAGE_TYPES`, so both transports serialise it through `runExclusive`; the panel's "N tickets selected" and `forPicked` come from the same list, so a short fan-out would have shown a smaller count; and `SwimlaneColumn` has no per-lane render cap that could hide a card.

The symptom has not recurred in 12 consecutive full-suite runs since the unrelated commit-path collision was fixed under `9710XT1`, against roughly three failures in thirteen before. No mechanism links the two, so that is correlation rather than a proven cause — the original failures are unexplained and have stopped.

### What this changes

The one weakness I could prove. `addIssueTag` updates GUI state optimistically and then fire-and-forgets over the socket, so `expect(aside).toContainText('bulky')` was true *before* the writes had landed, and the test navigated away without knowing the server had them. It now polls `/api/state` until both tickets carry the tag before reloading.

So if a bulk tag ever does drop a ticket, this fails at the write with an unambiguous message, instead of looking like a rendering fault on a board that is in fact correct.

Verified non-vacuous: asserting a tag name that does not exist gives `Received: 0`.

### Checks

Local pre-push gate green: lint, typecheck, 965 unit tests, both docker suites, 76 browser tests.