### PR TITLE
Centre the age on the line its neighbouring buttons keep

### DIFF
--- a/source/gui/client/components/IssueDetails.tsx
+++ b/source/gui/client/components/IssueDetails.tsx
@@ -1019,6 +1019,22 @@ export const IssueDetails = ({
 						</div>
 					));
 
+				// 0 when the id carries no time. Better to say nothing than to
+				// date the ticket to 1970.
+				const ageNode = issue && issue.createdAt > 0 && (
+					<span
+						data-testid="issue-created-at"
+						title={formatAbsolute(issue.createdAt)}
+						style={{
+							fontSize: TEXT.meta,
+							color: GUI_THEME.dim,
+							whiteSpace: 'nowrap',
+						}}
+					>
+						{timeAgo(issue.createdAt)}
+					</span>
+				);
+
 				return (
 					<>
 						{issue ? (
@@ -1049,32 +1065,21 @@ export const IssueDetails = ({
 											{issue.ref && <CopyRef refValue={issue.ref} />}
 										</span>
 
-										{inlineTitle && titleNode}
-
-										{/* 0 when the id carries no time. Better to say nothing
-										    than to date the ticket to 1970. */}
-										{issue.createdAt > 0 && (
-											<span
-												data-testid="issue-created-at"
-												title={formatAbsolute(issue.createdAt)}
-												style={{
-													fontSize: TEXT.meta,
-													color: GUI_THEME.dim,
-													// Sharing the row with the title, the age takes the
-													// far end of it, next to the panel's controls: the
-													// slack then falls between the two rather than
-													// after both.
-													...(inlineTitle
-														? {marginLeft: 'auto', whiteSpace: 'nowrap'}
-														: {}),
-												}}
-											>
-												{timeAgo(issue.createdAt)}
-											</span>
-										)}
+										{inlineTitle ? titleNode : ageNode}
 									</div>
 
+									{/* Sharing the row with the title, the age belongs to the
+									    far end of it rather than trailing the title — and to
+									    this group rather than the one beside it, which aligns
+									    on the baseline the ref and the title read along. Here
+									    it is centred on the line the buttons keep. */}
 									<div style={{display: 'flex', alignItems: 'center', gap: 2}}>
+										{/* Its own margin rather than the row's gap, which is
+										    the spacing the three buttons keep from each other. */}
+										{inlineTitle && (
+											<span style={{marginRight: 6}}>{ageNode}</span>
+										)}
+
 										<PanelDockMenu dock={dock} onDock={onDock} />
 										<FullscreenToggleButton
 											isFullscreen={isFullscreen}

--- a/source/test/e2e-gui/panel-header.pw.ts
+++ b/source/test/e2e-gui/panel-header.pw.ts
@@ -77,6 +77,32 @@ test('the header row reads ref, title, then age against the right edge', async (
 	expect(pageErrors).toEqual([]);
 });
 
+// The age stands next to the panel's buttons, so it has to sit on their line:
+// it used to belong to the group that aligns the ref and the title on their
+// baseline, which left it off by a few pixels against everything beside it.
+test('the age is centred on the line the panel buttons keep', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await openTicket(page, appUrl, `Header ${Date.now()}`);
+	await dockTo(page, 'bottom');
+
+	const age = await page.getByTestId('issue-created-at').boundingBox();
+	const close = await page
+		.locator('aside')
+		.getByRole('button', {name: '×'})
+		.boundingBox();
+
+	if (!age || !close) throw new Error('header parts not found');
+
+	const ageMiddle = age.y + age.height / 2;
+	const closeMiddle = close.y + close.height / 2;
+	expect(Math.abs(ageMiddle - closeMiddle)).toBeLessThanOrEqual(1);
+
+	expect(pageErrors).toEqual([]);
+});
+
 test('docked to the bottom the title rides in the header row, and moves back below it on the right', async ({
 	page,
 	appUrl,


### PR DESCRIPTION
**M133AMD** — a defect from PSGQZ8Y. The age is the last thing before the kebab, the fullscreen toggle and the close button, and it did not sit on their line: it was still a member of the header's left group, which aligns on the baseline so the ref and the title read as one line, while the buttons live in the right group, which centres. One apparent row, two alignment rules, and the age caught between them — 4.5px off.

The age is hoisted into an `ageNode` and rendered in whichever group it belongs to: the left one beside the ref when docked right, the right one beside the buttons when docked bottom, where centring is the rule. Its own `margin-right` keeps it off the kebab rather than the row's `gap`, which is the spacing the three buttons keep from each other.

New spec measures the age's centre against the close button's: 4.5px apart against the merged version, ≤1px now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7zsfHDDn19wgJA98QbULF
