### PR TITLE
5GSVH6T leave a lockfile collapsed when expanding all

### DIFF
--- a/source/gui/client/components/DiffPanel.tsx
+++ b/source/gui/client/components/DiffPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {
 	DiffFileInput,
 	DiffLineAnnotation,
@@ -8,6 +8,7 @@ import {
 } from '@pierre/diffs/react';
 import {GUI_THEME} from '../lib/gui-theme';
 import {GuiCommitDiffFile} from '../lib/gui-state.model';
+import {diffLineCount, isLargeDiff} from '../../../lib/utils/diff-size.js';
 import {Button} from './Button';
 import {CopyShaButton} from './CopyShaButton';
 import {Empty} from './FormPrimitives';
@@ -85,6 +86,61 @@ export const FileDiffView = <LAnnotation = undefined,>({
 	</div>
 );
 
+// This panel has no per-file disclosure to hide behind — it opens every file
+// of a commit at once — so a lockfile here stalls the view with no action from
+// the reader at all. Collapsed until asked for, the way the commit list leaves
+// its own large files shut.
+const PanelFile = ({
+	file,
+	diffStyle,
+}: {
+	file: GuiCommitDiffFile;
+	diffStyle: 'split' | 'unified';
+}) => {
+	const [shown, setShown] = useState(false);
+
+	if (shown || !isLargeDiff(file)) {
+		return <FileDiffView file={file} diffStyle={diffStyle} />;
+	}
+
+	return (
+		<div
+			data-testid="large-diff-notice"
+			style={{
+				display: 'flex',
+				alignItems: 'center',
+				justifyContent: 'space-between',
+				gap: 12,
+				marginBottom: 16,
+				padding: '10px 12px',
+				border: `1px solid ${GUI_THEME.line}`,
+				borderRadius: 8,
+				color: GUI_THEME.dim,
+				fontSize: 12,
+			}}
+		>
+			<span
+				style={{
+					fontFamily: 'ui-monospace, monospace',
+					overflow: 'hidden',
+					textOverflow: 'ellipsis',
+					whiteSpace: 'nowrap',
+				}}
+			>
+				{file.path}
+			</span>
+			<span
+				style={{flexShrink: 0, display: 'flex', alignItems: 'center', gap: 8}}
+			>
+				{diffLineCount(file).toLocaleString()} lines
+				<Button variant="ghost" onClick={() => setShown(true)}>
+					Show diff
+				</Button>
+			</span>
+		</div>
+	);
+};
+
 export const DiffPanel = ({
 	sha,
 	files,
@@ -141,7 +197,7 @@ export const DiffPanel = ({
 		{!loading &&
 			!error &&
 			files?.map(file => (
-				<FileDiffView key={file.path} file={file} diffStyle={diffStyle} />
+				<PanelFile key={file.path} file={file} diffStyle={diffStyle} />
 			))}
 	</>
 );

--- a/source/gui/client/components/IssueCommits.tsx
+++ b/source/gui/client/components/IssueCommits.tsx
@@ -10,6 +10,7 @@ import {
 	GuiRefCommitEntry,
 } from '../lib/gui-state.model';
 import {CONTENT_FONT, GUI_THEME, TEXT} from '../lib/gui-theme';
+import {diffLineCount, isLargeDiff} from '../../../lib/utils/diff-size.js';
 import {COMMENT_CARD_STYLE} from '../lib/comment-card.style';
 import {
 	DiffCommentMeta,
@@ -617,6 +618,24 @@ const FileRow = ({
 						{fileComments.length}
 					</span>
 				)}
+				{/* Says why "Expand all" passed this one over. Only while shut: once
+				    it is open the diff speaks for itself. */}
+				{!expanded && isLargeDiff(file) && (
+					<span
+						data-testid="large-diff-badge"
+						title={`${diffLineCount(
+							file,
+						).toLocaleString()} lines — left collapsed, open it to load the diff`}
+						style={{
+							flexShrink: 0,
+							color: GUI_THEME.dim,
+							fontSize: TEXT.label,
+							whiteSpace: 'nowrap',
+						}}
+					>
+						large diff
+					</span>
+				)}
 			</button>
 
 			{expanded && (
@@ -711,6 +730,18 @@ const CommitRow = ({
 	const [focused, setFocused] = useState(false);
 	const revealed = hovered || focused;
 
+	// Large files are not part of "expand all", so the button reads its state
+	// off the ones that are. The fallback covers a commit where every file is
+	// large, so the button can still collapse what was opened by hand rather
+	// than sitting there doing nothing.
+	const expandablePaths = (diff?.files ?? [])
+		.filter(file => !isLargeDiff(file))
+		.map(file => file.path);
+	const allExpandableExpanded =
+		expandablePaths.length > 0
+			? expandablePaths.every(path => expandedFiles.has(path))
+			: (diff?.files ?? []).some(file => expandedFiles.has(file.path));
+
 	return (
 		<div
 			style={{
@@ -801,16 +832,15 @@ const CommitRow = ({
 							<Button
 								variant="ghost"
 								onClick={() => {
-									const filePaths = diff.files!.map(file => file.path);
-									const allExpanded = filePaths.every(path =>
-										expandedFiles.has(path),
+									// Expanding skips the large ones; collapsing still takes
+									// everything, including a large file opened by hand.
+									onSetAllFilesExpanded(
+										allExpandableExpanded ? [] : expandablePaths,
+										!allExpandableExpanded,
 									);
-									onSetAllFilesExpanded(filePaths, !allExpanded);
 								}}
 							>
-								{diff.files.every(file => expandedFiles.has(file.path))
-									? 'Collapse all'
-									: 'Expand all'}
+								{allExpandableExpanded ? 'Collapse all' : 'Expand all'}
 							</Button>
 						</div>
 					)}
@@ -932,7 +962,9 @@ export const IssueCommits = ({
 				...prev,
 				[commit.sha]: new Set([
 					...(prev[commit.sha] ?? []),
-					...files.map(file => file.path),
+					// A lockfile opened unasked is what stalls this view, so the
+					// large ones stay shut until they are asked for by name.
+					...files.filter(file => !isLargeDiff(file)).map(file => file.path),
 				]),
 			}));
 		}

--- a/source/lib/utils/diff-size.ts
+++ b/source/lib/utils/diff-size.ts
@@ -1,0 +1,48 @@
+// Whether a file's diff is too big to be worth rendering unasked.
+//
+// The GUI receives both sides as whole blobs and diffs and syntax-highlights
+// them in the browser, so the cost scales with how much text there is rather
+// than with how much of it changed. A lockfile is the usual offender: a
+// one-line real change buried in tens of thousands of lines that all have to
+// be walked to prove it.
+
+// Structural rather than the GUI's own GuiCommitDiffFile: this lives outside
+// source/gui so the Node-side build and its tests can reach it too.
+export type DiffSides = {before: string; after: string};
+
+// Two limits because either alone has a blind spot: a minified bundle is one
+// 2MB line, and a long file of short lines stays under any byte cap worth
+// setting. Sized off this repo — its longest hand-written file is ~2k lines
+// and ~70KB, its package-lock ~10.5k lines and ~330KB.
+export const LARGE_DIFF_LINES = 4_000;
+export const LARGE_DIFF_CHARS = 200_000;
+
+// indexOf rather than split: this runs per file on every render, and splitting
+// a lockfile allocates an array the length of the file to count it.
+export const lineCount = (text: string): number => {
+	if (text === '') return 0;
+
+	let lines = 1;
+
+	for (
+		let index = text.indexOf('\n');
+		index !== -1;
+		index = text.indexOf('\n', index + 1)
+	) {
+		lines++;
+	}
+
+	return lines;
+};
+
+// Measured per side rather than over the pair: a file is big or it is not, and
+// summing would call a modification of a 110KB file large while an addition of
+// the same file is not.
+export const diffLineCount = (file: DiffSides): number =>
+	Math.max(lineCount(file.before), lineCount(file.after));
+
+// Deliberately a heuristic on the raw sides. The real diff is the expensive
+// thing, so computing it to decide whether to compute it defeats the point.
+export const isLargeDiff = (file: DiffSides): boolean =>
+	Math.max(file.before.length, file.after.length) > LARGE_DIFF_CHARS ||
+	diffLineCount(file) > LARGE_DIFF_LINES;

--- a/source/test/diff-size.test.ts
+++ b/source/test/diff-size.test.ts
@@ -1,0 +1,79 @@
+import {describe, expect, it} from 'vitest';
+import {
+	LARGE_DIFF_CHARS,
+	LARGE_DIFF_LINES,
+	diffLineCount,
+	isLargeDiff,
+	lineCount,
+} from '../lib/utils/diff-size.js';
+
+const file = (before: string, after: string) => ({
+	path: 'package-lock.json',
+	before,
+	after,
+});
+
+const lines = (count: number, text = 'x') =>
+	Array.from({length: count}, () => text).join('\n');
+
+describe('lineCount', () => {
+	it('counts an empty file as no lines rather than one', () => {
+		expect(lineCount('')).toBe(0);
+	});
+
+	it('counts a file with no trailing newline', () => {
+		expect(lineCount('a\nb\nc')).toBe(3);
+	});
+
+	// The common shape on disk, and the one an off-by-one would land on.
+	it('counts the empty last line a trailing newline leaves', () => {
+		expect(lineCount('a\nb\nc\n')).toBe(4);
+	});
+});
+
+describe('diffLineCount', () => {
+	// The label on the badge and the notice reads off this, so a modification
+	// must not report the smaller side.
+	it('reports the longer of the two sides', () => {
+		expect(diffLineCount(file(lines(10), lines(3)))).toBe(10);
+		expect(diffLineCount(file(lines(3), lines(10)))).toBe(10);
+	});
+});
+
+describe('isLargeDiff', () => {
+	it('leaves an ordinary source file alone', () => {
+		expect(isLargeDiff(file(lines(500), lines(520)))).toBe(false);
+	});
+
+	it('catches a file past the line limit', () => {
+		expect(isLargeDiff(file('', lines(LARGE_DIFF_LINES + 1)))).toBe(true);
+	});
+
+	// A minified bundle is one enormous line, so a line count alone would wave
+	// it through.
+	it('catches a single line past the character limit', () => {
+		expect(isLargeDiff(file('', 'x'.repeat(LARGE_DIFF_CHARS + 1)))).toBe(true);
+	});
+
+	// Measured per side, not summed: two ordinary sides of a modification must
+	// not add up to "large".
+	it('does not add the two sides together', () => {
+		const side = 'x'.repeat(Math.floor(LARGE_DIFF_CHARS * 0.6));
+
+		expect(isLargeDiff(file(side, side))).toBe(false);
+	});
+
+	// The reported case: a lockfile is large on the side it was deleted from
+	// as much as on the side it was added to.
+	it('catches a large file on either side', () => {
+		const big = lines(LARGE_DIFF_LINES + 1);
+
+		expect(isLargeDiff(file(big, ''))).toBe(true);
+		expect(isLargeDiff(file('', big))).toBe(true);
+	});
+
+	it('leaves a file exactly at the limits alone', () => {
+		expect(isLargeDiff(file('', lines(LARGE_DIFF_LINES)))).toBe(false);
+		expect(isLargeDiff(file('', 'x'.repeat(LARGE_DIFF_CHARS)))).toBe(false);
+	});
+});

--- a/source/test/e2e-gui/large-diff.pw.ts
+++ b/source/test/e2e-gui/large-diff.pw.ts
@@ -1,0 +1,86 @@
+import type {Page} from '@playwright/test';
+import {expect, test} from './fixtures.js';
+import {COMMIT_CACHE_MS, commitLinkedFiles} from './linked-commit.js';
+import {LARGE_DIFF_LINES} from '../../lib/utils/diff-size.js';
+
+// Just past the limit, and no further: the seeded repo carries this commit for
+// the rest of the worker's run, and the point is the threshold, not the size.
+const lockfileContents = `${Array.from(
+	{length: LARGE_DIFF_LINES + 1},
+	(_, index) => `    "package-${index}": "1.0.0",`,
+).join('\n')}\n`;
+
+const addTicket = async (page: Page, title: string) => {
+	await page.getByTitle('Add issue').first().click();
+	await page.getByPlaceholder('issue name').fill(title);
+	await page.getByPlaceholder('issue name').press('Enter');
+	await expect(page.locator('aside')).toContainText(title);
+};
+
+const refOf = async (page: Page): Promise<string> => {
+	const ref = (
+		await page.locator('aside button[title^="Copy "]').first().textContent()
+	)?.trim();
+	expect(ref).toBeTruthy();
+
+	return ref!;
+};
+
+test.beforeEach(async ({page, appUrl}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+});
+
+// The reported case: a commit that touches a lockfile alongside real code.
+// Expand all is for reading the code, and a 4000-line lockfile rendered
+// alongside it is what stalls the tab.
+test('“Expand all” opens the ordinary files and leaves a lockfile shut', async ({
+	page,
+	pageErrors,
+	repoRoot,
+}) => {
+	const stamp = Date.now();
+	await addTicket(page, `Lockfile ${stamp}`);
+	const ref = await refOf(page);
+
+	const codeFile = `notes-${ref}.txt`;
+	const lockFile = `lock-${ref}.json`;
+	commitLinkedFiles(repoRoot, ref, 'bump deps', {
+		[codeFile]: 'alpha\nbeta\ngamma\n',
+		[lockFile]: lockfileContents,
+	});
+
+	await page.waitForTimeout(COMMIT_CACHE_MS);
+	await page.reload();
+	await expect(page.locator('aside')).toContainText(`Lockfile ${stamp}`);
+
+	await page.getByRole('button', {name: /^Commits/}).click();
+	await page.getByRole('button', {name: 'bump deps'}).click();
+
+	const code = page.getByRole('button', {name: codeFile});
+	const lock = page.getByRole('button', {name: lockFile});
+	await expect(code).toBeVisible();
+	await expect(lock).toBeVisible();
+
+	// Says why it is going to be passed over, before anything is clicked.
+	await expect(lock.getByTestId('large-diff-badge')).toBeVisible();
+
+	await page.getByRole('button', {name: 'Expand all'}).click();
+
+	await expect(code).toHaveAttribute('aria-expanded', 'true');
+	await expect(lock).toHaveAttribute('aria-expanded', 'false');
+
+	// Still reachable by hand — collapsed is the default, not a refusal.
+	await lock.click();
+	await expect(lock).toHaveAttribute('aria-expanded', 'true');
+	// Open, the badge has nothing left to explain.
+	await expect(lock.getByTestId('large-diff-badge')).toHaveCount(0);
+
+	// And the button can still shut everything, including the one it never
+	// opened — otherwise a large file opened by hand would be stuck open.
+	await page.getByRole('button', {name: 'Collapse all'}).click();
+	await expect(code).toHaveAttribute('aria-expanded', 'false');
+	await expect(lock).toHaveAttribute('aria-expanded', 'false');
+
+	expect(pageErrors).toEqual([]);
+});

--- a/source/test/e2e-gui/linked-commit.ts
+++ b/source/test/e2e-gui/linked-commit.ts
@@ -18,22 +18,34 @@ export const COMMIT_CACHE_MS = 5_500;
  */
 export const linkedFileName = (ref: string): string => `notes-${ref}.txt`;
 
-export const commitLinkedFile = (
+/** One commit carrying several files, keyed by name. */
+export const commitLinkedFiles = (
 	repoRoot: string,
 	ref: string,
 	subject: string,
-	fileName = linkedFileName(ref),
-	contents = 'alpha\nbeta\ngamma\n',
+	contentsByFileName: Record<string, string>,
 ): string => {
-	fs.writeFileSync(path.join(repoRoot, fileName), contents);
 	const git = (...args: string[]) =>
 		execFileSync(
 			'git',
 			['-c', 'user.name=e2e', '-c', 'user.email=e2e@example.com', ...args],
 			{cwd: repoRoot, stdio: 'pipe'},
 		);
-	git('add', fileName);
+
+	for (const [fileName, contents] of Object.entries(contentsByFileName)) {
+		fs.writeFileSync(path.join(repoRoot, fileName), contents);
+		git('add', fileName);
+	}
+
 	git('commit', '-q', '-m', `${ref} ${subject}`);
 
 	return git('rev-parse', 'HEAD').toString().trim();
 };
+
+export const commitLinkedFile = (
+	repoRoot: string,
+	ref: string,
+	subject: string,
+	fileName = linkedFileName(ref),
+	contents = 'alpha\nbeta\ngamma\n',
+): string => commitLinkedFiles(repoRoot, ref, subject, {[fileName]: contents});

--- a/source/test/e2e-gui/scatter-gesture.pw.ts
+++ b/source/test/e2e-gui/scatter-gesture.pw.ts
@@ -2,6 +2,7 @@ import {execFileSync} from 'node:child_process';
 import type {Locator, Page} from '@playwright/test';
 import {expect, test} from './fixtures.js';
 import {COMMIT_CACHE_MS, commitLinkedFile} from './linked-commit.js';
+import {LARGE_DIFF_LINES} from '../../lib/utils/diff-size.js';
 
 // A dot is painted on a canvas, so there is no node to aim at and no
 // bounding box to read. Its x is pinned instead by handing the scrubber a
@@ -31,7 +32,10 @@ const seedCommitOnScatter = async (
 	page: Page,
 	appUrl: string,
 	repoRoot: string,
-	{link = true}: {link?: boolean} = {},
+	{
+		link = true,
+		contents,
+	}: {link?: boolean; contents?: (stamp: number) => string} = {},
 ) => {
 	await page.goto(appUrl);
 	await expect(page.getByTestId('board-switcher')).toContainText('Default');
@@ -57,7 +61,7 @@ const seedCommitOnScatter = async (
 		link ? ref! : 'chore:',
 		subject,
 		`notes-${stamp}.txt`,
-		`line for ${stamp}\n`,
+		contents ? contents(stamp) : `line for ${stamp}\n`,
 	);
 	const committedAt =
 		Number(
@@ -87,6 +91,7 @@ const seedCommitOnScatter = async (
 	return {
 		dot,
 		sha,
+		fileName: `notes-${stamp}.txt`,
 		title: `Scatter ${stamp}`,
 		window: {from: url.searchParams.get('from')!},
 	};
@@ -215,6 +220,38 @@ test('a ticket created while an unlinked commit diff is open replaces it', async
 
 	await expect(page.locator('aside')).toContainText(title);
 	await expect(diffPanel).toHaveCount(0);
+
+	expect(pageErrors).toEqual([]);
+});
+
+// This panel has no per-file disclosure — every file of the commit renders at
+// once — so a lockfile opened here stalls the view with no action from the
+// reader at all. Just past the limit and no further: the point is the
+// threshold, not the size.
+test('the commit panel holds a large file behind a "Show diff"', async ({
+	page,
+	appUrl,
+	repoRoot,
+	pageErrors,
+}) => {
+	const {dot, fileName} = await seedCommitOnScatter(page, appUrl, repoRoot, {
+		link: false,
+		contents: stamp =>
+			`${Array.from(
+				{length: LARGE_DIFF_LINES + 1},
+				(_, index) => `    "package-${index}": "1.0.0", ${stamp}`,
+			).join('\n')}\n`,
+	});
+
+	await page.mouse.click(dot.x, dot.y);
+
+	const notice = page.getByTestId('large-diff-notice');
+	await expect(notice).toBeVisible();
+	await expect(notice).toContainText(fileName);
+
+	// Collapsed is the default, not a refusal.
+	await notice.getByRole('button', {name: 'Show diff'}).click();
+	await expect(page.getByTestId('large-diff-notice')).toHaveCount(0);
 
 	expect(pageErrors).toEqual([]);
 });


### PR DESCRIPTION
A commit that touches `package-lock.json` alongside real code made the Commits tab unusable: "Expand all" opened the lockfile too, and the browser spent the next several seconds diffing and syntax-highlighting ten thousand lines nobody wanted to read. Large files now stay shut, the way GitLab leaves them.

### The heuristic

`source/lib/utils/diff-size.ts`, beside `diff-comment.ts` — the client already reaches into `lib/utils`, and this way the Node-side build and its tests can use it too (`source/gui` is excluded from the root TS program, so a test importing it from the client tree would not compile).

Both sides arrive as whole blobs and are diffed in the browser, so cost tracks total text, not how much changed. Two limits, because either alone has a blind spot:

- **4,000 lines** — catches a lockfile (~10.5k here) and clears the longest hand-written file in this repo (~2k).
- **200,000 chars** — catches a minified bundle, which is one enormous line.

Measured per side rather than summed, so a modification of a 110KB file isn't "large" when an addition of the same file isn't.

It's deliberately a heuristic on the raw sides: computing the real diff to decide whether to compute the real diff defeats the point.

### Two surfaces

**Commits tab** — large files are excluded from the `expandAll` auto-open and from the "Expand all" button, and carry a `large diff` badge while shut so the reason is visible before anything is clicked. Clicking one still opens it: collapsed is the default, not a refusal. "Collapse all" still takes everything, including a large file opened by hand, and its label reads off the expandable files (with a fallback so a commit of nothing *but* large files doesn't leave a dead button).

**Commit-dot panel** — this one has no per-file disclosure at all; it renders every file of a commit at once. So it was strictly worse than the reported case: no user action needed to stall it. Large files there sit behind a `Show diff`. Beyond the ticket's wording, but the ticket's requirement — "too big to be rendered by default" — is not met while this path exists.

### Tests

- `diff-size.test.ts` — line counting (empty file, no trailing newline, trailing newline), both limits, per-side measurement, either side large, and the exact boundary.
- `large-diff.pw.ts` — the reported case end to end: Expand all opens `notes.txt` and leaves the lockfile shut, the badge says why, a manual click still opens it, and Collapse all shuts both. Verified red by stubbing `isLargeDiff` to false.
- `scatter-gesture.pw.ts` — the panel holds a large file behind "Show diff", and shows it on click.

984 unit and 88 GUI tests pass.