### PR TITLE
Clamp a long description behind a show more, and open the editor on a double-click

### DIFF
--- a/source/gui/client/components/CollapsibleBody.tsx
+++ b/source/gui/client/components/CollapsibleBody.tsx
@@ -1,0 +1,96 @@
+import React, {useEffect, useRef, useState} from 'react';
+import {GUI_THEME, TEXT} from '../lib/gui-theme';
+
+// Room for a couple of paragraphs. Past it the body is clipped rather than
+// given a scrollbar of its own: the aside already scrolls, and a second bar
+// inside it is what this replaces.
+export const COLLAPSED_BODY_HEIGHT = 320;
+
+const FADE_HEIGHT = 64;
+
+export const CollapsibleBody = ({
+	children,
+	fadeTo = GUI_THEME.panel2,
+	testId,
+}: {
+	children: React.ReactNode;
+	fadeTo?: string;
+	testId?: string;
+}) => {
+	const [expanded, setExpanded] = useState(false);
+	const [overflows, setOverflows] = useState(false);
+	const contentRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		const content = contentRef.current;
+		if (!content) return;
+
+		// Measured, not guessed from the text's length: markdown reflows as
+		// images load and as the aside is resized, and either can carry the
+		// content across the clamp on its own.
+		const measure = () =>
+			setOverflows(content.scrollHeight > COLLAPSED_BODY_HEIGHT);
+
+		measure();
+
+		const observer = new ResizeObserver(measure);
+		observer.observe(content);
+
+		return () => observer.disconnect();
+	}, [children]);
+
+	const clamped = overflows && !expanded;
+
+	return (
+		<div data-testid={testId} style={{position: 'relative'}}>
+			<div
+				style={{
+					maxHeight: clamped ? COLLAPSED_BODY_HEIGHT : undefined,
+					overflow: 'hidden',
+				}}
+			>
+				<div ref={contentRef}>{children}</div>
+			</div>
+
+			{clamped && (
+				<div
+					aria-hidden={true}
+					style={{
+						position: 'absolute',
+						left: 0,
+						right: 0,
+						bottom: 0,
+						height: FADE_HEIGHT,
+						background: `linear-gradient(to bottom, ${GUI_THEME.transparent}, ${fadeTo})`,
+						pointerEvents: 'none',
+					}}
+				/>
+			)}
+
+			{overflows && (
+				<div style={{display: 'flex', justifyContent: 'center'}}>
+					<button
+						type="button"
+						data-testid="description-show-more"
+						aria-expanded={expanded}
+						onClick={() => setExpanded(!expanded)}
+						style={{
+							position: 'relative',
+							appearance: 'none',
+							WebkitAppearance: 'none',
+							background: 'transparent',
+							border: 'none',
+							color: GUI_THEME.dim2,
+							cursor: 'pointer',
+							fontFamily: 'inherit',
+							fontSize: TEXT.ui,
+							padding: '6px 8px 2px',
+						}}
+					>
+						{expanded ? 'show less' : 'show more'}
+					</button>
+				</div>
+			)}
+		</div>
+	);
+};

--- a/source/gui/client/components/CollapsibleBody.tsx
+++ b/source/gui/client/components/CollapsibleBody.tsx
@@ -61,33 +61,36 @@ export const CollapsibleBody = ({
 	};
 
 	return (
-		<div data-testid={testId} style={{position: 'relative'}}>
-			{/* The double-click belongs to the content, so the toggle and the
-			    fade below it are outside this element. */}
+		<div data-testid={testId}>
+			{/* The double-click belongs to the content, so the toggle below is
+			    outside this element. The fade is inside it, which is what puts
+			    the gradient over the last lines of text rather than over the
+			    toggle. */}
 			<div
 				onDoubleClick={handleDoubleClick}
 				style={{
+					position: 'relative',
 					maxHeight: clamped ? COLLAPSED_BODY_HEIGHT : undefined,
 					overflow: 'hidden',
 				}}
 			>
 				<div ref={contentRef}>{children}</div>
-			</div>
 
-			{clamped && (
-				<div
-					aria-hidden={true}
-					style={{
-						position: 'absolute',
-						left: 0,
-						right: 0,
-						bottom: 0,
-						height: FADE_HEIGHT,
-						background: `linear-gradient(to bottom, ${GUI_THEME.transparent}, ${fadeTo})`,
-						pointerEvents: 'none',
-					}}
-				/>
-			)}
+				{clamped && (
+					<div
+						aria-hidden={true}
+						style={{
+							position: 'absolute',
+							left: 0,
+							right: 0,
+							bottom: 0,
+							height: FADE_HEIGHT,
+							background: `linear-gradient(to bottom, ${GUI_THEME.transparent}, ${fadeTo})`,
+							pointerEvents: 'none',
+						}}
+					/>
+				)}
+			</div>
 
 			{overflows && (
 				<div style={{display: 'flex', justifyContent: 'center'}}>

--- a/source/gui/client/components/CollapsibleBody.tsx
+++ b/source/gui/client/components/CollapsibleBody.tsx
@@ -8,13 +8,19 @@ export const COLLAPSED_BODY_HEIGHT = 320;
 
 const FADE_HEIGHT = 64;
 
+// Roughly the platform's own double-click interval, which is the window the
+// second click of a pair can land in.
+const DOUBLE_CLICK_MS = 500;
+
 export const CollapsibleBody = ({
 	children,
 	fadeTo = GUI_THEME.panel2,
+	onDoubleClick,
 	testId,
 }: {
 	children: React.ReactNode;
 	fadeTo?: string;
+	onDoubleClick?: React.MouseEventHandler<HTMLDivElement>;
 	testId?: string;
 }) => {
 	const [expanded, setExpanded] = useState(false);
@@ -41,9 +47,25 @@ export const CollapsibleBody = ({
 
 	const clamped = overflows && !expanded;
 
+	const toggledAt = useRef(0);
+
+	// Toggling moves the button out from under the pointer, so the second click
+	// of a double-click on it lands on the body text that took its place — and
+	// that click's target is what the browser reports for the pair. Nothing in
+	// the event says the first click was the toggle; how recently the toggle
+	// ran is the only thing that does.
+	const handleDoubleClick: React.MouseEventHandler<HTMLDivElement> = event => {
+		if (Date.now() - toggledAt.current < DOUBLE_CLICK_MS) return;
+
+		onDoubleClick?.(event);
+	};
+
 	return (
 		<div data-testid={testId} style={{position: 'relative'}}>
+			{/* The double-click belongs to the content, so the toggle and the
+			    fade below it are outside this element. */}
 			<div
+				onDoubleClick={handleDoubleClick}
 				style={{
 					maxHeight: clamped ? COLLAPSED_BODY_HEIGHT : undefined,
 					overflow: 'hidden',
@@ -73,7 +95,10 @@ export const CollapsibleBody = ({
 						type="button"
 						data-testid="description-show-more"
 						aria-expanded={expanded}
-						onClick={() => setExpanded(!expanded)}
+						onClick={() => {
+							toggledAt.current = Date.now();
+							setExpanded(!expanded);
+						}}
 						style={{
 							position: 'relative',
 							appearance: 'none',

--- a/source/gui/client/components/IssueDetails.tsx
+++ b/source/gui/client/components/IssueDetails.tsx
@@ -33,6 +33,7 @@ import {
 	Textarea,
 } from './FormPrimitives';
 import {AttachmentUploadStatus, IssueAttachments} from './IssueAttachments';
+import {CollapsibleBody} from './CollapsibleBody';
 import {CommentBody, IssueComments} from './IssueComments';
 import {
 	CommitDiffState,
@@ -611,23 +612,27 @@ export const IssueDetails = ({
 								</>
 							) : issue.description ? (
 								<div
+									data-testid="description-box"
 									style={{
 										marginTop: 8,
 										padding: '8px 10px',
-										maxHeight: 320,
-										overflowY: 'auto',
 										background: GUI_THEME.panel2,
 										borderRadius: 8,
 									}}
 								>
-									{parseDiffCommentMeta(issue.description) ? (
-										<CommentBody
-											body={issue.description}
-											onOpenDiffLocation={onOpenDiffLocation}
-										/>
-									) : (
-										<MarkdownContent content={issue.description} />
-									)}
+									{/* Keyed on the issue, so opening another ticket starts
+									    its description collapsed rather than inheriting the
+									    last one's expanded state. */}
+									<CollapsibleBody key={issue.id} testId="description-body">
+										{parseDiffCommentMeta(issue.description) ? (
+											<CommentBody
+												body={issue.description}
+												onOpenDiffLocation={onOpenDiffLocation}
+											/>
+										) : (
+											<MarkdownContent content={issue.description} />
+										)}
+									</CollapsibleBody>
 								</div>
 							) : (
 								<Empty>No description</Empty>

--- a/source/gui/client/components/IssueDetails.tsx
+++ b/source/gui/client/components/IssueDetails.tsx
@@ -613,6 +613,7 @@ export const IssueDetails = ({
 							) : issue.description ? (
 								<div
 									data-testid="description-box"
+									title={issue.readonly ? undefined : 'Double-click to edit'}
 									style={{
 										marginTop: 8,
 										padding: '8px 10px',
@@ -623,7 +624,25 @@ export const IssueDetails = ({
 									{/* Keyed on the issue, so opening another ticket starts
 									    its description collapsed rather than inheriting the
 									    last one's expanded state. */}
-									<CollapsibleBody key={issue.id} testId="description-body">
+									<CollapsibleBody
+										key={issue.id}
+										testId="description-body"
+										onDoubleClick={event => {
+											if (issue.readonly) return;
+
+											// A description carries links, images and the code
+											// snippet's copy button. A double-click that landed
+											// on one of those was aimed at it, not at editing.
+											if (
+												(event.target as HTMLElement).closest(
+													'a, button, img, input, textarea, select',
+												)
+											)
+												return;
+
+											setEditingDescription(true);
+										}}
+									>
 										{parseDiffCommentMeta(issue.description) ? (
 											<CommentBody
 												body={issue.description}

--- a/source/test/e2e-gui/description-dblclick.pw.ts
+++ b/source/test/e2e-gui/description-dblclick.pw.ts
@@ -1,0 +1,72 @@
+import type {Page} from '@playwright/test';
+import {expect, test} from './fixtures.js';
+
+const openTicketWithDescription = async (
+	page: Page,
+	appUrl: string,
+	description: string,
+) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	await page.getByTitle('Add issue').first().click();
+	await page.getByPlaceholder('issue name').fill(`Dblclick ${Date.now()}`);
+	await page.getByPlaceholder('issue name').press('Enter');
+	await expect(page).toHaveURL(/\/issue\//);
+
+	await page.getByRole('button', {name: 'edit'}).first().click();
+	const box = page.getByRole('textbox').last();
+	await box.fill(description);
+	await box.press('ControlOrMeta+Enter');
+
+	await expect(page.getByTestId('description-box')).toBeVisible();
+};
+
+// The "edit" button only renders while the editor is shut, so its absence is
+// what says the editor opened.
+const editorOpen = (page: Page) =>
+	expect(page.getByRole('button', {name: 'edit'}).first()).toBeHidden();
+
+const editorClosed = (page: Page) =>
+	expect(page.getByRole('button', {name: 'edit'}).first()).toBeVisible();
+
+test('double-clicking a description opens the editor', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await openTicketWithDescription(page, appUrl, 'edit me by hand');
+
+	await page.getByTestId('description-box').dblclick();
+
+	await editorOpen(page);
+	await expect(page.getByRole('textbox').last()).toHaveValue('edit me by hand');
+
+	expect(pageErrors).toEqual([]);
+});
+
+// A description carries controls of its own — a link, an image, the show more
+// this clamp added. A double-click that landed on one was aimed at it.
+test('double-clicking show more expands without opening the editor', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	const long = Array.from({length: 60}, (_, index) => `line ${index}`).join(
+		'\n\n',
+	);
+	await openTicketWithDescription(page, appUrl, long);
+
+	const showMore = page
+		.getByTestId('description-box')
+		.getByTestId('description-show-more');
+	await showMore.dblclick();
+
+	await editorClosed(page);
+	// Expanded once and left there: the first click moved the toggle down the
+	// page, so the second landed on the text that grew into its place rather
+	// than collapsing the body again.
+	await expect(showMore).toHaveText('show less');
+
+	expect(pageErrors).toEqual([]);
+});

--- a/source/test/e2e-gui/description-overflow.pw.ts
+++ b/source/test/e2e-gui/description-overflow.pw.ts
@@ -39,18 +39,20 @@ const descriptionHeight = async (page: Page): Promise<number> => {
 // aside is the one scroller for this region; anything here is a second bar
 // inside it. Horizontal scrollers are left alone — a wide code block gets one,
 // and `overflow-x: auto` makes the computed `overflow-y` read `auto` too.
-const verticalScrollersInDescription = (page: Page) =>
-	page.getByTestId('description-box').evaluate(box => {
-		const elements = [box, ...box.querySelectorAll('*')];
+const verticalScrollersInDescription = async (page: Page): Promise<number> =>
+	(await page.evaluate(`
+(() => {
+	const box = document.querySelector('[data-testid="description-box"]');
 
-		return elements
-			.filter(element => element.scrollHeight - element.clientHeight > 2)
-			.filter(element => {
-				const overflowY = getComputedStyle(element).overflowY;
+	return [box, ...box.querySelectorAll('*')]
+		.filter(element => element.scrollHeight - element.clientHeight > 2)
+		.filter(element => {
+			const overflowY = getComputedStyle(element).overflowY;
 
-				return overflowY === 'auto' || overflowY === 'scroll';
-			}).length;
-	});
+			return overflowY === 'auto' || overflowY === 'scroll';
+		}).length;
+})()
+`)) as number;
 
 test('a long description is clamped with a show more, not a second scrollbar', async ({
 	page,

--- a/source/test/e2e-gui/description-overflow.pw.ts
+++ b/source/test/e2e-gui/description-overflow.pw.ts
@@ -1,0 +1,104 @@
+import type {Page} from '@playwright/test';
+import {expect, test} from './fixtures.js';
+
+// Long enough to clear the clamp several times over on any window this suite
+// runs in, so the test is measuring the clamp rather than the viewport.
+const LONG_DESCRIPTION = Array.from(
+	{length: 60},
+	(_, index) => `paragraph ${index}`,
+).join('\n\n');
+
+const openTicketWithDescription = async (
+	page: Page,
+	appUrl: string,
+	description: string,
+) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	await page.getByTitle('Add issue').first().click();
+	await page.getByPlaceholder('issue name').fill(`Overflow ${Date.now()}`);
+	await page.getByPlaceholder('issue name').press('Enter');
+	await expect(page).toHaveURL(/\/issue\//);
+
+	await page.getByRole('button', {name: 'edit'}).first().click();
+	const box = page.getByRole('textbox').last();
+	await box.fill(description);
+	await box.press('ControlOrMeta+Enter');
+
+	await expect(page.getByTestId('description-box')).toBeVisible();
+};
+
+const descriptionHeight = async (page: Page): Promise<number> => {
+	const size = await page.getByTestId('description-box').boundingBox();
+
+	return size?.height ?? 0;
+};
+
+// Every element inside the description that can be scrolled up and down. The
+// aside is the one scroller for this region; anything here is a second bar
+// inside it. Horizontal scrollers are left alone — a wide code block gets one,
+// and `overflow-x: auto` makes the computed `overflow-y` read `auto` too.
+const verticalScrollersInDescription = (page: Page) =>
+	page.getByTestId('description-box').evaluate(box => {
+		const elements = [box, ...box.querySelectorAll('*')];
+
+		return elements
+			.filter(element => element.scrollHeight - element.clientHeight > 2)
+			.filter(element => {
+				const overflowY = getComputedStyle(element).overflowY;
+
+				return overflowY === 'auto' || overflowY === 'scroll';
+			}).length;
+	});
+
+test('a long description is clamped with a show more, not a second scrollbar', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await openTicketWithDescription(page, appUrl, LONG_DESCRIPTION);
+
+	// First, because it is the regression: the description used to answer a
+	// long body with a scrollbar of its own, inside the aside's.
+	expect(await verticalScrollersInDescription(page)).toBe(0);
+
+	const showMore = page
+		.getByTestId('description-box')
+		.getByTestId('description-show-more');
+	await expect(showMore).toHaveText('show more');
+
+	const clamped = await descriptionHeight(page);
+	expect(clamped).toBeLessThan(420);
+
+	await showMore.click();
+
+	await expect(showMore).toHaveText('show less');
+	expect(await descriptionHeight(page)).toBeGreaterThan(clamped);
+	await expect(page.getByTestId('description-box')).toContainText(
+		'paragraph 59',
+	);
+	expect(await verticalScrollersInDescription(page)).toBe(0);
+
+	// And back, so the rest of the aside is reachable again without a reload.
+	await showMore.click();
+	await expect(showMore).toHaveText('show more');
+	expect(await descriptionHeight(page)).toBe(clamped);
+
+	expect(pageErrors).toEqual([]);
+});
+
+test('a short description has no show more at all', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await openTicketWithDescription(page, appUrl, 'one line');
+
+	await expect(page.getByTestId('description-box')).toContainText('one line');
+	await expect(
+		page.getByTestId('description-box').getByTestId('description-show-more'),
+	).toHaveCount(0);
+
+	expect(pageErrors).toEqual([]);
+});


### PR DESCRIPTION
The description in the ticket aside had a scrollbar of its own, nested inside the one the aside already has — two bars for one region, and a nesting comment bodies right below it never had.

**FWFQYYN** — the read-only description loses `maxHeight`/`overflowY` and gains a new `CollapsibleBody`: it clips at 320px, fades the bottom edge over the last lines of text, and offers a `show more` that expands it in place. The toggle is rendered only when a `ResizeObserver` on the content says it actually overflows, so a late-loading image or a resized aside is caught rather than guessed at from the length of the text. Rendering the description unclamped was the alternative, and was rejected: it sits at the top of the aside, so a long one would push Tags, Comments and Commits below the fold on every visit.

**2ZPZGJS** — a double-click on the description body opens the editor. Clicks landing on a link, image, or button are left alone. The toggle needed more than that: expanding moves it out from under the pointer, so the second click of a pair lands on the text that took its place, and *that* is the target the browser reports for the pair — nothing in the event says the first click was the toggle. `CollapsibleBody` records when the toggle last ran and ignores a double-click inside the platform's double-click window.

Two new e2e specs. The first asserts there is no vertical scroller anywhere inside the description in either state — verified red against the old component (it reports 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7zsfHDDn19wgJA98QbULF
