### PR TITLE
5RYVN23 check the board out at a log row

### DIFF
--- a/source/gui/api/lib/websocket.model.ts
+++ b/source/gui/api/lib/websocket.model.ts
@@ -80,6 +80,7 @@ export type GuiMessage =
 			};
 	  }
 	| {type: 'time-travel:scrub'; payload: {targetTime: number}}
+	| {type: 'time-travel:checkout-event'; payload: {eventId: string}}
 	| {type: 'time-travel:live'}
 	| {
 			type: 'commits:get';

--- a/source/gui/api/lib/websocket.schema.ts
+++ b/source/gui/api/lib/websocket.schema.ts
@@ -114,6 +114,7 @@ export const GuiMessageSchema = z.discriminatedUnion('type', [
 			.optional(),
 	}),
 	message('time-travel:scrub', z.object({targetTime: epochMs})),
+	message('time-travel:checkout-event', z.object({eventId: z.string().min(1)})),
 	message('commit:inspect', z.object({sha: z.string()})),
 	message('commit:diff:get', z.object({sha: z.string()})),
 	message('issue:commits:get', z.object({issueId: id})),

--- a/source/gui/api/lib/websocket.ts
+++ b/source/gui/api/lib/websocket.ts
@@ -29,6 +29,7 @@ import {
 } from '../../../mcp/epiq-api.js';
 import {
 	checkoutStateAt,
+	checkoutStateAtEvent,
 	getCommitDiff,
 	getCommitsForRef,
 	getCommitTimeline,
@@ -256,6 +257,22 @@ export const setupWebsocket = (
 					const result = await checkoutStateAt({
 						repoRoot,
 						targetTime: message.payload.targetTime,
+					});
+
+					sendSocket(socket, {
+						type: 'time-travel:result',
+						payload: result,
+					});
+
+					if (isFail(result)) return;
+
+					return broadcastDerivedState();
+				}
+
+				if (type === 'time-travel:checkout-event') {
+					const result = await checkoutStateAtEvent({
+						repoRoot,
+						eventId: message.payload.eventId,
 					});
 
 					sendSocket(socket, {

--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -1057,6 +1057,13 @@ export const App = () => {
 		send('time-travel:scrub', {targetTime});
 	};
 
+	// Checks the board out at the moment one Log row stands for. The event is
+	// named rather than timed: the server resolves the cut, so a row's displayed
+	// timestamp never has to agree with the log's own ordering.
+	const checkoutHistoryEvent = (eventId: string) => {
+		send('time-travel:checkout-event', {eventId});
+	};
+
 	const returnToLive = () => {
 		send('time-travel:live', {});
 	};
@@ -1832,6 +1839,9 @@ export const App = () => {
 										: []
 								}
 								onHoverHistoryEvent={setHoveredLogEventId}
+								onCheckoutHistoryEvent={
+									connected ? checkoutHistoryEvent : undefined
+								}
 								onChangeTab={changeIssueDetailsTab}
 								onClose={closeIssueDetails}
 								onEditTitle={editIssueTitle}

--- a/source/gui/client/components/IssueDetails.tsx
+++ b/source/gui/client/components/IssueDetails.tsx
@@ -240,6 +240,7 @@ export const IssueDetails = ({
 	comments,
 	history,
 	onHoverHistoryEvent,
+	onCheckoutHistoryEvent,
 	activeTab,
 	onChangeTab,
 	issue,
@@ -279,6 +280,7 @@ export const IssueDetails = ({
 	comments: GuiComment[];
 	history: GuiIssueHistoryEntry[];
 	onHoverHistoryEvent: (eventId: string | null) => void;
+	onCheckoutHistoryEvent?: (eventId: string) => void;
 	onClose: () => void;
 	activeTab: IssueDetailsTab;
 	onChangeTab: (tab: IssueDetailsTab) => void;
@@ -879,7 +881,11 @@ export const IssueDetails = ({
 				);
 
 				const historyPane = issue && (
-					<IssueHistory entries={history} onHoverEvent={onHoverHistoryEvent} />
+					<IssueHistory
+						entries={history}
+						onHoverEvent={onHoverHistoryEvent}
+						onCheckoutEvent={onCheckoutHistoryEvent}
+					/>
 				);
 
 				const commitsPane = issue && (

--- a/source/gui/client/components/IssueHistory.tsx
+++ b/source/gui/client/components/IssueHistory.tsx
@@ -1,14 +1,20 @@
 import {GuiIssueHistoryEntry} from '../lib/gui-state.model';
 import {GUI_THEME, CONTENT_FONT, TEXT} from '../lib/gui-theme';
 import {formatAbsolute, timeAgo} from '../lib/gui-format.helper';
+import {Button} from './Button';
+import {IconClock} from './IconClock';
 import {User} from './User';
 
 export const IssueHistory = ({
 	entries,
 	onHoverEvent,
+	onCheckoutEvent,
 }: {
 	entries: GuiIssueHistoryEntry[];
 	onHoverEvent: (eventId: string | null) => void;
+	// Absent with the socket down: nothing can be checked out from a page that
+	// cannot ask the server for it.
+	onCheckoutEvent?: (eventId: string) => void;
 }) => {
 	if (entries.length === 0) {
 		return (
@@ -34,7 +40,7 @@ export const IssueHistory = ({
 					onMouseEnter={() => onHoverEvent(entry.id)}
 					style={{
 						display: 'flex',
-						alignItems: 'baseline',
+						alignItems: 'center',
 						gap: 14,
 						padding: '8px 0',
 						borderTop: index === 0 ? 'none' : `1px solid ${GUI_THEME.line}`,
@@ -59,6 +65,23 @@ export const IssueHistory = ({
 					>
 						{timeAgo(entry.t)}
 					</span>
+
+					{onCheckoutEvent && (
+						<Button
+							variant="ghost"
+							data-testid="issue-history-checkout"
+							aria-label={`Check out the board as it was after: ${entry.label}`}
+							title="Check out the board as it was just after this event"
+							onClick={() => onCheckoutEvent(entry.id)}
+							style={{
+								display: 'flex',
+								alignItems: 'center',
+								color: GUI_THEME.dim,
+							}}
+						>
+							<IconClock size={13} />
+						</Button>
+					)}
 				</div>
 			))}
 		</div>

--- a/source/mcp/epiq-time-travel.ts
+++ b/source/mcp/epiq-time-travel.ts
@@ -16,6 +16,7 @@ import {AppEvent, EventAction} from '../lib/event/event.model.js';
 import {formatLogAction} from '../lib/event/format-log-utils.js';
 import {getStringColor} from '../lib/utils/color.js';
 import {
+	loadEffectiveEventTimes,
 	loadMergedEvents,
 	loadMergedEventsBefore,
 } from '../lib/event/event-load.js';
@@ -980,6 +981,31 @@ export const checkoutStateAt = (
 			asOfTime: input.targetTime,
 		});
 	});
+
+// Rewinds to just after one event in the log, so the state the checkout shows
+// is the state that event produced. The cut is exclusive, hence the +1.
+//
+// Resolved against effective times, not the raw ULID a Log row displays: a
+// poisoned far-future id is judged by the clamped time `splitEventsAtTime` will
+// cut on, so the checkout lands where the scrubber's dot for it sits.
+export const checkoutStateAtEvent = async (
+	input: ToolInput & {eventId: string},
+): Promise<Result<{asOfTime: number}>> => {
+	const stateBranchRootResult = resolveStateBranchRoot(input.repoRoot);
+	if (isFail(stateBranchRootResult)) {
+		return failed(stateBranchRootResult.message);
+	}
+
+	// Deliberately outside `runExclusive`: `checkoutStateAt` takes that lock and
+	// it is not re-entrant.
+	const timesResult = loadEffectiveEventTimes(stateBranchRootResult.value);
+	if (isFail(timesResult)) return failed(timesResult.message);
+
+	const time = timesResult.value.get(input.eventId) ?? null;
+	if (time === null) return failed('Event not found in the log');
+
+	return checkoutStateAt({repoRoot: input.repoRoot, targetTime: time + 1});
+};
 
 export const returnToLive = (input: ToolInput = {}): Promise<Result<true>> =>
 	runExclusive(async () => {

--- a/source/test/e2e-gui/issue-history.pw.ts
+++ b/source/test/e2e-gui/issue-history.pw.ts
@@ -13,6 +13,20 @@ test.beforeEach(async ({page, appUrl}) => {
 	await expect(page.getByTestId('board-switcher')).toContainText('Default');
 });
 
+// The suite shares one server per worker, and a checkout parks the whole board
+// in the past. A test that fails before it resumes would hand every later test
+// on that worker a read-only board.
+test.afterEach(async ({page}) => {
+	const resume = page.getByRole('button', {name: 'Resume', exact: true});
+
+	if ((await resume.count()) > 0 && (await resume.isEnabled())) {
+		await resume.click();
+		await expect(
+			page.getByRole('button', {name: 'Now', exact: true}),
+		).toBeVisible();
+	}
+});
+
 test('the log tab lists the ticket’s own events', async ({
 	page,
 	pageErrors,
@@ -66,4 +80,72 @@ test('the log tab survives a reload on its own url', async ({page}) => {
 
 	await page.reload();
 	await expect(page.getByTestId('issue-history')).toBeVisible();
+});
+
+// The point of the button: the board it parks you on is the board that existed
+// then, so the pane beside the Log carries the description of that moment
+// rather than today's.
+test('checking out a Log row reads the description as it was then', async ({
+	page,
+	pageErrors,
+}) => {
+	const title = `Checkout ${Date.now()}`;
+	await openFirstTicket(page, title);
+
+	const aside = page.locator('aside');
+
+	// Waiting for the saved text to be on screen, not merely for the editor to
+	// shut: the broadcast a save comes back as is what closes any open editor,
+	// so reopening one before it lands is a race the loaded machine loses.
+	const editDescription = async (text: string) => {
+		await page.getByRole('button', {name: 'edit'}).first().click();
+		const box = page.getByRole('textbox').last();
+		await box.fill(text);
+		await box.press('Enter');
+		await expect(aside).toContainText(text);
+		await expect(
+			page.getByRole('button', {name: 'edit'}).first(),
+		).toBeVisible();
+	};
+
+	await editDescription('first draft');
+	await editDescription('second draft');
+
+	await page.getByRole('button', {name: /^Log/}).click();
+
+	const rows = page.getByTestId('issue-history-row');
+	// Newest first, and nothing else has touched this ticket: the second edit,
+	// the first edit, then the creation. Asserted so the index below cannot
+	// drift onto a row that means something else.
+	await expect(rows).toHaveCount(3);
+	await expect(rows.nth(0)).toContainText('Changed description');
+	await expect(rows.nth(1)).toContainText('Changed description');
+	await expect(rows.nth(2)).toContainText('Created with title');
+
+	// The older of the two edits, so the board it checks out is the one holding
+	// the draft that was later replaced.
+	await rows.nth(1).getByTestId('issue-history-checkout').click();
+
+	const resume = page.getByRole('button', {name: 'Resume', exact: true});
+	await expect(resume).toBeEnabled();
+
+	// The Log is now the log of that moment too: the edit checked out is the
+	// newest thing that had happened.
+	await expect(rows).toHaveCount(2);
+
+	// Asserted on the details pane rather than the page: the board behind it
+	// carries this ticket's title too.
+	await page.getByRole('button', {name: 'Overview'}).click();
+	// The cut lands one past the event rather than one short of it: stopping
+	// before the edit would have shown the empty description it replaced.
+	await expect(aside).toContainText('first draft');
+	await expect(aside).not.toContainText('second draft');
+
+	await resume.click();
+	await expect(
+		page.getByRole('button', {name: 'Now', exact: true}),
+	).toBeVisible();
+	await expect(aside).toContainText('second draft');
+
+	expect(pageErrors).toEqual([]);
 });

--- a/source/test/epiq-time-travel.test.ts
+++ b/source/test/epiq-time-travel.test.ts
@@ -11,6 +11,7 @@ vi.mock('../lib/storage/paths.js', () => ({
 }));
 
 vi.mock('../lib/event/event-load.js', () => ({
+	loadEffectiveEventTimes: vi.fn(),
 	loadMergedEvents: vi.fn(),
 	loadMergedEventsBefore: vi.fn(),
 	getLastUnreadableEvents: vi.fn(() => []),
@@ -73,6 +74,7 @@ import {
 } from '../lib/editor/editor.js';
 import {resolveClosestEpiqProjectRoot} from '../lib/storage/paths.js';
 import {
+	loadEffectiveEventTimes,
 	loadMergedEvents,
 	loadMergedEventsBefore,
 } from '../lib/event/event-load.js';
@@ -93,6 +95,7 @@ import {
 } from '../lib/model/result-types.js';
 import {
 	checkoutStateAt,
+	checkoutStateAtEvent,
 	FULL_TIMELINE_CACHE_TTL_MS,
 	getCommitDiff,
 	getCommitsForRef,
@@ -1465,6 +1468,80 @@ describe('epiq-time-travel', () => {
 			expect(result.message.indexOf('boom')).toBeLessThan(
 				result.message.indexOf('log unreadable'),
 			);
+		});
+	});
+
+	describe('checkoutStateAtEvent', () => {
+		beforeEach(() => {
+			vi.mocked(loadMergedEventsBefore).mockReturnValue(
+				succeeded('events', {
+					appliedEvents: [{id: 'a'}],
+					unappliedEvents: [{id: 'b'}],
+				} as never),
+			);
+		});
+
+		// The cut is exclusive, so checking out *at* the event's own time would
+		// show the state before it — the description it replaced, not the one it
+		// wrote.
+		it('cuts one millisecond after the named event, so that event is applied', async () => {
+			vi.mocked(loadEffectiveEventTimes).mockReturnValue(
+				succeeded('times', new Map([['evt-1', 5000]])),
+			);
+
+			const result = await checkoutStateAtEvent({eventId: 'evt-1'});
+
+			expect(loadMergedEventsBefore).toHaveBeenCalledWith('/repo/.epiq', 5001);
+			expect(isSuccess(result)).toBe(true);
+			if (isFail(result)) return;
+			expect(result.value.asOfTime).toBe(5001);
+		});
+
+		// The Log row displays the raw ULID time; the split judges by the
+		// effective one. Resolving here rather than on the client is what keeps a
+		// poisoned far-future id from checking out the whole log.
+		it('resolves the effective time rather than trusting a displayed one', async () => {
+			vi.mocked(loadEffectiveEventTimes).mockReturnValue(
+				succeeded('times', new Map([['poisoned', 1000]])),
+			);
+
+			await checkoutStateAtEvent({eventId: 'poisoned'});
+
+			expect(loadMergedEventsBefore).toHaveBeenCalledWith('/repo/.epiq', 1001);
+		});
+
+		it('fails without touching state when the event is not in the log', async () => {
+			vi.mocked(loadEffectiveEventTimes).mockReturnValue(
+				succeeded('times', new Map([['evt-1', 5000]])),
+			);
+
+			const result = await checkoutStateAtEvent({eventId: 'missing'});
+
+			expect(isSuccess(result)).toBe(false);
+			expect(loadMergedEventsBefore).not.toHaveBeenCalled();
+			expect(resetState).not.toHaveBeenCalled();
+		});
+
+		it('fails when the event carries no decodable time', async () => {
+			vi.mocked(loadEffectiveEventTimes).mockReturnValue(
+				succeeded('times', new Map([['evt-1', null]])),
+			);
+
+			const result = await checkoutStateAtEvent({eventId: 'evt-1'});
+
+			expect(isSuccess(result)).toBe(false);
+			expect(loadMergedEventsBefore).not.toHaveBeenCalled();
+		});
+
+		it('fails when the event times cannot be read', async () => {
+			vi.mocked(loadEffectiveEventTimes).mockReturnValue(failed('unreadable'));
+
+			const result = await checkoutStateAtEvent({eventId: 'evt-1'});
+
+			expect(isSuccess(result)).toBe(false);
+			if (isSuccess(result)) return;
+			expect(result.message).toContain('unreadable');
+			expect(resetState).not.toHaveBeenCalled();
 		});
 	});
 

--- a/source/test/websocket-schema.test.ts
+++ b/source/test/websocket-schema.test.ts
@@ -78,6 +78,21 @@ describe('parseGuiMessage', () => {
 		expect(parsed.message.payload).toEqual(payload);
 	});
 
+	it('accepts a checkout addressed by event id', () => {
+		const payload = {eventId: '01H0000000000000000000000B'};
+		const parsed = parseGuiMessage({
+			type: 'time-travel:checkout-event',
+			payload,
+		});
+
+		expect(parsed.ok).toBe(true);
+		if (!parsed.ok || parsed.message.type !== 'time-travel:checkout-event') {
+			throw new Error('expected a time-travel:checkout-event message');
+		}
+
+		expect(parsed.message.payload).toEqual(payload);
+	});
+
 	it.each([
 		['null', null],
 		['a number', 123],
@@ -99,6 +114,10 @@ describe('parseGuiMessage', () => {
 		[
 			'NaN as a time',
 			{type: 'time-travel:scrub', payload: {targetTime: Number.NaN}},
+		],
+		[
+			'a checkout naming no event',
+			{type: 'time-travel:checkout-event', payload: {eventId: ''}},
 		],
 		[
 			'an unknown move position',


### PR DESCRIPTION
Each row in a ticket's **Log** tab gets a clock button that parks the whole board at that moment, so the description, comments and tags you read beside it are the ones that existed then.

The board already time-travelled — the scrubber has done it since it landed. What was missing was a way to aim it at a moment you can name rather than one you have to find by dragging.

### The cut

`checkoutStateAtEvent` resolves the event's **effective** time and checks out at `time + 1`:

- **`+1`** because `splitEventsAtTime` cuts exclusively (`time < targetTime`). Landing *on* the event would show the state it replaced — click "Changed description" and you would read the previous draft, not the one that row wrote. Same convention `:peek next` already uses.
- **effective, not raw**, because the Log row displays `ulidTimeMs(event.id)` while the split judges by the clamped time. A poisoned far-future id would otherwise check out the entire log. Resolving server-side also means the client never has to hold event-log semantics.

### Scope

The button is addressed by event id, not by the timestamp on screen, and it is absent while the socket is down — a page that cannot ask for a checkout should not offer one.

Once parked, the Log is the log of that moment too, so rows after the one you picked are gone. `Resume` in the scrubber header is the way back.

### Tests

- `epiq-time-travel.test.ts` — the cut lands one past the named event, resolves effective times, and fails without touching state on an unknown id, an undecodable time, or an unreadable log. Verified red by dropping the `+1`.
- `websocket-schema.test.ts` — the new message is accepted, and refused with no event named.
- `issue-history.pw.ts` — full path: two description edits, check out the older one, read the replaced draft, resume, read the current one.

Full unit suite (981) and the GUI suite (82) pass.