### PR TITLE
Fold the bottom dock's header into one row, and draw the panel's own edge

### DIFF
--- a/source/gui/client/components/Aside.tsx
+++ b/source/gui/client/components/Aside.tsx
@@ -225,10 +225,18 @@ export const Aside = forwardRef<
 					? {position: 'relative', height, minHeight: height}
 					: {position: 'relative', width, minWidth: width}),
 				// The border faces the board, which is above it in one dock and
-				// beside it in the other.
+				// beside it in the other. It carries a shadow cast the same way,
+				// so the panel reads as a surface in front of the board rather
+				// than as more of it.
 				...(bottom && !isFullscreen
-					? {borderTop: `1px solid ${GUI_THEME.line}`}
-					: {borderLeft: `1px solid ${GUI_THEME.line}`}),
+					? {
+							borderTop: `1px solid ${GUI_THEME.edge}`,
+							boxShadow: '0 -10px 24px rgba(0, 0, 0, 0.45)',
+					  }
+					: {
+							borderLeft: `1px solid ${GUI_THEME.edge}`,
+							boxShadow: '-10px 0 24px rgba(0, 0, 0, 0.45)',
+					  }),
 				background: GUI_THEME.panel,
 				padding: ASIDE_PADDING,
 				fontSize: 12,

--- a/source/gui/client/components/IssueDetails.tsx
+++ b/source/gui/client/components/IssueDetails.tsx
@@ -946,6 +946,79 @@ export const IssueDetails = ({
 					/>
 				);
 
+				// Docked to the bottom the panel is wide and short, so the title
+				// rides in the header row beside the ref and the age rather than
+				// taking a row of its own. Docked right it is the other way round:
+				// height to spare, width to protect.
+				const inlineTitle = dock === 'bottom';
+
+				const titleNode =
+					issue &&
+					(editingTitle ? (
+						<textarea
+							ref={titleTextareaRef}
+							value={title}
+							autoFocus
+							rows={1}
+							onChange={event => {
+								setTitle(event.target.value);
+								resizeTitleTextarea();
+							}}
+							onKeyDown={event => {
+								if (event.key === 'Enter') {
+									event.preventDefault();
+									event.currentTarget.blur();
+								}
+								if (event.key === 'Escape') cancelTitle();
+							}}
+							onBlur={saveTitle}
+							style={{
+								display: 'block',
+								width: '100%',
+								boxSizing: 'border-box',
+								resize: 'none',
+								overflow: 'hidden',
+								background: GUI_THEME.bg,
+								color: GUI_THEME.primary,
+								border: `1px solid ${GUI_THEME.line}`,
+								borderRadius: 8,
+								padding: '6px 10px',
+								outline: 'none',
+								font: 'inherit',
+								fontSize: TEXT.title,
+								fontWeight: 600,
+								lineHeight: 1.35,
+								marginBottom: inlineTitle ? 0 : 20,
+							}}
+						/>
+					) : (
+						<div
+							onClick={() => !issue.readonly && setEditingTitle(true)}
+							title={inlineTitle ? issue.title : undefined}
+							style={{
+								marginBottom: inlineTitle ? 0 : 18,
+								color: GUI_THEME.primary,
+								fontSize: TEXT.title,
+								fontWeight: 600,
+								lineHeight: 1.35,
+								cursor: issue.readonly ? 'default' : 'text',
+								// One row shared with the ref, the age and the panel's
+								// own controls: a long title takes what is left and
+								// gives up the rest, rather than wrapping the row.
+								...(inlineTitle
+									? {
+											minWidth: 0,
+											whiteSpace: 'nowrap',
+											overflow: 'hidden',
+											textOverflow: 'ellipsis',
+									  }
+									: {wordBreak: 'break-word'}),
+							}}
+						>
+							{issue.title}
+						</div>
+					));
+
 				return (
 					<>
 						{issue ? (
@@ -958,7 +1031,12 @@ export const IssueDetails = ({
 							>
 								<FormHeader>
 									<div
-										style={{display: 'flex', alignItems: 'baseline', gap: 10}}
+										style={{
+											display: 'flex',
+											alignItems: 'baseline',
+											gap: 10,
+											...(inlineTitle ? {flex: 1, minWidth: 0} : {}),
+										}}
 									>
 										<span
 											style={{
@@ -982,9 +1060,11 @@ export const IssueDetails = ({
 													color: GUI_THEME.dim,
 												}}
 											>
-												Created {timeAgo(issue.createdAt)}
+												{timeAgo(issue.createdAt)}
 											</span>
 										)}
+
+										{inlineTitle && titleNode}
 									</div>
 
 									<div style={{display: 'flex', alignItems: 'center', gap: 2}}>
@@ -999,59 +1079,7 @@ export const IssueDetails = ({
 									</div>
 								</FormHeader>
 
-								{editingTitle ? (
-									<textarea
-										ref={titleTextareaRef}
-										value={title}
-										autoFocus
-										rows={1}
-										onChange={event => {
-											setTitle(event.target.value);
-											resizeTitleTextarea();
-										}}
-										onKeyDown={event => {
-											if (event.key === 'Enter') {
-												event.preventDefault();
-												event.currentTarget.blur();
-											}
-											if (event.key === 'Escape') cancelTitle();
-										}}
-										onBlur={saveTitle}
-										style={{
-											display: 'block',
-											width: '100%',
-											boxSizing: 'border-box',
-											resize: 'none',
-											overflow: 'hidden',
-											background: GUI_THEME.bg,
-											color: GUI_THEME.primary,
-											border: `1px solid ${GUI_THEME.line}`,
-											borderRadius: 8,
-											padding: '6px 10px',
-											outline: 'none',
-											font: 'inherit',
-											fontSize: TEXT.title,
-											fontWeight: 600,
-											lineHeight: 1.35,
-											marginBottom: 20,
-										}}
-									/>
-								) : (
-									<div
-										onClick={() => !issue.readonly && setEditingTitle(true)}
-										style={{
-											marginBottom: 18,
-											color: GUI_THEME.primary,
-											fontSize: TEXT.title,
-											fontWeight: 600,
-											lineHeight: 1.35,
-											wordBreak: 'break-word',
-											cursor: issue.readonly ? 'default' : 'text',
-										}}
-									>
-										{issue.title}
-									</div>
-								)}
+								{!inlineTitle && titleNode}
 
 								{laneView ? (
 									<div

--- a/source/gui/client/lib/gui-theme.tsx
+++ b/source/gui/client/lib/gui-theme.tsx
@@ -19,6 +19,10 @@ export const GUI_THEME = {
 	panel: '#11141b',
 	panel2: '#151a24',
 	line: 'rgba(70, 87, 126, 0.15)',
+	// The detail panel's own outer edge. `line` divides sections inside one
+	// surface; this one has to hold the panel apart from the board behind it,
+	// which takes considerably more contrast.
+	edge: 'rgba(96, 116, 165, 0.55)',
 	primary: '#c2c5d0',
 	secondary: '#7f8aa3',
 	tertiary: 'rgb(31 33 43)',

--- a/source/test/e2e-gui/issue-history.pw.ts
+++ b/source/test/e2e-gui/issue-history.pw.ts
@@ -58,7 +58,8 @@ test('the panel header names when the ticket was created', async ({page}) => {
 
 	const created = page.getByTestId('issue-created-at');
 	await expect(created).toBeVisible();
-	await expect(created).toContainText(/Created (just now|\d+\w+ ago)/);
+	// The age alone: "Created" said nothing the "ago" does not.
+	await expect(created).toHaveText(/^(just now|\d+\w+ ago)$/);
 	// The exact timestamp stays on hover rather than crowding the line.
 	await expect(created).toHaveAttribute(
 		'title',

--- a/source/test/e2e-gui/panel-edge.pw.ts
+++ b/source/test/e2e-gui/panel-edge.pw.ts
@@ -1,0 +1,61 @@
+import type {Page} from '@playwright/test';
+import {expect, test} from './fixtures.js';
+
+test.use({viewport: {width: 1600, height: 900}});
+
+const openTicket = async (page: Page, appUrl: string) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	await page.getByTitle('Add issue').first().click();
+	await page.getByPlaceholder('issue name').fill(`Edge ${Date.now()}`);
+	await page.getByPlaceholder('issue name').press('Enter');
+	await expect(page.locator('aside')).toBeVisible();
+};
+
+const dockTo = async (page: Page, side: 'bottom' | 'right') => {
+	await page.getByTestId('panel-menu').click();
+	await page.getByRole('button', {name: `Dock to ${side}`}).click();
+};
+
+// Passed as a source string, not a closure: the root tsconfig has no DOM lib.
+// Reports the edge facing the board — the left border when the panel is docked
+// right, the top border when it is docked bottom — as its alpha, and whether a
+// shadow is cast along it.
+const edge = (page: Page, side: 'bottom' | 'right') =>
+	page.evaluate<{alpha: number; shadow: string}>(`
+		(() => {
+			const style = getComputedStyle(document.querySelector('aside'));
+			const color = ${side === 'bottom'}
+				? style.borderTopColor
+				: style.borderLeftColor;
+			const parts = color.match(/[\\d.]+/g) ?? [];
+
+			return {
+				alpha: parts.length > 3 ? Number(parts[3]) : 1,
+				shadow: style.boxShadow,
+			};
+		})()
+	`);
+
+test('the panel edge is drawn strongly enough to separate it from the board', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await openTicket(page, appUrl);
+
+	// The section rule inside the panel is 0.15, which was the edge too and is
+	// what made the panel hard to pick out. Anything at that strength fails.
+	const right = await edge(page, 'right');
+	expect(right.alpha).toBeGreaterThan(0.4);
+	expect(right.shadow).not.toBe('none');
+
+	await dockTo(page, 'bottom');
+
+	const bottom = await edge(page, 'bottom');
+	expect(bottom.alpha).toBeGreaterThan(0.4);
+	expect(bottom.shadow).not.toBe('none');
+
+	expect(pageErrors).toEqual([]);
+});

--- a/source/test/e2e-gui/panel-header.pw.ts
+++ b/source/test/e2e-gui/panel-header.pw.ts
@@ -1,0 +1,105 @@
+import type {Page} from '@playwright/test';
+import {expect, test} from './fixtures.js';
+
+test.use({viewport: {width: 1600, height: 900}});
+
+const openTicket = async (page: Page, appUrl: string, title: string) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	await page.getByTitle('Add issue').first().click();
+	await page.getByPlaceholder('issue name').fill(title);
+	await page.getByPlaceholder('issue name').press('Enter');
+	await expect(page.locator('aside')).toBeVisible();
+};
+
+const dockTo = async (page: Page, side: 'bottom' | 'right') => {
+	await page.getByTestId('panel-menu').click();
+	await page.getByRole('button', {name: `Dock to ${side}`}).click();
+};
+
+// Their rows, as the reader sees them: two boxes share a row when each one's
+// centre falls inside the other's height.
+const sharesRowWithRef = async (page: Page, title: string) => {
+	const ref = await page
+		.locator('aside button[title^="Copy "]')
+		.first()
+		.boundingBox();
+	const heading = await page
+		.locator('aside')
+		.getByText(title, {exact: true})
+		.boundingBox();
+
+	if (!ref || !heading) throw new Error('header parts not found');
+
+	const refMiddle = ref.y + ref.height / 2;
+	const headingMiddle = heading.y + heading.height / 2;
+
+	return (
+		refMiddle > heading.y &&
+		refMiddle < heading.y + heading.height &&
+		headingMiddle > ref.y &&
+		headingMiddle < ref.y + ref.height
+	);
+};
+
+test('docked to the bottom the title rides in the header row, and moves back below it on the right', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	const title = `Header ${Date.now()}`;
+	await openTicket(page, appUrl, title);
+
+	await dockTo(page, 'bottom');
+	await expect(page.locator('aside')).toContainText(title);
+	expect(await sharesRowWithRef(page, title)).toBe(true);
+
+	await dockTo(page, 'right');
+	await expect(page.locator('aside')).toContainText(title);
+	expect(await sharesRowWithRef(page, title)).toBe(false);
+
+	expect(pageErrors).toEqual([]);
+});
+
+// The header is one row now, so a title long enough to wrap would push the
+// tabs and everything under them down the panel.
+test('a long title gives up what does not fit rather than growing the row', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	// Trimmed, because saving trims it and the assertions read it back.
+	const title = `Header ${'a title long enough to run out of room '.repeat(
+		6,
+	)}`.trim();
+	await openTicket(page, appUrl, title);
+	await dockTo(page, 'bottom');
+
+	const heading = page.locator('aside').getByText(title, {exact: true});
+	await expect(heading).toBeVisible();
+
+	const box = await heading.boundingBox();
+	expect(box?.height).toBeLessThan(40);
+	// Clipped, not lost: the whole title is still there to be read on hover.
+	await expect(heading).toHaveAttribute('title', title);
+
+	expect(pageErrors).toEqual([]);
+});
+
+// Editing still has to work from the row it now sits in.
+test('the title opens its editor from the header row', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	const title = `Header ${Date.now()}`;
+	await openTicket(page, appUrl, title);
+	await dockTo(page, 'bottom');
+
+	await page.locator('aside').getByText(title, {exact: true}).click();
+
+	await expect(page.locator('aside textarea').first()).toHaveValue(title);
+
+	expect(pageErrors).toEqual([]);
+});


### PR DESCRIPTION
Two things the bottom dock made obvious.

**7QXA00K** — docked to the bottom the panel is wide and short, and the header spent two rows on what fits in one. The title is hoisted into a `titleNode` and rendered inside the header row when `dock === 'bottom'`, beside the ref and the age; docked right, where height is plentiful and width is not, it stays below as before. Inline it takes the width the ref, the age and the panel controls leave and clips with an ellipsis — a wrapped title would push the tabs and everything under them down a panel that is short by definition — with the full text on the tooltip, and clicking it still opens the editor in place.

Also drops "Created" from the age in both docks. `35m ago` says it, and the absolute timestamp was already on the tooltip.

**SMYC38E** — the panel's outer border was the shared `line` token, `rgba(70, 87, 126, 0.15)`, too faint to tell the panel from the board behind it. New `edge` token at 0.55 for that border, plus a shadow cast the way the border faces: up when docked bottom, left when docked right. `line` is untouched — dividing sections inside a surface is a different job.

Three specs for the header (row sharing, a long title, editing from the row) and one for the edge, which reads the computed border in both docks and fails anything at `line` strength. `issue-history.pw.ts` asserted the old "Created …" wording and now reads the age alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7zsfHDDn19wgJA98QbULF
