### PR TITLE
Drop the centre bar from the lane collapse icon

### DIFF
--- a/source/gui/client/components/IconCollapseLane.tsx
+++ b/source/gui/client/components/IconCollapseLane.tsx
@@ -1,5 +1,6 @@
-// A panel squeezed shut: chevrons pressing inward against the edge it collapses
-// to. The mirrored pair (IconExpandLane) pushes back out.
+// A panel squeezed shut: two chevrons pressing inward. Drawn as just the pair —
+// a centre bar between them collapses into the chevron tips at the 12px this
+// renders at, and the three marks together read as a star rather than an arrow.
 export const IconCollapseLane = ({size = 16}: {size?: number}) => (
 	<svg
 		width={size}
@@ -12,8 +13,7 @@ export const IconCollapseLane = ({size = 16}: {size?: number}) => (
 		strokeLinejoin="round"
 		aria-hidden="true"
 	>
-		<polyline points="5 7 9 12 5 17" />
-		<line x1="12" y1="5" x2="12" y2="19" />
-		<polyline points="19 7 15 12 19 17" />
+		<polyline points="4 6 9 12 4 18" />
+		<polyline points="20 6 15 12 20 18" />
 	</svg>
 );

--- a/source/gui/client/components/IconExpandLane.tsx
+++ b/source/gui/client/components/IconExpandLane.tsx
@@ -1,5 +1,5 @@
-// The mirror of IconCollapseLane: chevrons pushing outward from the bar, for
-// the rail that is already collapsed.
+// The mirror of IconCollapseLane: chevrons pushing back outward, for the rail
+// that is already collapsed.
 export const IconExpandLane = ({size = 16}: {size?: number}) => (
 	<svg
 		width={size}
@@ -12,8 +12,7 @@ export const IconExpandLane = ({size = 16}: {size?: number}) => (
 		strokeLinejoin="round"
 		aria-hidden="true"
 	>
-		<polyline points="9 7 5 12 9 17" />
-		<line x1="12" y1="5" x2="12" y2="19" />
-		<polyline points="15 7 19 12 15 17" />
+		<polyline points="9 6 4 12 9 18" />
+		<polyline points="15 6 20 12 15 18" />
 	</svg>
 );


### PR DESCRIPTION
Closes TRKDTDS. Follow-up to NVTDXD7.

The `>|<` icon read as a `*` at actual size. The icons are drawn on a 24 viewBox and rendered at 12, so everything halves: the 2-unit stroke lands on 1px and the gap between each chevron tip and the centre bar lands on 1.5px. Three marks that close together fill in.

Size was not the lever. 12 is the project's de facto standard — 17 of 22 icon usages in the client, with only `IconScatter`/`IconBars` at 13 and `IconImage` at 14 for specific spots — so inflating this one would have made it the odd control in the panel.

Dropping the bar leaves `><` to collapse and `<>` to expand, with a 6-unit gap between the chevron tips (3px at render) that stays open. Same convention, half the marks to resolve.

Verified at true 1:1 this time rather than magnified — an 8× crop is exactly what hid the problem in the first review.