### PR TITLE
XT7HX2B take the commit diff down on any route change

### DIFF
--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -1139,6 +1139,16 @@ export const App = () => {
 
 	const closeCommitDiff = useCallback(() => setCommitDiff(null), []);
 
+	// A diff belongs to the view it was opened over, and the ticket panel
+	// renders only while no diff does — so one left up hides whatever the next
+	// route lands on. Cleared here rather than at each call site: a ticket is
+	// also reached by creating one, by a ref link, and by a comment permalink,
+	// and each of those had to remember on its own. Selecting the ticket
+	// already open is the one case this cannot see, and selectIssue clears it.
+	useEffect(() => {
+		setCommitDiff(null);
+	}, [boardId, issueId]);
+
 	useEffect(() => {
 		if (!removeError) return;
 

--- a/source/test/e2e-gui/scatter-gesture.pw.ts
+++ b/source/test/e2e-gui/scatter-gesture.pw.ts
@@ -188,3 +188,33 @@ test('a ticket opened after an unlinked commit replaces its diff', async ({
 
 	expect(pageErrors).toEqual([]);
 });
+
+// Every other way of reaching a ticket used to leave the panel where it was:
+// only a click on a card cleared it. Creating one navigates on the create
+// reply — from a column here, and from the diff panel's own "File ticket" —
+// so the ticket it lands on was drawn behind the diff that opened it.
+test('a ticket created while an unlinked commit diff is open replaces it', async ({
+	page,
+	appUrl,
+	repoRoot,
+	pageErrors,
+}) => {
+	const {dot, sha} = await seedCommitOnScatter(page, appUrl, repoRoot, {
+		link: false,
+	});
+
+	await page.mouse.click(dot.x, dot.y);
+
+	const diffPanel = page.locator(`aside button[title="Copy ${sha}"]`);
+	await expect(diffPanel).toBeVisible();
+
+	const title = `Filed under a diff ${Date.now()}`;
+	await page.getByTitle('Add issue').first().click();
+	await page.getByPlaceholder('issue name').fill(title);
+	await page.getByPlaceholder('issue name').press('Enter');
+
+	await expect(page.locator('aside')).toContainText(title);
+	await expect(diffPanel).toHaveCount(0);
+
+	expect(pageErrors).toEqual([]);
+});


### PR DESCRIPTION
The bare commit-diff panel is component state that outlived a route change. `selectIssue`/`selectIssueComments` cleared it (BGAJQAM), but nothing else did — so filing a ticket from the diff panel, adding one from a column, following a ticket ref link or a comment permalink all navigated to a ticket that was then drawn behind the diff.

Reproduced on a scratch board: with an unlinked commit's diff open, creating a ticket left the URL on `/issue/<ref>?tab=overview` with the aside still showing COMMIT.

Cleared once, on a change of board or ticket in the route, instead of at each call site. `selectIssue` keeps its own clear for the one case a route change cannot see: reselecting the ticket already open.

Regression test in `scatter-gesture.pw.ts`, verified failing without the fix (aside still on the diff after the ticket was created). `npm test`, `npm run build`, `npm run lint:err` and the `scatter-gesture` Playwright file (5 passed) are green.