### PR TITLE
Unblock the release: drop the longhand border that reddened the GUI job, and cut v1.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "epiq",
-	"version": "1.5.0",
+	"version": "1.7.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "epiq",
-			"version": "1.5.0",
+			"version": "1.7.1",
 			"license": "MIT",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "epiq",
-	"version": "1.7.0",
+	"version": "1.7.1",
 	"license": "MIT",
 	"type": "module",
 	"description": "EPIQ - ergonomic, distributed CLI-first issue tracker TUI ready for the agentic era",

--- a/source/gui/client/components/ManageContributorsModal.tsx
+++ b/source/gui/client/components/ManageContributorsModal.tsx
@@ -146,7 +146,12 @@ export const ManageContributorsModal = ({
 											alignItems: 'center',
 											gap: 6,
 											color: armed ? GUI_THEME.red : GUI_THEME.dim,
-											borderColor: armed ? GUI_THEME.red : undefined,
+											// The whole shorthand, and only when armed: Button sets
+											// `border` itself, and React warns that an element given
+											// both it and `borderColor` can drop whichever loses the
+											// race. Spreading `border: undefined` is not the other
+											// branch — that reads as "remove this style".
+											...(armed ? {border: `1px solid ${GUI_THEME.red}`} : {}),
 										}}
 									>
 										{armed && <span style={{fontSize: 10}}>confirm</span>}

--- a/source/gui/client/components/ManageTagsModal.tsx
+++ b/source/gui/client/components/ManageTagsModal.tsx
@@ -107,7 +107,12 @@ export const ManageTagsModal = ({tags, onDelete, onClose}: Props) => {
 										alignItems: 'center',
 										gap: 6,
 										color: armed ? GUI_THEME.red : GUI_THEME.dim,
-										borderColor: armed ? GUI_THEME.red : undefined,
+										// The whole shorthand, and only when armed: Button sets
+										// `border` itself, and React warns that an element given
+										// both it and `borderColor` can drop whichever loses the
+										// race. Spreading `border: undefined` is not the other
+										// branch — that reads as "remove this style".
+										...(armed ? {border: `1px solid ${GUI_THEME.red}`} : {}),
 									}}
 								>
 									{armed && <span style={{fontSize: 10}}>confirm</span>}

--- a/source/version.ts
+++ b/source/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated. Do not edit.
-export const EPIQ_VERSION = '1.7.0';
+export const EPIQ_VERSION = '1.7.1';


### PR DESCRIPTION
Unblocks the release. The SEA build was never broken — it never ran.

**J8D2A6F** — `manage-tags.pw.ts` asserts a clean console, and arming a delete logged React's "don't mix shorthand and non-shorthand properties for the same value … Updating border borderColor". Both manage modals passed `borderColor` to the confirm `Button`, which sets the `border` shorthand itself; `image-insert.ts` already carries a note about this exact trap. The armed branch now adds the whole shorthand and the unarmed branch adds nothing — spreading `border: undefined` is not the other branch, since an undefined value still wins over the key it lands on and React reads it as "remove this style".

Why it stopped the release: both Release jobs declare `needs: [test, gui]`, and a job whose `needs` fails reports as *skipped*. The red GUI job on the v1.7.0 tag is why no binary was built or uploaded, and why the site advertises a version with nothing to download.

**v1.7.1** — 1.7.0 is already published to npm, so this is the next version. The bump also brings `package-lock.json` up from a stale 1.5.0.

Verification: full local gate green (lint, typecheck, 991 unit, 16 container, 11 collaboration, 99 GUI), and `npm run build:binary` produces a working macOS binary reporting 1.7.1 with its GUI assets embedded.

Note on the regression test: the warning could not be reproduced locally in 16 unfixed runs, including under CI's own config — it needs the runner's timing to land the hover and the arm in one commit. A style-attribute assertion was tried as deterministic proof and discarded: Chrome collapses `border-color` back into the shorthand, so it passed unfixed too. The fix removes the longhand entirely, so the collision cannot occur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7zsfHDDn19wgJA98QbULF
