### PR TITLE
Read the bottom dock's header as ref, title, then age

### DIFF
--- a/source/gui/client/components/IssueDetails.tsx
+++ b/source/gui/client/components/IssueDetails.tsx
@@ -1049,6 +1049,8 @@ export const IssueDetails = ({
 											{issue.ref && <CopyRef refValue={issue.ref} />}
 										</span>
 
+										{inlineTitle && titleNode}
+
 										{/* 0 when the id carries no time. Better to say nothing
 										    than to date the ticket to 1970. */}
 										{issue.createdAt > 0 && (
@@ -1058,13 +1060,18 @@ export const IssueDetails = ({
 												style={{
 													fontSize: TEXT.meta,
 													color: GUI_THEME.dim,
+													// Sharing the row with the title, the age takes the
+													// far end of it, next to the panel's controls: the
+													// slack then falls between the two rather than
+													// after both.
+													...(inlineTitle
+														? {marginLeft: 'auto', whiteSpace: 'nowrap'}
+														: {}),
 												}}
 											>
 												{timeAgo(issue.createdAt)}
 											</span>
 										)}
-
-										{inlineTitle && titleNode}
 									</div>
 
 									<div style={{display: 'flex', alignItems: 'center', gap: 2}}>

--- a/source/test/e2e-gui/panel-header.pw.ts
+++ b/source/test/e2e-gui/panel-header.pw.ts
@@ -43,6 +43,40 @@ const sharesRowWithRef = async (page: Page, title: string) => {
 	);
 };
 
+// Left to right: the ref, then the title, then the age at the far end of the
+// row. The slack belongs between the title and the age, not after all three.
+test('the header row reads ref, title, then age against the right edge', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	const title = `Header ${Date.now()}`;
+	await openTicket(page, appUrl, title);
+	await dockTo(page, 'bottom');
+
+	const aside = page.locator('aside');
+	const ref = await aside
+		.locator('button[title^="Copy "]')
+		.first()
+		.boundingBox();
+	const heading = await aside.getByText(title, {exact: true}).boundingBox();
+	const age = await page.getByTestId('issue-created-at').boundingBox();
+
+	if (!ref || !heading || !age) throw new Error('header parts not found');
+
+	expect(heading.x).toBeGreaterThan(ref.x + ref.width);
+	expect(age.x).toBeGreaterThan(heading.x + heading.width);
+
+	// Against the right edge rather than trailing the title: the gap left of
+	// the age is the wider one.
+	const asideBox = await aside.boundingBox();
+	const gapBefore = age.x - (heading.x + heading.width);
+	const gapAfter = asideBox!.x + asideBox!.width - (age.x + age.width);
+	expect(gapBefore).toBeGreaterThan(gapAfter);
+
+	expect(pageErrors).toEqual([]);
+});
+
 test('docked to the bottom the title rides in the header row, and moves back below it on the right', async ({
 	page,
 	appUrl,


### PR DESCRIPTION
**PSGQZ8Y** — 7QXA00K put the title in the bottom dock's header row, but left it after the age, with the whole rest of the row empty: `REF  35m ago  Title  ·······`.

Now it reads ref, title, age. The title moves up beside the ref, and the age takes `margin-left: auto` so it sits at the far end of the row, just before the panel's controls — the slack falls between the title and the age rather than after all three. A long title still shrinks and clips before the age gives up its place.

Right-docked the header is unchanged: ref and age on their own line, title below.

One new spec asserting the left-to-right order, and that the gap before the age is the wider of the two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7zsfHDDn19wgJA98QbULF
