### PR TITLE
Dock the detail panel to the bottom as well as the right

### DIFF
--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -38,6 +38,7 @@ import {GlobalScrollbarStyles} from './components/GlobalScrollbarStyles';
 import {TicketRefLinksProvider} from './components/MarkdownContent';
 import {ErrorToast} from './components/ErrorToast';
 import {TimeScrubber} from './components/TimeScrubber';
+import {useAsideDock} from './lib/aside-dock';
 import {moveIssue} from './lib/gui-move-issue';
 import {reconnectDelayMs} from './lib/reconnect';
 import {moveSwimlane} from './lib/gui-move-swimlane';
@@ -155,6 +156,10 @@ export const App = () => {
 	// so the first render already picks the right layout instead of flashing.
 	const [commitDiffPanelWidth, setCommitDiffPanelWidth] =
 		useState(readStoredAsideWidth);
+	// Which edge every panel attaches to. Owned here rather than inside
+	// `Aside`, because the row below turns into a column for a bottom dock and
+	// a component cannot style its own parent.
+	const [asideDock, setAsideDock] = useAsideDock();
 	// The ticket detail Commits tab's commit list, fetched on selection so the
 	// tab can show its count up front. Reset per selected issue, like
 	// issueDetail below.
@@ -1591,6 +1596,7 @@ export const App = () => {
 				<div
 					style={{
 						display: 'flex',
+						flexDirection: asideDock === 'bottom' ? 'column' : 'row',
 						flex: 1,
 						overflow: 'hidden',
 						// A fullscreen panel is positioned against this row.
@@ -1736,10 +1742,14 @@ export const App = () => {
 							open/closed so the board doesn't bounce back when scrolled far
 							right. Reads the panel's persisted width directly rather than
 							tracking it live: the panel — and any drag — isn't mounted while
-							this spacer is, so the last-persisted value is always current. */}
-							{!commitDiff && !(selectedIssue && state?.user) && (
-								<div style={{width: readStoredAsideWidth(), flexShrink: 0}} />
-							)}
+							this spacer is, so the last-persisted value is always current.
+							Only for a side dock: a bottom panel takes height, not width, so
+							reserving width for it would shove the board the other way. */}
+							{asideDock === 'right' &&
+								!commitDiff &&
+								!(selectedIssue && state?.user) && (
+									<div style={{width: readStoredAsideWidth(), flexShrink: 0}} />
+								)}
 
 							{/* The page's right margin, scrolling with the columns. Constant,
 							so it cancels out of the invariant above. */}
@@ -1748,7 +1758,7 @@ export const App = () => {
 					</main>
 
 					{commitDiff && (
-						<Aside onWidthChange={setCommitDiffPanelWidth}>
+						<Aside dock={asideDock} onWidthChange={setCommitDiffPanelWidth}>
 							{({isFullscreen, toggleFullscreen}) => (
 								<DiffPanel
 									sha={commitDiff.sha}
@@ -1763,6 +1773,8 @@ export const App = () => {
 									onClose={closeCommitDiff}
 									isFullscreen={isFullscreen}
 									toggleFullscreen={toggleFullscreen}
+									dock={asideDock}
+									onDock={setAsideDock}
 								/>
 							)}
 						</Aside>
@@ -1770,6 +1782,7 @@ export const App = () => {
 
 					{!commitDiff && pickedIssues.length > 1 && (
 						<BulkDetails
+							dock={asideDock}
 							issues={pickedIssues}
 							knownTags={state?.tags ?? []}
 							knownAssignees={contributors}
@@ -1811,6 +1824,8 @@ export const App = () => {
 						selectedIssue &&
 						state?.user && (
 							<IssueDetails
+								dock={asideDock}
+								onDock={setAsideDock}
 								whoAmI={state.user}
 								issue={((): GuiIssue => {
 									const base =

--- a/source/gui/client/components/Aside.tsx
+++ b/source/gui/client/components/Aside.tsx
@@ -6,6 +6,7 @@ import React, {
 	useRef,
 	useState,
 } from 'react';
+import {AsideDock} from '../lib/aside-dock';
 import {GUI_THEME} from '../lib/gui-theme';
 
 export const ASIDE_WIDTH = 440;
@@ -14,7 +15,12 @@ const MIN_ASIDE_WIDTH = 380;
 // Clamped against the live window width too (see handlePointerMove) — this is
 // just a sane ceiling on an unusually wide monitor.
 const MAX_ASIDE_WIDTH = 1400;
-const MAX_ASIDE_WIDTH_RATIO = 0.9;
+const MAX_ASIDE_RATIO = 0.9;
+
+// Docked to the bottom the panel is window-wide, so it needs far less of its
+// own axis than a side panel does to be worth opening.
+export const ASIDE_HEIGHT = 380;
+const MIN_ASIDE_HEIGHT = 160;
 
 // Below this, a diff's before/after columns don't have room to stay legible
 // side by side; above it, they do. Exported so DiffPanel picks the same
@@ -22,6 +28,9 @@ const MAX_ASIDE_WIDTH_RATIO = 0.9;
 export const STACKED_DIFF_WIDTH = 760;
 
 const WIDTH_STORAGE_KEY = 'epiq.aside.width';
+// Kept apart from the width on purpose: switching sides and back should give
+// you the size you had on that side, which one shared number cannot do.
+const HEIGHT_STORAGE_KEY = 'epiq.aside.height';
 
 export const readStoredAsideWidth = (): number => {
 	const stored = Number(localStorage.getItem(WIDTH_STORAGE_KEY));
@@ -31,6 +40,17 @@ export const readStoredAsideWidth = (): number => {
 		stored <= MAX_ASIDE_WIDTH
 		? stored
 		: ASIDE_WIDTH;
+};
+
+// No upper bound here: the ceiling is the board row's live height, which this
+// cannot see. The drag clamps against it, so a stored value can only ever be
+// one a drag already allowed.
+export const readStoredAsideHeight = (): number => {
+	const stored = Number(localStorage.getItem(HEIGHT_STORAGE_KEY));
+
+	return Number.isFinite(stored) && stored >= MIN_ASIDE_HEIGHT
+		? stored
+		: ASIDE_HEIGHT;
 };
 
 export type AsideRenderApi = {
@@ -43,51 +63,71 @@ export const Aside = forwardRef<
 	{
 		children: React.ReactNode | ((api: AsideRenderApi) => React.ReactNode);
 		onWidthChange?: (width: number) => void;
+		dock?: AsideDock;
 	}
->(({children, onWidthChange}, ref) => {
+>(({children, onWidthChange, dock = 'right'}, ref) => {
 	const [width, setWidth] = useState(readStoredAsideWidth);
+	const [height, setHeight] = useState(readStoredAsideHeight);
 	const [handleHovered, setHandleHovered] = useState(false);
 	const [isFullscreen, setIsFullscreen] = useState(false);
-	// Mirrors `width` synchronously: handlePointerMove/handleDragEnd are
+	const bottom = dock === 'bottom';
+
+	// Mirrors the sizes synchronously: handlePointerMove/handleDragEnd are
 	// memoized once (empty deps, so the pointermove/pointerup listeners stay
-	// stable across renders) and would otherwise close over a stale `width`
+	// stable across renders) and would otherwise close over a stale size
 	// from whichever render first attached them.
-	const latestWidth = useRef(width);
-	const dragStart = useRef<{pointerX: number; width: number} | null>(null);
+	const latestSize = useRef({width, height});
+	// `max` is measured once, at the moment the drag starts: the ceiling is the
+	// board row, whose height moves when the scrubber collapses, so reading it
+	// then is both cheaper and more accurate than any stored figure.
+	const dragStart = useRef<{
+		pointer: number;
+		size: number;
+		bottom: boolean;
+		max: number;
+	} | null>(null);
 	// The width to come back to on un-maximizing — not persisted, since
 	// fullscreen itself is a transient view toggle, not a stored preference.
 	const preFullscreenWidth = useRef<number | null>(null);
 
 	useEffect(() => {
-		latestWidth.current = width;
-	}, [width]);
+		latestSize.current = {width, height};
+	}, [width, height]);
 
 	const handlePointerMove = useCallback((event: PointerEvent) => {
-		if (!dragStart.current) return;
+		const start = dragStart.current;
+		if (!start) return;
 
-		// The panel is on the right edge of the screen; dragging the handle
-		// left (negative clientX delta) is what grows it.
-		const delta = dragStart.current.pointerX - event.clientX;
-		const maxWidth = Math.min(
-			MAX_ASIDE_WIDTH,
-			window.innerWidth * MAX_ASIDE_WIDTH_RATIO,
-		);
+		// The panel is on the far edge either way, so the handle travels toward
+		// the middle of the screen to grow it: left when docked right, up when
+		// docked bottom. Same sign, different axis.
+		const delta = start.bottom
+			? start.pointer - event.clientY
+			: start.pointer - event.clientX;
 
-		setWidth(
-			Math.min(
-				maxWidth,
-				Math.max(MIN_ASIDE_WIDTH, dragStart.current.width + delta),
+		const next = Math.min(
+			start.max,
+			Math.max(
+				start.bottom ? MIN_ASIDE_HEIGHT : MIN_ASIDE_WIDTH,
+				start.size + delta,
 			),
 		);
+
+		if (start.bottom) setHeight(next);
+		else setWidth(next);
 	}, []);
 
 	const handleDragEnd = useCallback(() => {
+		const wasBottom = dragStart.current?.bottom ?? false;
 		dragStart.current = null;
 		document.removeEventListener('pointermove', handlePointerMove);
 		document.removeEventListener('pointerup', handleDragEnd);
 		document.body.style.cursor = '';
 		document.body.style.userSelect = '';
-		localStorage.setItem(WIDTH_STORAGE_KEY, String(latestWidth.current));
+		localStorage.setItem(
+			wasBottom ? HEIGHT_STORAGE_KEY : WIDTH_STORAGE_KEY,
+			String(wasBottom ? latestSize.current.height : latestSize.current.width),
+		);
 	}, [handlePointerMove]);
 
 	// A drag left in progress when the panel unmounts (e.g. closing it mid-drag)
@@ -101,14 +141,30 @@ export const Aside = forwardRef<
 
 	const handlePointerDown = (event: React.PointerEvent) => {
 		event.preventDefault();
-		// A manual resize is a clear signal the user wants a specific width,
+		// A manual resize is a clear signal the user wants a specific size,
 		// not the fullscreen one — drop out of fullscreen first so the drag
-		// starts from the panel's normal (pre-fullscreen) width.
+		// starts from the panel's normal (pre-fullscreen) size.
 		if (isFullscreen) setIsFullscreen(false);
-		dragStart.current = {pointerX: event.clientX, width};
+
+		// handle -> aside -> the row holding the board and this panel. That row
+		// is exactly the space between the timeline and the bottom of the
+		// window, so it is the ceiling for a bottom dock without anyone having
+		// to know the header's or the scrubber's height.
+		const row = event.currentTarget.parentElement?.parentElement;
+		const rowSize = row?.getBoundingClientRect();
+
+		dragStart.current = {
+			pointer: bottom ? event.clientY : event.clientX,
+			size: bottom ? height : width,
+			bottom,
+			max: bottom
+				? (rowSize?.height ?? window.innerHeight) * MAX_ASIDE_RATIO
+				: Math.min(MAX_ASIDE_WIDTH, window.innerWidth * MAX_ASIDE_RATIO),
+		};
+
 		document.addEventListener('pointermove', handlePointerMove);
 		document.addEventListener('pointerup', handleDragEnd);
-		document.body.style.cursor = 'ew-resize';
+		document.body.style.cursor = bottom ? 'ns-resize' : 'ew-resize';
 		document.body.style.userSelect = 'none';
 	};
 
@@ -118,7 +174,7 @@ export const Aside = forwardRef<
 				setWidth(preFullscreenWidth.current ?? readStoredAsideWidth());
 				preFullscreenWidth.current = null;
 			} else {
-				preFullscreenWidth.current = latestWidth.current;
+				preFullscreenWidth.current = latestSize.current.width;
 			}
 			return !prev;
 		});
@@ -127,28 +183,29 @@ export const Aside = forwardRef<
 	// window.innerWidth is only read at render time, so without this the panel
 	// would stay pinned to whatever width the browser happened to be when
 	// fullscreen was toggled on, ignoring a resize of the window itself while
-	// it's active.
+	// it's active. Tracked for a bottom dock too, which is window-wide by
+	// construction rather than by its own stored size.
 	const [windowWidth, setWindowWidth] = useState(() => window.innerWidth);
 
 	useEffect(() => {
-		if (!isFullscreen) return;
+		if (!isFullscreen && !bottom) return;
 
 		setWindowWidth(window.innerWidth);
 		const onResize = () => setWindowWidth(window.innerWidth);
 		window.addEventListener('resize', onResize);
 		return () => window.removeEventListener('resize', onResize);
-	}, [isFullscreen]);
+	}, [isFullscreen, bottom]);
 
-	const effectiveWidth = isFullscreen ? windowWidth : width;
+	const effectiveWidth = isFullscreen || bottom ? windowWidth : width;
 
-	// Reports the width the panel is actually drawn at — in fullscreen the
-	// window's, not the stored one — so layout decisions track what is on
-	// screen. Fires on mount too, not just on drag, so a caller that only
-	// reads this (rather than also calling readStoredAsideWidth itself) sees
-	// the persisted width immediately. A layout effect so the caller's
-	// re-render lands before the browser paints: a passive effect would let
-	// a frame through with the panel at its new width but the content still
-	// laid out for the old one.
+	// Reports the width the panel is actually drawn at — in fullscreen or
+	// docked to the bottom the window's, not the stored one — so layout
+	// decisions track what is on screen. Fires on mount too, not just on drag,
+	// so a caller that only reads this (rather than also calling
+	// readStoredAsideWidth itself) sees the persisted width immediately. A
+	// layout effect so the caller's re-render lands before the browser paints:
+	// a passive effect would let a frame through with the panel at its new
+	// width but the content still laid out for the old one.
 	useLayoutEffect(() => {
 		onWidthChange?.(effectiveWidth);
 	}, [effectiveWidth]);
@@ -164,8 +221,14 @@ export const Aside = forwardRef<
 				// on the right. Overlaying also leaves the board's scroll alone.
 				...(isFullscreen
 					? {position: 'absolute', top: 0, right: 0, bottom: 0, left: 0}
+					: bottom
+					? {position: 'relative', height, minHeight: height}
 					: {position: 'relative', width, minWidth: width}),
-				borderLeft: `1px solid ${GUI_THEME.line}`,
+				// The border faces the board, which is above it in one dock and
+				// beside it in the other.
+				...(bottom && !isFullscreen
+					? {borderTop: `1px solid ${GUI_THEME.line}`}
+					: {borderLeft: `1px solid ${GUI_THEME.line}`}),
 				background: GUI_THEME.panel,
 				padding: ASIDE_PADDING,
 				fontSize: 12,
@@ -183,21 +246,34 @@ export const Aside = forwardRef<
 				title="Drag to resize"
 				style={{
 					position: 'absolute',
-					left: 0,
-					top: 0,
-					bottom: 0,
-					width: 12,
-					marginLeft: -6,
-					cursor: 'ew-resize',
 					zIndex: 1,
 					display: 'flex',
-					justifyContent: 'center',
+					...(bottom
+						? {
+								top: 0,
+								left: 0,
+								right: 0,
+								height: 12,
+								marginTop: -6,
+								cursor: 'ns-resize',
+								alignItems: 'center',
+						  }
+						: {
+								left: 0,
+								top: 0,
+								bottom: 0,
+								width: 12,
+								marginLeft: -6,
+								cursor: 'ew-resize',
+								justifyContent: 'center',
+						  }),
 				}}
 			>
 				<div
 					style={{
-						width: 2,
-						alignSelf: 'stretch',
+						...(bottom
+							? {height: 2, width: '100%'}
+							: {width: 2, alignSelf: 'stretch'}),
 						background:
 							handleHovered || dragStart.current
 								? GUI_THEME.accent

--- a/source/gui/client/components/BulkDetails.tsx
+++ b/source/gui/client/components/BulkDetails.tsx
@@ -1,6 +1,7 @@
 import {GuiContributor, GuiIssue, GuiTag} from '../lib/gui-state.model';
 import {GUI_THEME} from '../lib/gui-theme';
 import {Aside} from './Aside';
+import {AsideDock} from '../lib/aside-dock';
 import {Button} from './Button';
 import {ChipRow, Empty, Input, AddRow} from './FormPrimitives';
 import {Section} from './Section';
@@ -27,6 +28,7 @@ const ticketWord = (count: number): string =>
 	count === 1 ? 'ticket' : 'tickets';
 
 export const BulkDetails = ({
+	dock,
 	issues,
 	knownTags,
 	knownAssignees,
@@ -42,6 +44,7 @@ export const BulkDetails = ({
 	onReopenIssues,
 	onClear,
 }: {
+	dock: AsideDock;
 	issues: GuiIssue[];
 	knownTags: GuiTag[];
 	knownAssignees: GuiContributor[];
@@ -78,7 +81,7 @@ export const BulkDetails = ({
 		count === total ? '' : ` ${count}/${total}`;
 
 	return (
-		<Aside>
+		<Aside dock={dock}>
 			<div
 				style={{
 					display: 'flex',

--- a/source/gui/client/components/DiffPanel.tsx
+++ b/source/gui/client/components/DiffPanel.tsx
@@ -13,6 +13,8 @@ import {CopyShaButton} from './CopyShaButton';
 import {Empty} from './FormPrimitives';
 import {FormHeader} from './FormHeader';
 import {FullscreenToggleButton} from './FullscreenToggleButton';
+import {PanelDockMenu} from './PanelDockMenu';
+import {AsideDock} from '../lib/aside-dock';
 
 // A single dark theme: the app has no light mode to match (GUI_THEME is a
 // fixed dark palette), so there is no pair to switch between.
@@ -92,6 +94,8 @@ export const DiffPanel = ({
 	onClose,
 	isFullscreen,
 	toggleFullscreen,
+	dock,
+	onDock,
 }: {
 	sha: string;
 	files: GuiCommitDiffFile[] | null;
@@ -101,6 +105,8 @@ export const DiffPanel = ({
 	onClose: () => void;
 	isFullscreen: boolean;
 	toggleFullscreen: () => void;
+	dock: AsideDock;
+	onDock: (next: AsideDock) => void;
 }) => (
 	<>
 		<FormHeader>
@@ -117,6 +123,7 @@ export const DiffPanel = ({
 
 			<div style={{display: 'flex', alignItems: 'center', gap: 2}}>
 				<CopyShaButton sha={sha} />
+				<PanelDockMenu dock={dock} onDock={onDock} />
 				<FullscreenToggleButton
 					isFullscreen={isFullscreen}
 					onClick={toggleFullscreen}

--- a/source/gui/client/components/DockButtons.tsx
+++ b/source/gui/client/components/DockButtons.tsx
@@ -1,0 +1,77 @@
+import {useState} from 'react';
+import {AsideDock} from '../lib/aside-dock';
+import {GUI_THEME} from '../lib/gui-theme';
+import {IconDockBottom} from './IconDockBottom';
+import {IconDockRight} from './IconDockRight';
+
+const DockButton = ({
+	label,
+	active,
+	icon,
+	onClick,
+}: {
+	label: string;
+	active: boolean;
+	icon: React.ReactNode;
+	onClick: () => void;
+}) => {
+	const [hovered, setHovered] = useState(false);
+
+	return (
+		<button
+			type="button"
+			aria-label={label}
+			aria-pressed={active}
+			title={label}
+			onClick={onClick}
+			onMouseEnter={() => setHovered(true)}
+			onMouseLeave={() => setHovered(false)}
+			style={{
+				display: 'inline-flex',
+				alignItems: 'center',
+				flexShrink: 0,
+				border: 'none',
+				padding: 4,
+				borderRadius: 4,
+				cursor: 'pointer',
+				// The selected side is lit rather than boxed: one accent mark in a
+				// row of dim ones says which it is without adding a frame the rest
+				// of this header does not have.
+				color: active ? GUI_THEME.accent : GUI_THEME.dim,
+				background:
+					active || hovered ? 'rgba(255,255,255,0.04)' : 'transparent',
+				transition: 'color 120ms ease, background 120ms ease',
+			}}
+		>
+			{icon}
+		</button>
+	);
+};
+
+/**
+ * Which edge the panel is attached to, as the pair of states rather than a
+ * toggle: devtools shows both choices at once, and the one that is lit is the
+ * answer to "where is it now" without having to click to find out.
+ */
+export const DockButtons = ({
+	dock,
+	onDock,
+}: {
+	dock: AsideDock;
+	onDock: (next: AsideDock) => void;
+}) => (
+	<>
+		<DockButton
+			label="Dock to bottom"
+			active={dock === 'bottom'}
+			icon={<IconDockBottom size={12} />}
+			onClick={() => onDock('bottom')}
+		/>
+		<DockButton
+			label="Dock to right"
+			active={dock === 'right'}
+			icon={<IconDockRight size={12} />}
+			onClick={() => onDock('right')}
+		/>
+	</>
+);

--- a/source/gui/client/components/IconDockBottom.tsx
+++ b/source/gui/client/components/IconDockBottom.tsx
@@ -1,0 +1,19 @@
+// A pane attached to the bottom edge, the way devtools draws its dock choices:
+// the frame, and one divider showing where the panel sits. Two marks only —
+// anything finer closes up at the 12px these render at.
+export const IconDockBottom = ({size = 16}: {size?: number}) => (
+	<svg
+		width={size}
+		height={size}
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		strokeWidth="2"
+		strokeLinecap="round"
+		strokeLinejoin="round"
+		aria-hidden="true"
+	>
+		<rect x="3" y="4" width="18" height="16" rx="2" />
+		<line x1="3" y1="14" x2="21" y2="14" />
+	</svg>
+);

--- a/source/gui/client/components/IconDockRight.tsx
+++ b/source/gui/client/components/IconDockRight.tsx
@@ -1,0 +1,17 @@
+// The mirror of IconDockBottom: the panel attached to the right edge.
+export const IconDockRight = ({size = 16}: {size?: number}) => (
+	<svg
+		width={size}
+		height={size}
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		strokeWidth="2"
+		strokeLinecap="round"
+		strokeLinejoin="round"
+		aria-hidden="true"
+	>
+		<rect x="3" y="4" width="18" height="16" rx="2" />
+		<line x1="14" y1="4" x2="14" y2="20" />
+	</svg>
+);

--- a/source/gui/client/components/IssueDetails.tsx
+++ b/source/gui/client/components/IssueDetails.tsx
@@ -22,6 +22,7 @@ import {ManageTagsModal} from './ManageTagsModal';
 import {CopyRef} from './CopyRef';
 import {FormHeader} from './FormHeader';
 import {FullscreenToggleButton} from './FullscreenToggleButton';
+import {PanelDockMenu} from './PanelDockMenu';
 import {IconCollapseLane} from './IconCollapseLane';
 import {IconExpandLane} from './IconExpandLane';
 import {
@@ -48,6 +49,7 @@ import {Tabs, TabItem} from './Tabs';
 import {IssueHistory} from './IssueHistory';
 import {formatAbsolute, timeAgo} from '../lib/gui-format.helper';
 import {usePersistedFlag} from '../lib/scrubber';
+import {AsideDock} from '../lib/aside-dock';
 import {MAX_DESCRIPTION_LENGTH} from '../../../lib/utils/text.limits.js';
 import {useImageInsert} from '../lib/image-insert';
 import {AddImageButton} from './AddImageButton';
@@ -236,6 +238,8 @@ const Lane = ({
 };
 
 export const IssueDetails = ({
+	dock,
+	onDock,
 	whoAmI,
 	comments,
 	history,
@@ -274,6 +278,8 @@ export const IssueDetails = ({
 	knownAssignees: assignees,
 	onOpenAssigneePicker,
 }: {
+	dock: AsideDock;
+	onDock: (next: AsideDock) => void;
 	whoAmI: GuiUser;
 	issue: GuiIssue | null;
 	comments: GuiComment[];
@@ -490,9 +496,14 @@ export const IssueDetails = ({
 		);
 
 	return (
-		<Aside ref={panelRef} onWidthChange={setPanelWidth}>
+		<Aside ref={panelRef} dock={dock} onWidthChange={setPanelWidth}>
 			{({isFullscreen, toggleFullscreen}) => {
-				const laneView = isFullscreen && panelWidth >= LANE_VIEW_WIDTH;
+				// Docked to the bottom the panel already spans the window, so it earns
+				// the lanes without fullscreen. Not width alone: MAX_ASIDE_WIDTH and
+				// LANE_VIEW_WIDTH are both 1400, so a side panel dragged to its limit
+				// would otherwise flip into lanes on the last pixel.
+				const laneView =
+					(isFullscreen || dock === 'bottom') && panelWidth >= LANE_VIEW_WIDTH;
 
 				// A collapsed lane costs a fixed rail; the rest of the width is split
 				// between the lanes still open, so the diff actually receives what
@@ -947,6 +958,7 @@ export const IssueDetails = ({
 									</div>
 
 									<div style={{display: 'flex', alignItems: 'center', gap: 2}}>
+										<PanelDockMenu dock={dock} onDock={onDock} />
 										<FullscreenToggleButton
 											isFullscreen={isFullscreen}
 											onClick={toggleFullscreen}

--- a/source/gui/client/components/KebabMenu.tsx
+++ b/source/gui/client/components/KebabMenu.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useRef, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import {GUI_THEME} from '../lib/gui-theme';
 
 export type KebabMenuItem = {
@@ -10,11 +10,18 @@ export type KebabMenuItem = {
 };
 
 export const KebabMenu = ({
-	items,
+	items = [],
 	testId,
+	title = 'Actions',
+	children,
 }: {
-	items: KebabMenuItem[];
+	items?: KebabMenuItem[];
 	testId?: string;
+	title?: string;
+	// Rendered above the items, for a menu whose contents are a control rather
+	// than a list of commands. Handed the same close the items get, so choosing
+	// inside it dismisses the menu and shows what it did.
+	children?: (close: () => void) => React.ReactNode;
 }) => {
 	const [open, setOpen] = useState(false);
 	const [hovered, setHovered] = useState(false);
@@ -47,7 +54,7 @@ export const KebabMenu = ({
 			<button
 				type="button"
 				data-testid={testId}
-				title="Swimlane actions"
+				title={title}
 				aria-haspopup="menu"
 				aria-expanded={open}
 				onClick={() => setOpen(value => !value)}
@@ -90,6 +97,8 @@ export const KebabMenu = ({
 						zIndex: 20,
 					}}
 				>
+					{children?.(() => setOpen(false))}
+
 					{items.map(item => (
 						<MenuItem
 							key={item.id}

--- a/source/gui/client/components/PanelDockMenu.tsx
+++ b/source/gui/client/components/PanelDockMenu.tsx
@@ -1,0 +1,55 @@
+import {AsideDock} from '../lib/aside-dock';
+import {GUI_THEME, TEXT} from '../lib/gui-theme';
+import {DockButtons} from './DockButtons';
+import {KebabMenu} from './KebabMenu';
+
+/**
+ * Where the panel attaches, tucked behind the header's kebab.
+ *
+ * Out of the header proper on purpose: it is a preference set once, and the
+ * row beside the close button is for things you reach for every ticket. Inside
+ * the menu it still shows both sides at once, so the lit one answers "where is
+ * it now" without a click.
+ */
+export const PanelDockMenu = ({
+	dock,
+	onDock,
+}: {
+	dock: AsideDock;
+	onDock: (next: AsideDock) => void;
+}) => (
+	<KebabMenu testId="panel-menu" title="Panel options">
+		{close => (
+			<div
+				style={{
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'space-between',
+					gap: 12,
+					padding: '4px 6px',
+				}}
+			>
+				<span
+					style={{
+						color: GUI_THEME.secondary,
+						fontSize: TEXT.label,
+						textTransform: 'uppercase',
+						letterSpacing: '0.08em',
+					}}
+				>
+					Dock
+				</span>
+
+				<span style={{display: 'inline-flex', gap: 2}}>
+					<DockButtons
+						dock={dock}
+						onDock={next => {
+							onDock(next);
+							close();
+						}}
+					/>
+				</span>
+			</div>
+		)}
+	</KebabMenu>
+);

--- a/source/gui/client/components/SwimlaneColumn.tsx
+++ b/source/gui/client/components/SwimlaneColumn.tsx
@@ -228,6 +228,7 @@ export const SwimlaneColumn = ({
 					{!swimlane.readonly && (
 						<KebabMenu
 							testId="swimlane-menu"
+							title="Swimlane actions"
 							items={[
 								{
 									id: 'rename',

--- a/source/gui/client/lib/aside-dock.ts
+++ b/source/gui/client/lib/aside-dock.ts
@@ -1,0 +1,31 @@
+import {useState} from 'react';
+
+/**
+ * Which edge the detail panel is attached to.
+ *
+ * This lives outside `Aside` because the flex row that holds the board and the
+ * panel has to turn into a column for a bottom dock, and a component cannot
+ * style its own parent. `App` owns the state and hands it down; `Aside` only
+ * reads it.
+ */
+export type AsideDock = 'right' | 'bottom';
+
+const DOCK_STORAGE_KEY = 'epiq.aside.dock';
+
+export const readStoredAsideDock = (): AsideDock =>
+	localStorage.getItem(DOCK_STORAGE_KEY) === 'bottom' ? 'bottom' : 'right';
+
+// Read synchronously in the initializer, like the panel's width: the lanes
+// layout is decided on the first render, and an effect would let a frame
+// through with the panel docked one way and its contents laid out the other.
+export const useAsideDock = (): [AsideDock, (next: AsideDock) => void] => {
+	const [dock, setDock] = useState(readStoredAsideDock);
+
+	return [
+		dock,
+		(next: AsideDock) => {
+			setDock(next);
+			localStorage.setItem(DOCK_STORAGE_KEY, next);
+		},
+	];
+};

--- a/source/test/e2e-gui/aside-dock.pw.ts
+++ b/source/test/e2e-gui/aside-dock.pw.ts
@@ -1,0 +1,132 @@
+import type {Page} from '@playwright/test';
+import {expect, test} from './fixtures.js';
+
+// Wide enough that a bottom dock earns the lanes without fullscreen.
+test.use({viewport: {width: 1600, height: 900}});
+
+const openTicket = async (page: Page, appUrl: string) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	await page.getByTitle('Add issue').first().click();
+	await page.getByPlaceholder('issue name').fill(`Dock ${Date.now()}`);
+	await page.getByPlaceholder('issue name').press('Enter');
+	await expect(page.locator('aside')).toBeVisible();
+};
+
+const dockTo = async (page: Page, side: 'bottom' | 'right') => {
+	await page.getByTestId('panel-menu').click();
+	await page.getByRole('button', {name: `Dock to ${side}`}).click();
+};
+
+// Passed as a source string, not a closure: the root tsconfig has no DOM lib.
+const edges = (page: Page) =>
+	page.evaluate<{
+		asideTop: number;
+		asideLeft: number;
+		mainBottom: number;
+		mainRight: number;
+	}>(`
+		(() => {
+			const main = document.querySelector('main');
+			const aside = document.querySelector('aside');
+			const m = main.getBoundingClientRect();
+			const a = aside.getBoundingClientRect();
+
+			return {
+				asideTop: Math.round(a.top),
+				asideLeft: Math.round(a.left),
+				mainBottom: Math.round(m.bottom),
+				mainRight: Math.round(m.right),
+			};
+		})()
+	`);
+
+test('the panel moves under the board and back beside it', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await openTicket(page, appUrl);
+
+	// Docked right: the board ends where the panel begins, horizontally.
+	const beside = await edges(page);
+	expect(beside.mainRight).toBe(beside.asideLeft);
+
+	await dockTo(page, 'bottom');
+
+	// Docked bottom: the same seam, rotated. The board now runs full width.
+	await expect.poll(async () => (await edges(page)).asideLeft).toBe(0);
+	const under = await edges(page);
+	expect(under.mainBottom).toBe(under.asideTop);
+
+	await dockTo(page, 'right');
+	await expect
+		.poll(async () => (await edges(page)).asideLeft)
+		.toBeGreaterThan(0);
+
+	expect(pageErrors).toEqual([]);
+});
+
+// The lanes are about how wide the panel is, and a bottom dock is window-wide
+// by construction — so it earns them without going fullscreen first.
+test('a bottom dock shows the lanes without fullscreen', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await openTicket(page, appUrl);
+
+	await expect(page.getByTestId('lane-overview')).toHaveCount(0);
+
+	await dockTo(page, 'bottom');
+
+	await expect(page.getByTestId('lane-overview')).toBeVisible();
+	await expect(page.getByTestId('lane-commits')).toBeVisible();
+
+	expect(pageErrors).toEqual([]);
+});
+
+test('the dock side survives a reload', async ({page, appUrl, pageErrors}) => {
+	await openTicket(page, appUrl);
+	await dockTo(page, 'bottom');
+	await expect(page.getByTestId('lane-overview')).toBeVisible();
+
+	await page.reload();
+	await expect(page.locator('aside')).toBeVisible();
+
+	await expect.poll(async () => (await edges(page)).asideLeft).toBe(0);
+
+	expect(pageErrors).toEqual([]);
+});
+
+// Docked bottom the handle moves to the top edge and the drag runs vertically:
+// dragging it up toward the timeline is what grows the panel.
+test('a bottom dock resizes vertically from its top edge', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await openTicket(page, appUrl);
+	await dockTo(page, 'bottom');
+	await expect(page.getByTestId('lane-overview')).toBeVisible();
+
+	const before = await page.locator('aside').boundingBox();
+	if (!before) throw new Error('panel is not on screen');
+
+	await page.mouse.move(800, before.y + 1);
+	await page.mouse.down();
+	await page.mouse.move(800, before.y - 150, {steps: 12});
+	await page.mouse.up();
+
+	const after = await page.locator('aside').boundingBox();
+	if (!after) throw new Error('panel is not on screen');
+
+	expect(after.height).toBeGreaterThan(before.height + 100);
+	// It grew upward into the board rather than downward off the window.
+	expect(Math.round(after.y + after.height)).toBe(
+		Math.round(before.y + before.height),
+	);
+
+	expect(pageErrors).toEqual([]);
+});


### PR DESCRIPTION
Closes W1666PB.

The panel can now attach to the bottom edge, devtools style. Docked bottom it spans the window, resizes vertically from its top edge, and shows the lanes without needing fullscreen — which is what the extra width is for.

**The dock lives in App, not in `Aside`.** The row holding the board and the panel has to become a `flexDirection: column`, and a component cannot style its own parent. `App` owns the preference (`epiq.aside.dock`) and hands it down; `Aside` only reads it.

**Sizes are per side.** `epiq.aside.width` and `epiq.aside.height` are separate keys, so switching sides and back restores the size you had on that side. One shared number cannot do that.

**The height ceiling is measured, not calculated.** The scrubber is collapsible and its height also varies with `layoutMode`, so `window.innerHeight − header − scrubber` would be stale the moment either changed. The drag reads the board row's own `getBoundingClientRect()` at pointer-down instead — that row *is* the space between the timeline and the bottom of the window.

**The board spacer is now side-specific.** It exists to keep `scrollWidth − clientWidth` constant so the board does not bounce when the panel closes. A bottom panel takes height rather than width, so reserving width for it would shove the board the other way; it is skipped while docked bottom.

**`laneView` gains the dock, not width alone.** `(isFullscreen || dock === 'bottom') && panelWidth >= LANE_VIEW_WIDTH`. Width alone would be tidier but `MAX_ASIDE_WIDTH` and `LANE_VIEW_WIDTH` are both 1400, so a side panel dragged to its limit would flip into lanes on the last pixel.

**UI:** a kebab in the panel header holds a `DOCK` row with both sides shown at once, the current one lit in accent — so it answers "where is it now" without a click. Choosing closes the menu, matching every other menu here and revealing the change behind it. `KebabMenu` gained an optional `title` and render-prop `children` for this; the swimlane menu passes its old title explicitly and is unchanged.

Tests: `aside-dock.pw.ts` covers the seam moving from `main.right === aside.left` to `main.bottom === aside.top` and back, lanes without fullscreen, persistence across a reload, and the vertical drag growing the panel upward. The existing `board-gutter`, `aside-stacking`, `fullscreen-lanes`, `lane-collapse` and `swimlane-menu` suites all still pass — the dock defaults to `right`, which is what keeps their geometry assertions valid.

Full pre-push gate green.