### PR TITLE
Harden the event log against a peer payload, and the sync against its own git

### DIFF
--- a/source/git/git-commands.ts
+++ b/source/git/git-commands.ts
@@ -1,8 +1,25 @@
 import {execGit} from './git-utils.js';
 
 export const git = {
-	stage: ({cwd, pathspec}: {cwd: string; pathspec: string[]}) =>
-		execGit({args: ['add', ...pathspec], cwd}),
+	// `ignoreRemoval`: stage additions and modifications but not deletions, for
+	// paths where a missing file is damage rather than an intent to remove it.
+	stage: ({
+		cwd,
+		pathspec,
+		ignoreRemoval = false,
+	}: {
+		cwd: string;
+		pathspec: string[];
+		ignoreRemoval?: boolean;
+	}) =>
+		execGit({
+			args: [
+				'add',
+				...(ignoreRemoval ? ['--ignore-removal'] : []),
+				...pathspec,
+			],
+			cwd,
+		}),
 
 	// `pathspec` commits only those paths and ignores the rest of the index.
 	// Without it a commit takes whatever the user happened to have staged, which

--- a/source/git/git-storage.ts
+++ b/source/git/git-storage.ts
@@ -173,9 +173,14 @@ export const ensureStateBranchIsStorageOnly = async (
 		return failed(`Failed to clean storage branch\n${removeResult.message}`);
 	}
 
+	// Only the paths this repair removed. Without a pathspec the commit takes
+	// whatever else is in the index — and this runs during bootstrap, before
+	// the pull and before `assertLogOnlyGrew`, so event-log content a crashed
+	// sync left staged would be published here with no integrity check at all.
 	const commitResult = await commitAndGetSha({
 		cwd: stateBranchRoot,
 		message: '[epiq:repair-storage-branch]',
+		pathspec: disallowedFiles,
 	});
 
 	if (isFail(commitResult)) return failed(commitResult.message);

--- a/source/git/git-utils.ts
+++ b/source/git/git-utils.ts
@@ -11,7 +11,54 @@ export type GitExecResult = {
 	exitCode: number;
 };
 
+/**
+ * A local git call against a worktree holding only `.epiq/` answers in
+ * milliseconds. Ten seconds is already far past "something is wrong".
+ */
 const GIT_TIMEOUT_MS = 10_000;
+
+/**
+ * Everything whose duration is set by how much data there is rather than by
+ * whether anything is wrong: the calls that talk to a remote, and the ones
+ * that write the worktree out.
+ *
+ * A fetch is bounded by the link and by how much history and media the state
+ * branch carries, so the short cap turned "slow" into "timed out" — and a
+ * timed-out fetch used to read as *offline*, a quiet, self-healing-looking
+ * state that never healed. The others are worse when cut short than when slow:
+ * a SIGTERMed rebase leaves `.git/rebase-merge` for the next process to abort,
+ * and a SIGTERMed checkout or `worktree add` leaves the state worktree
+ * half-written — which is exactly what a second machine joining an established
+ * board does first.
+ *
+ * Long enough that reaching it means something is genuinely wrong rather than
+ * merely slow, and a caller that reaches it now hears about it.
+ */
+const GIT_SLOW_TIMEOUT_MS = 120_000;
+
+// Matched on argv rather than declared per call site: `execGit` is reached from
+// a dozen places and the cost of forgetting one is a truncated fetch.
+const SLOW_GIT_SUBCOMMANDS = new Set([
+	'fetch',
+	'push',
+	'pull',
+	'clone',
+	'ls-remote',
+	'rebase',
+	'checkout',
+	'worktree',
+]);
+
+const timeoutFor = (args: string[]): number => {
+	// `-c key=value` pairs precede the subcommand.
+	const subcommand = args.find(
+		(arg, index) => !arg.startsWith('-') && args[index - 1] !== '-c',
+	);
+
+	return subcommand && SLOW_GIT_SUBCOMMANDS.has(subcommand)
+		? GIT_SLOW_TIMEOUT_MS
+		: GIT_TIMEOUT_MS;
+};
 
 // A bare `spawn('git')` has execvp attempt an execve in every PATH directory
 // ahead of git's, and each miss costs milliseconds; resolve the path once.
@@ -91,13 +138,15 @@ const runGit = ({
 			resolve(value);
 		};
 
+		const timeoutMs = timeoutFor(args);
+
 		const timeout = setTimeout(() => {
 			child.kill('SIGTERM');
 
 			const message = [
 				`git ${args.join(' ')}`,
 				`cwd=${cwd}`,
-				`Git command timed out after ${GIT_TIMEOUT_MS}ms`,
+				`Git command timed out after ${timeoutMs}ms`,
 			].join('\n');
 
 			if (allowFail) {
@@ -105,7 +154,7 @@ const runGit = ({
 			} else {
 				finish(failed(message));
 			}
-		}, GIT_TIMEOUT_MS);
+		}, timeoutMs);
 
 		child.stdout.setEncoding('utf8');
 		child.stderr.setEncoding('utf8');
@@ -520,16 +569,23 @@ const readHeadSha = async (cwd: string): Promise<string | null> => {
 	return result.exitCode === 0 ? result.stdout.trim() : null;
 };
 
-// Network-level failures only. An auth or policy rejection reaches the user as
-// a failure, because it needs them to act; being offline does not.
+/**
+ * Network-level failures only. An auth or policy rejection reaches the user as
+ * a failure, because it needs them to act; being offline does not.
+ *
+ * Our own timeout is deliberately *not* here. A remote that answers, slowly,
+ * looked identical to one that is not there: the board reported "committed
+ * locally, offline", every later attempt hit the same cap, and the work never
+ * published — silently, forever. Being slow needs the user to act, so it
+ * reaches them as a failure like any other.
+ */
 export const isRemoteUnreachable = (message: string): boolean =>
 	/could not resolve host/i.test(message) ||
 	/connection refused|connection timed out|operation timed out/i.test(
 		message,
 	) ||
 	/network is unreachable|no route to host/i.test(message) ||
-	/failed to connect to/i.test(message) ||
-	/git command timed out after/i.test(message);
+	/failed to connect to/i.test(message);
 
 // git's wording when the branch does not exist on the remote.
 const isMissingRemoteRef = (message: string): boolean =>

--- a/source/git/git.ts
+++ b/source/git/git.ts
@@ -593,6 +593,13 @@ export const stageStateBranchOwnEventFile = async ({
  * Stages the content-addressed attachment blobs so they land in the same
  * commit as the events that reference them. Blobs are immutable and unique
  * per content, so staging the whole directory is always conflict-free.
+ *
+ * `--ignore-removal`, so a blob missing from the worktree is not committed as
+ * deleted. Nothing removes one on purpose — `delete.issue.attachment` writes a
+ * tombstone and keeps the bytes, precisely so a historical checkout can still
+ * render them — so a gap here is damage, and the same reasoning that makes
+ * `assertLogOnlyGrew` refuse a shrunken log applies: the last thing to do with
+ * a damaged worktree is publish it.
  */
 export const stageStateBranchMediaFiles = async ({
 	stateBranchRoot,
@@ -609,6 +616,7 @@ export const stageStateBranchMediaFiles = async ({
 	const stageResult = await git.stage({
 		cwd: stateBranchRoot,
 		pathspec: [mediaPath],
+		ignoreRemoval: true,
 	});
 
 	if (isFail(stageResult)) {

--- a/source/git/log-integrity.ts
+++ b/source/git/log-integrity.ts
@@ -53,6 +53,112 @@ export const findStrandedEventLogs = (root: string): Result<string[]> => {
 	}
 };
 
+export type EventLogSnapshot = ReadonlyMap<string, string[]>;
+
+const eventsDirIn = (root: string): string =>
+	path.join(root, EPIQ_DIR_NAME, EVENTS_DIR_NAME);
+
+/**
+ * Every event log line on disk right now, per file.
+ *
+ * Paired with `restoreDroppedEventLines` around anything that hands the
+ * worktree to git. `withSyncLock` binds the processes that *sync*; nothing
+ * binds the processes that *write*, so while one process rebases, another may
+ * be appending to and reading from the directory git is rewriting.
+ * `rebase.autoStash` widens that window — it reverts the working copy to HEAD
+ * and puts it back afterwards — and an interrupted rebase widens it further,
+ * since the next process recovers with `git rebase --abort`, which resets the
+ * working tree over anything written in between.
+ *
+ * Snapshotting is not a lock. It is the weaker guarantee that whatever was
+ * already on disk is still on disk when git is done, which is the same rule
+ * `assertLogOnlyGrew` enforces at the commit boundary: a log may gain lines
+ * and reorder nothing.
+ */
+export const snapshotEventLogs = (root: string): EventLogSnapshot => {
+	const dir = eventsDirIn(root);
+	const snapshot = new Map<string, string[]>();
+
+	try {
+		if (!fs.existsSync(dir)) return snapshot;
+
+		for (const name of fs.readdirSync(dir)) {
+			if (!name.endsWith('.jsonl')) continue;
+
+			snapshot.set(
+				name,
+				linesIn(fs.readFileSync(path.join(dir, name), 'utf8')),
+			);
+		}
+	} catch {
+		// Best effort by design: this is a safety net over git, and failing the
+		// sync because the net could not be strung would be the worse outcome.
+		return snapshot;
+	}
+
+	return snapshot;
+};
+
+/**
+ * Puts back any line the snapshot had that the file no longer does.
+ *
+ * Append-only makes this always safe: an id means one byte sequence forever,
+ * `getSortedEvents` dedupes by id, and file order is not load-bearing — so
+ * re-appending a line that is already there costs nothing and re-appending one
+ * git dropped restores an event that had no other copy.
+ *
+ * Returns the files it repaired, for the caller to report.
+ */
+export const restoreDroppedEventLines = (
+	root: string,
+	snapshot: EventLogSnapshot,
+): string[] => {
+	if (snapshot.size === 0) return [];
+
+	const dir = eventsDirIn(root);
+	const repaired: string[] = [];
+
+	for (const [name, lines] of snapshot) {
+		if (lines.length === 0) continue;
+
+		const filePath = path.join(dir, name);
+
+		try {
+			const present = new Set(
+				fs.existsSync(filePath)
+					? linesIn(fs.readFileSync(filePath, 'utf8'))
+					: [],
+			);
+
+			const dropped = lines.filter(line => !present.has(line));
+			if (dropped.length === 0) continue;
+
+			fs.mkdirSync(dir, {recursive: true});
+
+			// A file git truncated may have no trailing newline, and splicing a
+			// line onto a partial one would corrupt both.
+			const needsNewline =
+				fs.existsSync(filePath) &&
+				fs.readFileSync(filePath, 'utf8').replace(/\n$/, '').length > 0 &&
+				!fs.readFileSync(filePath, 'utf8').endsWith('\n');
+
+			fs.appendFileSync(
+				filePath,
+				`${needsNewline ? '\n' : ''}${dropped.join('\n')}\n`,
+				'utf8',
+			);
+
+			repaired.push(`${name} (${dropped.length})`);
+		} catch {
+			// Same reasoning as above: a net that cannot be checked is not a
+			// reason to fail the operation it was watching.
+			continue;
+		}
+	}
+
+	return repaired;
+};
+
 /** Lines present in `committed` that `working` no longer has. */
 export const findDroppedLines = (
 	committed: string,

--- a/source/git/log-integrity.ts
+++ b/source/git/log-integrity.ts
@@ -100,9 +100,26 @@ export const snapshotEventLogs = (root: string): EventLogSnapshot => {
 };
 
 /**
+ * A line worth putting back: one that parses, so it carries an id and can take
+ * its place in the causal order.
+ *
+ * A half-written line — a crash mid-append — has no id and is already lost to
+ * the loader, which quarantines it. Restoring one would only re-dirty the file
+ * and hand the next commit something to publish.
+ */
+const isRestorable = (line: string): boolean => {
+	try {
+		const parsed: unknown = JSON.parse(line);
+		return typeof parsed === 'object' && parsed !== null;
+	} catch {
+		return false;
+	}
+};
+
+/**
  * Puts back any line the snapshot had that the file no longer does.
  *
- * Append-only makes this always safe: an id means one byte sequence forever,
+ * Append-only makes this safe: an id means one byte sequence forever,
  * `getSortedEvents` dedupes by id, and file order is not load-bearing — so
  * re-appending a line that is already there costs nothing and re-appending one
  * git dropped restores an event that had no other copy.
@@ -124,13 +141,16 @@ export const restoreDroppedEventLines = (
 		const filePath = path.join(dir, name);
 
 		try {
-			const present = new Set(
-				fs.existsSync(filePath)
-					? linesIn(fs.readFileSync(filePath, 'utf8'))
-					: [],
-			);
+			const content = fs.existsSync(filePath)
+				? fs.readFileSync(filePath, 'utf8')
+				: null;
 
-			const dropped = lines.filter(line => !present.has(line));
+			const present = new Set(content === null ? [] : linesIn(content));
+
+			const dropped = lines
+				.filter(line => !present.has(line))
+				.filter(isRestorable);
+
 			if (dropped.length === 0) continue;
 
 			fs.mkdirSync(dir, {recursive: true});
@@ -138,9 +158,7 @@ export const restoreDroppedEventLines = (
 			// A file git truncated may have no trailing newline, and splicing a
 			// line onto a partial one would corrupt both.
 			const needsNewline =
-				fs.existsSync(filePath) &&
-				fs.readFileSync(filePath, 'utf8').replace(/\n$/, '').length > 0 &&
-				!fs.readFileSync(filePath, 'utf8').endsWith('\n');
+				content !== null && content.length > 0 && !content.endsWith('\n');
 
 			fs.appendFileSync(
 				filePath,

--- a/source/git/sync.ts
+++ b/source/git/sync.ts
@@ -31,6 +31,7 @@ import {
 	stageStateBranchMediaFiles,
 	stageStateBranchOwnEventFile,
 } from './git.js';
+import {restoreDroppedEventLines, snapshotEventLogs} from './log-integrity.js';
 import {withSyncLock} from './sync-lock.js';
 
 type SyncSummary = {
@@ -498,6 +499,41 @@ const runSync = async ({
 };
 
 /**
+ * Runs the sync with the event logs on disk held to their one rule: they may
+ * gain lines and lose none.
+ *
+ * Everything inside hands the worktree to git — a checkout, a `rebase
+ * --abort`, an autostash reverting the working copy to HEAD and putting it
+ * back — while other processes on this machine are appending to the same
+ * directory with no lock of their own. Lines that were there when we took the
+ * worktree and are not there when we give it back were lost by git, never
+ * removed on purpose, so they go back.
+ *
+ * `finally`, because a sync that failed part-way is exactly when a rebase is
+ * left half-applied.
+ */
+const withEventLogsIntact = async <T>(
+	stateBranchRoot: string,
+	fn: () => Promise<T>,
+): Promise<T> => {
+	const snapshot = snapshotEventLogs(stateBranchRoot);
+
+	try {
+		return await fn();
+	} finally {
+		const repaired = restoreDroppedEventLines(stateBranchRoot, snapshot);
+
+		if (repaired.length > 0) {
+			logger.error(
+				`[sync] restored event log lines git dropped from the worktree: ${repaired.join(
+					', ',
+				)}`,
+			);
+		}
+	}
+};
+
+/**
  * Only one process may drive the state worktree at a time.
  *
  * `runExclusive` covers a single process; this covers the several that share
@@ -532,7 +568,7 @@ export const syncEpiqWithRemote = async (
 	const lockedResult = await withSyncLock({
 		worktreeRoot: stateBranchRoot,
 		operation: 'sync',
-		fn: () => runSync(args),
+		fn: () => withEventLogsIntact(stateBranchRoot, () => runSync(args)),
 	});
 	if (isFail(lockedResult)) return failSync(lockedResult.message);
 

--- a/source/lib/event/event-load.ts
+++ b/source/lib/event/event-load.ts
@@ -12,6 +12,7 @@ import {
 	parsePersistedEnvelope,
 	PersistedEnvelope,
 } from './event-persist.js';
+import {parseEventPayload} from './event-payload.schema.js';
 
 const EventFileNameSchema = z.object({
 	userId: z.string().min(1).default('unknown'),
@@ -235,6 +236,21 @@ export const decodeReconstructedEvents = (
 				eventId: entry.id[0],
 				reason: 'unknown-action',
 				detail: action,
+				targetNodeId: getTargetNodeId(entry),
+			});
+			continue;
+		}
+
+		// The action is one we know, so the payload is one we are about to
+		// dereference. Quarantined like any other unreadable line rather than
+		// handed to a materializer that assumes a well-behaved writer produced
+		// it — the same reasoning as the envelope check above, one layer in.
+		const payloadResult = parseEventPayload(action, eventResult.value.payload);
+		if (isFail(payloadResult)) {
+			unreadable?.push({
+				eventId: entry.id[0],
+				reason: 'invalid-payload',
+				detail: payloadResult.message,
 				targetNodeId: getTargetNodeId(entry),
 			});
 			continue;

--- a/source/lib/event/event-materialize.ts
+++ b/source/lib/event/event-materialize.ts
@@ -952,7 +952,23 @@ export function materialize<A extends EventAction>(
 		replayBatch.genesisApplied = true;
 	}
 
-	const result = handler(event);
+	// Last line of defence. Payloads are validated on load and every
+	// precondition below is a `materializeSkip`, but a handler this build gets
+	// wrong must still not stop the board: a throw here escapes every `isFail`
+	// on the boot path, and the log that caused it is append-only and already
+	// in every clone. Converging on a skipped event beats never opening again.
+	let result: MaterializeResult<A>;
+	try {
+		result = handler(event);
+	} catch (error) {
+		return materializeSkip(
+			`threw while materializing (${
+				error instanceof Error ? error.message : String(error)
+			})`,
+			event,
+		);
+	}
+
 	if (isFail(result)) return result;
 
 	const completionFail = completeMaterialization(event, bypassLogging);

--- a/source/lib/event/event-materialize.ts
+++ b/source/lib/event/event-materialize.ts
@@ -276,6 +276,35 @@ const completeMaterialization = (
 	return null;
 };
 
+/**
+ * The two ways a creation event can damage state rather than add to it.
+ *
+ * `createNode` writes into the node map unconditionally — it has to, since the
+ * TUI rebuilds ephemeral nodes under fixed ids on every render — so a second
+ * `add.*` naming a live id replaces that node's title, rank, parent,
+ * description, tags, assignees and readonly flag. And a node that is its own
+ * parent turns every ancestor walk into a loop.
+ *
+ * Neither is reachable from this build's writers; both are reachable from a
+ * log, which is why they are convergence skips rather than failures. First
+ * writer wins, which is the only choice that converges.
+ */
+const refuseUncreatableNode = (
+	id: string,
+	parentId: string | undefined,
+	event: AppEvent,
+): ConvergenceFail | null => {
+	if (nodeRepo.getNode(id)) {
+		return materializeSkip(`a node with id ${id} already exists`, event);
+	}
+
+	if (parentId === id) {
+		return materializeSkip('a node cannot be its own parent', event);
+	}
+
+	return null;
+};
+
 const materializeHandlers: MaterializeHandlers = {
 	'init.workspace': event => {
 		const {id, name, rank} = event.payload;
@@ -306,6 +335,10 @@ const materializeHandlers: MaterializeHandlers = {
 
 	'add.workspace': event => {
 		const {id, name, rank} = event.payload;
+
+		const uncreatable = refuseUncreatableNode(id, undefined, event);
+		if (uncreatable) return uncreatable;
+
 		const result = nodeRepo.createNode(nodes.workspace(id, name, rank));
 
 		if (isFail(result)) {
@@ -327,6 +360,10 @@ const materializeHandlers: MaterializeHandlers = {
 
 	'add.board': event => {
 		const {id, name, parent: parentId, rank} = event.payload;
+
+		const uncreatable = refuseUncreatableNode(id, parentId, event);
+		if (uncreatable) return uncreatable;
+
 		const result = nodeRepo.createNode(nodes.board(id, name, parentId, rank));
 
 		if (isFail(result)) {
@@ -345,6 +382,10 @@ const materializeHandlers: MaterializeHandlers = {
 
 	'add.swimlane': event => {
 		const {id, name, parent: parentId, rank} = event.payload;
+
+		const uncreatable = refuseUncreatableNode(id, parentId, event);
+		if (uncreatable) return uncreatable;
+
 		const result = nodeRepo.createNode(
 			nodes.swimlane(id, name, parentId, rank),
 		);
@@ -368,6 +409,10 @@ const materializeHandlers: MaterializeHandlers = {
 
 	'add.issue': event => {
 		const {id, name, parent: parentId, rank} = event.payload;
+
+		const uncreatable = refuseUncreatableNode(id, parentId, event);
+		if (uncreatable) return uncreatable;
+
 		const result = nodeRepo.createNode(nodes.ticket(id, name, parentId, rank));
 
 		if (isFail(result)) {
@@ -386,6 +431,9 @@ const materializeHandlers: MaterializeHandlers = {
 
 	'add.field': event => {
 		const {id, name, parent: parentId, val: value, rank} = event.payload;
+
+		const uncreatable = refuseUncreatableNode(id, parentId, event);
+		if (uncreatable) return uncreatable;
 
 		const result = nodeRepo.createNode(
 			nodes.field({

--- a/source/lib/event/event-payload.schema.ts
+++ b/source/lib/event/event-payload.schema.ts
@@ -1,0 +1,119 @@
+import {z} from 'zod';
+import {failed, Result, succeeded} from '../model/result-types.js';
+import {EventAction} from './event.model.js';
+
+/**
+ * What a payload has to look like before a materializer is allowed to touch it.
+ *
+ * The envelope (`v`, `id`) was the only part ever parsed, so a line that is
+ * valid JSON at a supported version naming a known action reached its handler
+ * with any shape at all. A peer's log arrives over `merge=union` and the log is
+ * append-only, so one such line stopped the board for everybody, permanently:
+ * a numeric `rank` threw out of `derive`, a numeric id threw in `nodeRef`, a
+ * null `ranks` threw in `Object.entries`, and a node naming itself as its own
+ * parent made the move guard's ancestor walk run forever.
+ *
+ * Two rules shape these schemas:
+ *
+ * - **Loose, never strict.** Every object accepts unknown keys, because a
+ *   newer epiq may add a field to an existing action without bumping
+ *   `SCHEMA_VERSION`. Rejecting those would quarantine events this build can
+ *   read perfectly well.
+ * - **Require only what a handler dereferences.** These are not a description
+ *   of the domain; they are the preconditions the code already assumes.
+ *   Anything narrower (an enum of extensions, a rank's hex shape) belongs in
+ *   the handler as a `materializeSkip`, where a future value is a skipped
+ *   event rather than a quarantined one.
+ */
+
+const id = z.string().min(1);
+const name = z.string();
+const rank = z.string();
+
+const withId = z.looseObject({id});
+
+const positioned = z.looseObject({
+	id,
+	name,
+	parent: id,
+	rank,
+});
+
+const EventPayloadSchemas: Record<EventAction, z.ZodType> = {
+	'init.workspace': z.looseObject({id, name, rank}),
+	'add.workspace': z.looseObject({id, name, rank}),
+	'add.board': positioned,
+	'add.swimlane': positioned,
+	'add.issue': positioned,
+	// `val` is unconstrained: the handler puts it straight into the node's
+	// props without reading it, so a shape this build did not expect costs
+	// nothing, while requiring one would drop the field node entirely.
+	'add.field': z.looseObject({id, name, parent: id, rank}),
+
+	'edit.title': z.looseObject({id, name}),
+	'delete.node': withId,
+	'lock.node': withId,
+	'move.node': z.looseObject({id, parent: id, rank}),
+	'edit.description': z.looseObject({id, md: z.string()}),
+
+	'close.issue': z.looseObject({id, parent: id, rank}),
+	'reopen.issue': z.looseObject({id, parent: id, rank}),
+
+	'create.tag': z.looseObject({id, name}),
+	'tombstone.tag': withId,
+	'restore.tag': z.looseObject({id, name}),
+
+	'create.contributor': z.looseObject({id, name}),
+	'rename.contributor': z.looseObject({id, name}),
+	'tombstone.contributor': withId,
+	'restore.contributor': z.looseObject({id, name}),
+	'link.contributor.user': z.looseObject({contributor: id}),
+
+	'add.issue.assignee': z.looseObject({id, assignee: id}),
+	'remove.issue.assignee': z.looseObject({id, assignee: id}),
+	'add.issue.tag': z.looseObject({id, tag: id}),
+	'remove.issue.tag': z.looseObject({id, tag: id}),
+
+	// `author` is unconstrained on both, though the type declares it. The
+	// attachment handler never reads it, and the comment handler resolves it
+	// through the registry and falls back to "Unknown" — and this board's log
+	// already holds an attachment written without one. Requiring it would have
+	// made that attachment disappear, which is the exact damage this check
+	// exists to prevent.
+	'add.issue.comment': z.looseObject({id, issue: id, md: z.string()}),
+	'edit.issue.comment': z.looseObject({id, issue: id, md: z.string()}),
+	'delete.issue.comment': z.looseObject({id, issue: id}),
+
+	'add.issue.attachment': z.looseObject({
+		id,
+		issue: id,
+		hash: z.string().min(1),
+		ext: z.string().min(1),
+		name,
+		bytes: z.number(),
+	}),
+	'delete.issue.attachment': z.looseObject({id, issue: id}),
+
+	// Values are ranks, keys node ids. `Object.entries` over anything else
+	// throws, and a rank that is not a string reaches the child index sort.
+	'rebalance.children': z.looseObject({
+		parent: id,
+		ranks: z.record(z.string(), rank),
+	}),
+};
+
+export const parseEventPayload = (
+	action: EventAction,
+	payload: unknown,
+): Result<void> => {
+	const schema = EventPayloadSchemas[action];
+
+	const result = schema.safeParse(payload);
+	if (result.success) return succeeded('Payload is readable', undefined);
+
+	return failed(
+		`${action}: ${result.error.issues
+			.map(issue => `${issue.path.join('.') || 'payload'} ${issue.message}`)
+			.join(', ')}`,
+	);
+};

--- a/source/lib/repository/node-repo.ts
+++ b/source/lib/repository/node-repo.ts
@@ -17,6 +17,13 @@ import {
 import {getState, patchState, updateState} from '../state/state.js';
 import {getOrderedChildren} from './rank.js';
 
+/**
+ * Every walk up `parentNodeId` bounds itself on the nodes it has already
+ * seen. The tree is acyclic as long as only this build's writers built it —
+ * `moveNodeToRank` refuses a move into a descendant, and applying those one at
+ * a time can never close a loop — but the node map is built from a log, and a
+ * loop there costs a hung process rather than a wrong answer.
+ */
 export const findAncestor = <T extends AnyContext>(
 	targetId: string,
 	ctx: T,
@@ -30,12 +37,15 @@ export const findAncestor = <T extends AnyContext>(
 		return succeeded('Resolved ancestor node', start as NavNode<T>);
 	}
 
+	const seen = new Set<string>([start.id]);
 	let current = start.parentNodeId ? nodes[start.parentNodeId] : undefined;
 
-	while (current) {
+	while (current && !seen.has(current.id)) {
 		if (current.context === ctx) {
 			return succeeded('Resolved ancestor node', current as NavNode<T>);
 		}
+
+		seen.add(current.id);
 		current = current.parentNodeId ? nodes[current.parentNodeId] : undefined;
 	}
 
@@ -45,9 +55,13 @@ export const findAncestor = <T extends AnyContext>(
 export const isDescendantOf = (nodeId: string, ancestorId: string): boolean => {
 	const {nodes} = getState();
 
+	const seen = new Set<string>();
 	let current = nodes[nodeId];
-	while (current?.parentNodeId) {
+
+	while (current?.parentNodeId && !seen.has(current.id)) {
 		if (current.parentNodeId === ancestorId) return true;
+
+		seen.add(current.id);
 		current = nodes[current.parentNodeId];
 	}
 

--- a/source/lib/utils/nav-tree.ts
+++ b/source/lib/utils/nav-tree.ts
@@ -13,10 +13,16 @@ export function buildBreadCrumb(
 	}
 
 	const path: NavNode<AnyContext>[] = [];
+	// Bounded on nodes already seen: this walk runs inside `derive`, so a loop
+	// in the node map would hang every render rather than fail one lookup.
+	// A loop cannot reach the root, so stopping leaves the "not connected to
+	// root" failure below to report it.
+	const seen = new Set<string>();
 	let current: NavNode<AnyContext> | undefined = contextNode;
 
-	while (current) {
+	while (current && !seen.has(current.id)) {
 		path.push(current);
+		seen.add(current.id);
 
 		if (current.id === rootNodeId) break;
 		if (!current.parentNodeId) break;

--- a/source/lib/utils/rank.ts
+++ b/source/lib/utils/rank.ts
@@ -46,8 +46,14 @@ export function rankBetween(prev?: string, next?: string): Result<string> {
 	const a = aResult.value;
 	const b = bResult.value;
 
+	// Neighbours out of order, or holding the same rank — which two clients
+	// appending to one lane while unsynced produce routinely, since both read
+	// the same last sibling and compute the same midpoint. Returning the middle
+	// of the whole space instead put the node somewhere nobody asked for, and
+	// could collide again. A failure is what `resolveMoveRank` turns into
+	// `needsRebalance`, and rebalancing is the repair this case wants.
 	if (b <= a) {
-		return bigIntToHex(MAX_RANK / 2n, HEX_LEN);
+		return failed('Neighbouring ranks leave no space between them');
 	}
 
 	const mid = (a + b) / 2n;

--- a/source/test/e2e-collab/actor.ts
+++ b/source/test/e2e-collab/actor.ts
@@ -32,6 +32,10 @@ import type {ActorJob, ActorReport} from './protocol.js';
 const job = JSON.parse(process.argv[2] ?? '{}') as ActorJob;
 const problems: string[] = [];
 
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+if (job.startDelayMs) await sleep(job.startDelayMs);
+
 const settings = loadSettingsFromConfig();
 if (isFail(settings)) problems.push(`settings: ${settings.message}`);
 else patchSettingsState(settings.value);
@@ -102,6 +106,8 @@ for (const action of swimlaneId === null ? [] : job.actions) {
 			  });
 
 	if (isFail(result)) problems.push(`${action.kind}: ${result.message}`);
+
+	if (job.pauseMs) await sleep(job.pauseMs);
 }
 
 if (job.sync) {

--- a/source/test/e2e-collab/harness.ts
+++ b/source/test/e2e-collab/harness.ts
@@ -7,7 +7,9 @@ import path from 'node:path';
 import {fileURLToPath} from 'node:url';
 import {ulid} from 'ulid';
 import {execGit} from '../../git/git-utils.js';
+import {deriveActorId} from '../../lib/config/actor-env.js';
 import {isFail} from '../../lib/model/result-types.js';
+import {sanitizeFilePart} from '../../lib/utils/file-part.js';
 import type {ActorAction, ActorJob, ActorReport} from './protocol.js';
 
 const STATE_BRANCH = 'epiq/state';
@@ -26,6 +28,9 @@ export type Actor = {
 	// Identity and the state worktree both live here, so this is what makes two
 	// clones two different machines.
 	globalDir: string;
+	// Set when this identity comes from the environment rather than
+	// `config.json` — a second tool on somebody's machine, not a second machine.
+	envActorName?: string;
 };
 
 export type Collaboration = {
@@ -135,13 +140,40 @@ export const startCollaboration = async ({
 	return {remoteRoot, actors, dirs};
 };
 
+/**
+ * A second tool on the same machine: the same clone, the same state worktree,
+ * a different identity. That is a GUI beside an MCP server beside a TUI —
+ * several processes appending to one events directory — as opposed to
+ * `startCollaboration`, whose actors are separate machines.
+ *
+ * The identity comes from `EPIQ_USER_NAME`, so it must be derived the way
+ * `resolveEnvActor` derives it or the two would disagree about which log file
+ * is this actor's own.
+ */
+export const sameMachineTool = (host: Actor, name: string): Actor => ({
+	name,
+	userId: deriveActorId(name),
+	userName: name.trim().toLowerCase(),
+	repoRoot: host.repoRoot,
+	globalDir: host.globalDir,
+	envActorName: name,
+});
+
 export const runActor = async (
 	actor: Actor,
 	{
 		actions,
 		sync,
 		init = false,
-	}: {actions: ActorAction[]; sync: boolean; init?: boolean},
+		startDelayMs,
+		pauseMs,
+	}: {
+		actions: ActorAction[];
+		sync: boolean;
+		init?: boolean;
+		startDelayMs?: number;
+		pauseMs?: number;
+	},
 ): Promise<ActorReport> => {
 	const reportPath = path.join(actor.globalDir, `report-${ulid()}.json`);
 	const job: ActorJob = {
@@ -152,6 +184,8 @@ export const runActor = async (
 		init,
 		sync,
 		reportPath,
+		startDelayMs,
+		pauseMs,
 	};
 
 	const stderr = await new Promise<string>((resolve, reject) => {
@@ -161,6 +195,7 @@ export const runActor = async (
 				...process.env,
 				EPIQ_GLOBAL_DIR: actor.globalDir,
 				IS_LOCAL: 'true',
+				...(actor.envActorName ? {EPIQ_USER_NAME: actor.envActorName} : {}),
 			},
 		});
 
@@ -185,6 +220,57 @@ export const runActor = async (
 	return JSON.parse(fs.readFileSync(reportPath, 'utf8')) as ActorReport;
 };
 
+/**
+ * Starts an actor and kills it partway through, without waiting for a report.
+ *
+ * A sync that dies mid-git is not exotic: the 10s cap on every git call
+ * SIGTERMs a slow fetch, an agent session ends, a laptop sleeps. What it
+ * leaves behind — a stopped rebase, a stash nobody popped — is what the next
+ * process has to cope with.
+ */
+export const runActorAndKill = async (
+	actor: Actor,
+	{
+		actions,
+		sync,
+		killAfterMs,
+	}: {actions: ActorAction[]; sync: boolean; killAfterMs: number},
+): Promise<void> => {
+	const reportPath = path.join(actor.globalDir, `report-${ulid()}.json`);
+	const job: ActorJob = {
+		repoRoot: actor.repoRoot,
+		userId: actor.userId,
+		userName: actor.userName,
+		actions,
+		sync,
+		reportPath,
+	};
+
+	await new Promise<void>(resolve => {
+		const child = spawn(TSX, [ACTOR_ENTRY, JSON.stringify(job)], {
+			cwd: actor.repoRoot,
+			stdio: 'ignore',
+			env: {
+				...process.env,
+				EPIQ_GLOBAL_DIR: actor.globalDir,
+				IS_LOCAL: 'true',
+				...(actor.envActorName ? {EPIQ_USER_NAME: actor.envActorName} : {}),
+			},
+		});
+
+		const timer = setTimeout(() => child.kill('SIGKILL'), killAfterMs);
+
+		child.on('error', () => {
+			clearTimeout(timer);
+			resolve();
+		});
+		child.on('close', () => {
+			clearTimeout(timer);
+			resolve();
+		});
+	});
+};
+
 export const cleanUp = ({dirs}: Collaboration): void => {
 	for (const dir of dirs) fs.rmSync(dir, {recursive: true, force: true});
 };
@@ -207,6 +293,29 @@ export const stateBranchRootFor = (actor: Actor): string => {
 
 export const ownLogPathFor = (actor: Actor, fileName: string): string =>
 	path.join(stateBranchRootFor(actor), '.epiq', 'events', fileName);
+
+/** The log file this actor writes, named the way `persist` names it. */
+export const logFileNameFor = (actor: Actor): string =>
+	`${sanitizeFilePart(actor.userId)}.${sanitizeFilePart(actor.userName)}.jsonl`;
+
+/** Event ids currently in this actor's own log, straight off disk. */
+export const idsInOwnLog = (actor: Actor): string[] => {
+	const logPath = ownLogPathFor(actor, logFileNameFor(actor));
+	if (!fs.existsSync(logPath)) return [];
+
+	return fs
+		.readFileSync(logPath, 'utf8')
+		.split('\n')
+		.flatMap(line => {
+			if (!line.trim()) return [];
+			try {
+				const id = (JSON.parse(line) as {id?: [string, string | null]}).id;
+				return Array.isArray(id) && typeof id[0] === 'string' ? [id[0]] : [];
+			} catch {
+				return [];
+			}
+		});
+};
 
 /**
  * Appends bytes to an actor's own log without going through `persist`.

--- a/source/test/e2e-collab/killed-sync.test.ts
+++ b/source/test/e2e-collab/killed-sync.test.ts
@@ -1,0 +1,146 @@
+/**
+ * A sync that dies partway through, and the writes that come after it.
+ *
+ * Every git call is capped at 10 seconds and SIGTERMed at the cap, an agent's
+ * MCP server is killed when its session ends, and a laptop sleeps mid-fetch.
+ * All three leave the state worktree in a state git calls "rebase in
+ * progress": HEAD detached, an autostash holding whatever was uncommitted.
+ *
+ * The next epiq process recovers by running `git rebase --abort`, and an abort
+ * resets the working tree. Anything a *write* put in that directory in the
+ * meantime is in the working tree and not in any commit — so the question this
+ * asks is whether recovery takes those writes with it.
+ *
+ * The board is allowed to be behind. It is not allowed to lose an issue it
+ * said it had created.
+ */
+import {afterEach, describe, expect, it} from 'vitest';
+import {
+	cleanUp,
+	runActor,
+	runActorAndKill,
+	startCollaboration,
+	type Actor,
+	type Collaboration,
+} from './harness.js';
+import type {ActorReport} from './protocol.js';
+
+const TIMEOUT_MS = 900_000;
+const ROUNDS = 8;
+const COMMITS_PER_ROUND = 6;
+const WRITES_PER_ROUND = 6;
+
+let running: Collaboration | null = null;
+
+afterEach(() => {
+	if (running) cleanUp(running);
+	running = null;
+});
+
+const create = (n: number, by: string) =>
+	Array.from({length: n}, (_, index) => ({
+		kind: 'create' as const,
+		title: `${by}-${index}`,
+	}));
+
+const titlesIn = (report: ActorReport): Set<string> =>
+	new Set(report.issues.map(entry => entry.split('\t')[1] ?? ''));
+
+describe('a sync killed partway through', () => {
+	it(
+		'does not take later writes with it when the next process recovers',
+		async () => {
+			const collab = await startCollaboration({names: ['ana', 'bo']});
+			running = collab;
+
+			const [ana, bo] = collab.actors as [Actor, Actor];
+
+			expect(
+				(await runActor(ana, {init: true, actions: [], sync: true})).problems,
+				'ana creating the project',
+			).toEqual([]);
+			expect(
+				(await runActor(bo, {actions: [], sync: true})).problems,
+				'bo joining',
+			).toEqual([]);
+
+			const expected: string[] = [];
+
+			for (let round = 0; round < ROUNDS; round += 1) {
+				// Work for ana's rebase to be partway through when it dies.
+				for (let commit = 0; commit < COMMITS_PER_ROUND; commit += 1) {
+					const published = await runActor(bo, {
+						actions: create(2, `bo-r${round}c${commit}`),
+						sync: true,
+					});
+					expect(
+						published.problems,
+						`bo publishing r${round}c${commit}`,
+					).toEqual([]);
+				}
+
+				// Killed at a different point each round, so the window lands
+				// somewhere different in the sync every time.
+				await runActorAndKill(ana, {
+					actions: [],
+					sync: true,
+					killAfterMs: 900 + round * 250,
+				});
+
+				// Now write, into whatever the killed process left behind.
+				const titles = create(WRITES_PER_ROUND, `after-kill-r${round}`).map(
+					action => action.title,
+				);
+
+				const writing = await runActor(ana, {
+					actions: create(WRITES_PER_ROUND, `after-kill-r${round}`),
+					sync: false,
+				});
+
+				const refused = writing.problems.filter(problem =>
+					problem.startsWith('create:'),
+				);
+
+				// A refusal is a legitimate answer — the board saying no is not the
+				// board losing something. Only what it accepted is tracked.
+				if (refused.length === 0) expected.push(...titles);
+
+				// And then a normal sync, which is where recovery happens.
+				const recovered = await runActor(ana, {actions: [], sync: true});
+				expect(
+					recovered.problems.filter(
+						problem => !/Another process is syncing/.test(problem),
+					),
+					`ana recovering after round ${round}`,
+				).toEqual([]);
+
+				const stillHere = titlesIn(recovered);
+				expect(
+					titles.filter(
+						title => expected.includes(title) && !stillHere.has(title),
+					),
+					`issues written after the kill in round ${round}`,
+				).toEqual([]);
+			}
+
+			const settled = await runActor(ana, {actions: [], sync: true});
+			const received = await runActor(bo, {actions: [], sync: true});
+
+			expect(settled.problems, 'ana settling').toEqual([]);
+			expect(received.problems, 'bo settling').toEqual([]);
+
+			const mine = titlesIn(settled);
+			const theirs = titlesIn(received);
+
+			expect(
+				expected.filter(title => !mine.has(title)),
+				'issues gone from the machine that wrote them',
+			).toEqual([]);
+			expect(
+				expected.filter(title => !theirs.has(title)),
+				'issues that never reached the other machine',
+			).toEqual([]);
+		},
+		TIMEOUT_MS,
+	);
+});

--- a/source/test/e2e-collab/protocol.ts
+++ b/source/test/e2e-collab/protocol.ts
@@ -15,6 +15,12 @@ export type ActorJob = {
 	init?: boolean;
 	sync: boolean;
 	reportPath: string;
+	// Holds the process still before it starts, so two of them can be aimed at
+	// the same moment rather than merely started together.
+	startDelayMs?: number;
+	// Spreads the actions out, so a writer stays writing for as long as the
+	// sync it is racing takes.
+	pauseMs?: number;
 };
 
 export type ActorReport = {

--- a/source/test/e2e-collab/slow-remote.test.ts
+++ b/source/test/e2e-collab/slow-remote.test.ts
@@ -1,0 +1,129 @@
+/**
+ * A remote that is reachable, but slower than the 10-second cap every git
+ * call in `git-utils.ts` runs under.
+ *
+ * The cap SIGTERMs the child and reports "Git command timed out after
+ * 10000ms", and `isRemoteUnreachable` matches that string — so a slow link and
+ * an absent one produce the same answer: `offline`, "Committed locally". A
+ * state branch carrying a few hundred attachment blobs, a phone hotspot, or a
+ * repository host having a bad minute all land here, and the board reports
+ * that it saved the work locally rather than that it cannot publish.
+ *
+ * Simulated with git's `ext::` transport rather than a real slow network: it
+ * is a genuine remote, reached by a genuine fetch, that simply takes longer
+ * than the cap allows.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import {afterEach, describe, expect, it} from 'vitest';
+import {execGit} from '../../git/git-utils.js';
+import {isFail} from '../../lib/model/result-types.js';
+import {
+	cleanUp,
+	runActor,
+	startCollaboration,
+	type Actor,
+	type Collaboration,
+} from './harness.js';
+
+const TIMEOUT_MS = 600_000;
+
+let running: Collaboration | null = null;
+
+afterEach(() => {
+	if (running) cleanUp(running);
+	running = null;
+});
+
+const git = async (cwd: string, args: string[]): Promise<void> => {
+	const result = await execGit({args, cwd});
+	if (isFail(result)) {
+		throw new Error(`git ${args.join(' ')}\n${result.message}`);
+	}
+};
+
+/**
+ * Points every clone of this repository at a transport that pauses before
+ * serving. `%s` is the service name git asks for (`upload-pack`,
+ * `receive-pack`), so both directions go through the pause.
+ */
+const slowDownRemote = async (
+	actor: Actor,
+	remoteRoot: string,
+	seconds: number,
+): Promise<void> => {
+	// A script rather than an inline `sh -c`: git's ext:: transport splits its
+	// command on whitespace, so quoting does not survive the round trip.
+	const script = path.join(actor.globalDir, 'slow-transport.sh');
+	fs.writeFileSync(
+		script,
+		['#!/bin/sh', `sleep ${seconds}`, 'exec "git-$1" "$2"', ''].join('\n'),
+		{mode: 0o755},
+	);
+
+	const url = `ext::${script} %s ${remoteRoot}`;
+
+	// Off by default since git 2.x; this is test scaffolding, not a change to
+	// how epiq talks to a remote.
+	await git(actor.repoRoot, [
+		'config',
+		'--local',
+		'protocol.ext.allow',
+		'always',
+	]);
+	await git(actor.repoRoot, ['remote', 'set-url', 'origin', url]);
+
+	// The state branch lives in its own worktree, but shares the clone's
+	// config, so this is the same remote the sync will use.
+};
+
+describe('a remote that answers, slowly', () => {
+	it(
+		'tells the difference between a slow remote and no remote',
+		async () => {
+			const collab = await startCollaboration({names: ['ana', 'bo']});
+			running = collab;
+
+			const [ana, bo] = collab.actors as [Actor, Actor];
+
+			expect(
+				(await runActor(ana, {init: true, actions: [], sync: true})).problems,
+				'ana creating the project',
+			).toEqual([]);
+			expect(
+				(await runActor(bo, {actions: [], sync: true})).problems,
+				'bo joining',
+			).toEqual([]);
+
+			// Something for ana to publish, and something for bo to be missing.
+			await slowDownRemote(ana, collab.remoteRoot, 12);
+
+			const report = await runActor(ana, {
+				actions: [{kind: 'create', title: 'written-over-a-slow-link'}],
+				sync: true,
+			});
+
+			// Whatever it does, it must not claim success and it must not lose the
+			// issue locally.
+			expect(
+				report.issues.some(entry => entry.endsWith('written-over-a-slow-link')),
+				'the issue is on ana’s own board',
+			).toBe(true);
+
+			// Bo is the proof: ana was told nothing was wrong, and the work is
+			// still only on her machine.
+			const received = await runActor(bo, {actions: [], sync: true});
+			expect(received.problems, 'bo settling').toEqual([]);
+
+			const reachedBo = received.issues.some(entry =>
+				entry.endsWith('written-over-a-slow-link'),
+			);
+
+			expect(
+				{reachedBo, problems: report.problems},
+				'a reachable remote that is merely slow must still receive the work',
+			).toEqual({reachedBo: true, problems: []});
+		},
+		TIMEOUT_MS,
+	);
+});

--- a/source/test/e2e-collab/write-during-sync.test.ts
+++ b/source/test/e2e-collab/write-during-sync.test.ts
@@ -1,0 +1,221 @@
+/**
+ * One machine, several tools, one of them writing while another syncs.
+ *
+ * `concurrent-sync.test.ts` races several syncs against each other, and the
+ * sync lock settles those. Nothing holds that lock on the write path:
+ * `persist` appends and `loadMergedEvents` reads with no lock at all, while a
+ * sync in another process is rewriting the same directory — `git rebase`
+ * replays commits over that worktree, and `rebase.autoStash` reverts the
+ * working copy to HEAD and puts it back afterwards.
+ *
+ * A GUI beside an MCP server beside a TUI is the ordinary arrangement for an
+ * agent-driven board, and only one of them has to be syncing for the others to
+ * be writing into a directory git is part-way through rewriting.
+ *
+ * The contract under test is the narrowest one there is: an issue the board
+ * accepted has to still exist afterwards, on every machine. Nothing about
+ * ordering, nothing about ranks.
+ */
+import {afterEach, describe, expect, it} from 'vitest';
+import {
+	cleanUp,
+	runActor,
+	sameMachineTool,
+	startCollaboration,
+	type Actor,
+	type Collaboration,
+} from './harness.js';
+import type {ActorReport} from './protocol.js';
+
+const TIMEOUT_MS = 900_000;
+const ROUNDS = 6;
+// Enough commits that the rebase is still replaying when the writer starts.
+const COMMITS_PER_ROUND = 8;
+const WRITES_PER_ROUND = 20;
+
+let running: Collaboration | null = null;
+
+afterEach(() => {
+	if (running) cleanUp(running);
+	running = null;
+});
+
+const create = (n: number, by: string) =>
+	Array.from({length: n}, (_, index) => ({
+		kind: 'create' as const,
+		title: `${by}-${index}`,
+	}));
+
+const titlesIn = (report: ActorReport): Set<string> =>
+	new Set(report.issues.map(entry => entry.split('\t')[1] ?? ''));
+
+/** Titles the board accepted — a refused create is not a lost one. */
+const acceptedTitles = (report: ActorReport, expected: string[]): string[] => {
+	const refused = report.problems.filter(problem =>
+		problem.startsWith('create:'),
+	);
+
+	return refused.length > 0 ? [] : expected;
+};
+
+const publishRemoteWork = async (peer: Actor, round: number): Promise<void> => {
+	for (let commit = 0; commit < COMMITS_PER_ROUND; commit += 1) {
+		const published = await runActor(peer, {
+			actions: create(2, `peer-r${round}c${commit}`),
+			sync: true,
+		});
+
+		expect(published.problems, `peer publishing r${round}c${commit}`).toEqual(
+			[],
+		);
+	}
+};
+
+describe('a tool writes while another process syncs the same worktree', () => {
+	// Two identities in one events directory: an agent's MCP server beside the
+	// user's own GUI. Different log files, one worktree, one git checkout.
+	it(
+		'keeps issues written by a second tool during a sync',
+		async () => {
+			const collab = await startCollaboration({names: ['ana', 'bo']});
+			running = collab;
+
+			const [ana, bo] = collab.actors as [Actor, Actor];
+			const agent = sameMachineTool(ana, 'agent');
+
+			expect(
+				(await runActor(ana, {init: true, actions: [], sync: true})).problems,
+				'ana creating the project',
+			).toEqual([]);
+			expect(
+				(await runActor(bo, {actions: [], sync: true})).problems,
+				'bo joining',
+			).toEqual([]);
+
+			// Publishes the agent's log, so it is tracked from here on: an
+			// untracked file is not what a rebase or an autostash touches.
+			expect(
+				(await runActor(agent, {actions: create(1, 'warmup'), sync: true}))
+					.problems,
+				'agent registering',
+			).toEqual([]);
+
+			const expected: string[] = [];
+
+			for (let round = 0; round < ROUNDS; round += 1) {
+				await publishRemoteWork(bo, round);
+
+				const titles = create(WRITES_PER_ROUND, `agent-r${round}`).map(
+					action => action.title,
+				);
+
+				const [syncing, writing] = await Promise.all([
+					runActor(ana, {actions: [], sync: true}),
+					runActor(agent, {
+						actions: create(WRITES_PER_ROUND, `agent-r${round}`),
+						sync: false,
+						startDelayMs: 120,
+						pauseMs: 25,
+					}),
+				]);
+
+				expect(
+					syncing.problems.filter(p => !/Another process is syncing/.test(p)),
+					`ana syncing round ${round}`,
+				).toEqual([]);
+
+				expected.push(...acceptedTitles(writing, titles));
+			}
+
+			const settled = await runActor(agent, {actions: [], sync: true});
+			expect(settled.problems, 'agent settling').toEqual([]);
+
+			const received = await runActor(bo, {actions: [], sync: true});
+			expect(received.problems, 'bo settling').toEqual([]);
+
+			const here = titlesIn(settled);
+			const there = titlesIn(received);
+
+			expect(
+				expected.filter(title => !here.has(title)),
+				'issues the agent created that are gone from its own machine',
+			).toEqual([]);
+			expect(
+				expected.filter(title => !there.has(title)),
+				'issues the agent created that never reached the other machine',
+			).toEqual([]);
+		},
+		TIMEOUT_MS,
+	);
+
+	// The sharper case: the writer and the syncer are the same person, so they
+	// share one log file — and the remote has new lines for that same file, so
+	// the rebase must rewrite exactly the file being appended to.
+	it(
+		'keeps issues written into the same log file a sync is rewriting',
+		async () => {
+			const collab = await startCollaboration({
+				names: ['ana', 'ana-elsewhere'],
+				sharedIdentityFor: [['ana', 'ana-elsewhere']],
+			});
+			running = collab;
+
+			const [here, elsewhere] = collab.actors as [Actor, Actor];
+
+			expect(
+				(await runActor(here, {init: true, actions: [], sync: true})).problems,
+				'creating the project',
+			).toEqual([]);
+			expect(
+				(await runActor(elsewhere, {actions: [], sync: true})).problems,
+				'the other machine joining',
+			).toEqual([]);
+
+			const expected: string[] = [];
+
+			for (let round = 0; round < ROUNDS; round += 1) {
+				await publishRemoteWork(elsewhere, round);
+
+				const titles = create(WRITES_PER_ROUND, `same-r${round}`).map(
+					action => action.title,
+				);
+
+				const [syncing, writing] = await Promise.all([
+					runActor(here, {actions: [], sync: true}),
+					runActor(here, {
+						actions: create(WRITES_PER_ROUND, `same-r${round}`),
+						sync: false,
+						startDelayMs: 120,
+						pauseMs: 25,
+					}),
+				]);
+
+				expect(
+					syncing.problems.filter(p => !/Another process is syncing/.test(p)),
+					`syncing round ${round}`,
+				).toEqual([]);
+
+				expected.push(...acceptedTitles(writing, titles));
+			}
+
+			const settled = await runActor(here, {actions: [], sync: true});
+			expect(settled.problems, 'settling').toEqual([]);
+
+			const received = await runActor(elsewhere, {actions: [], sync: true});
+			expect(received.problems, 'the other machine settling').toEqual([]);
+
+			const mine = titlesIn(settled);
+			const theirs = titlesIn(received);
+
+			expect(
+				expected.filter(title => !mine.has(title)),
+				'issues gone from the machine that wrote them',
+			).toEqual([]);
+			expect(
+				expected.filter(title => !theirs.has(title)),
+				'issues that never reached the other machine',
+			).toEqual([]);
+		},
+		TIMEOUT_MS,
+	);
+});

--- a/source/test/event-payload-schema.test.ts
+++ b/source/test/event-payload-schema.test.ts
@@ -1,0 +1,161 @@
+/**
+ * The payload check sits between "this build knows the action" and "a handler
+ * dereferences the payload", so it has two ways to be wrong, and the expensive
+ * one is not the obvious one.
+ *
+ * Rejecting junk is what it is for. Rejecting something a *newer* epiq wrote —
+ * an added field, a value this build has no opinion about — would quarantine
+ * events this build can apply perfectly well, on every clone, permanently.
+ */
+import {describe, expect, it} from 'vitest';
+import {createDefaultEvents} from '../lib/event/event-boot.js';
+import {createIssueEvents} from '../lib/event/common-events.js';
+import {EVENT_ACTIONS} from '../lib/event/event.model.js';
+import {parseEventPayload} from '../lib/event/event-payload.schema.js';
+import {isFail} from '../lib/model/result-types.js';
+
+const ID = '01M1FD32E0323ZNXEKCY8YK9JR';
+const RANK = '800000000000000000000000';
+
+const accepts = (action: string, payload: unknown): boolean =>
+	!isFail(parseEventPayload(action as never, payload));
+
+describe('parseEventPayload', () => {
+	it('has a schema for every action this build knows', () => {
+		// A new action with no schema would throw on `safeParse` of undefined,
+		// which is the failure mode this whole check exists to remove.
+		for (const action of EVENT_ACTIONS) {
+			expect(() => parseEventPayload(action, {}), action).not.toThrow();
+		}
+	});
+
+	// The strongest form of "does not reject what we write": run the real
+	// constructors rather than hand-written samples that can drift from them.
+	it('accepts every event a fresh project writes', () => {
+		const defaults = createDefaultEvents({userId: ID, userName: 'ana'});
+		expect(isFail(defaults)).toBe(false);
+		if (isFail(defaults)) return;
+
+		for (const event of defaults.value) {
+			const result = parseEventPayload(event.action, event.payload);
+			expect(isFail(result), `${event.action}: ${result.message}`).toBe(false);
+		}
+	});
+
+	it('accepts the events an issue creation writes', () => {
+		const events = createIssueEvents({
+			name: 'a ticket',
+			parent: ID,
+			rank: RANK,
+			user: {userId: ID, userName: 'ana'},
+		});
+
+		expect(isFail(events)).toBe(false);
+		if (isFail(events)) return;
+
+		for (const event of events.value) {
+			expect(isFail(parseEventPayload(event.action, event.payload))).toBe(
+				false,
+			);
+		}
+	});
+
+	it('accepts a payload carrying a field this build does not know', () => {
+		expect(
+			accepts('add.issue', {
+				id: ID,
+				name: 'from a newer epiq',
+				parent: ID,
+				rank: RANK,
+				estimate: 5,
+			}),
+		).toBe(true);
+	});
+
+	/**
+	 * Found by running this check over the live board rather than by reading
+	 * the types: an `add.issue.attachment` there carries no `author`, the
+	 * declared field notwithstanding. The handler never reads it. Requiring it
+	 * would have made that attachment disappear from every clone.
+	 */
+	it('accepts a comment and an attachment written without an author', () => {
+		expect(accepts('add.issue.comment', {id: ID, issue: ID, md: 'hi'})).toBe(
+			true,
+		);
+		expect(
+			accepts('add.issue.attachment', {
+				id: ID,
+				issue: ID,
+				hash: 'a'.repeat(64),
+				ext: 'png',
+				name: 'shot.png',
+				bytes: 12,
+			}),
+		).toBe(true);
+	});
+
+	it('accepts an attachment extension this build has never seen', () => {
+		// Narrowing this to an enum would quarantine a format a later version
+		// added. The blob resolver already refuses to serve one it cannot verify.
+		expect(
+			accepts('add.issue.attachment', {
+				id: ID,
+				issue: ID,
+				author: ID,
+				hash: 'a'.repeat(64),
+				ext: 'avif',
+				name: 'shot.avif',
+				bytes: 12,
+			}),
+		).toBe(true);
+	});
+
+	describe('refuses what a handler would fall over', () => {
+		it('a rank that is not a string', () => {
+			expect(
+				accepts('add.issue', {id: ID, name: 'x', parent: ID, rank: 42}),
+			).toBe(false);
+		});
+
+		it('a missing rank', () => {
+			expect(accepts('add.issue', {id: ID, name: 'x', parent: ID})).toBe(false);
+		});
+
+		it('an id that is not a string', () => {
+			expect(
+				accepts('add.issue', {id: 7, name: 'x', parent: ID, rank: RANK}),
+			).toBe(false);
+		});
+
+		it('an empty id', () => {
+			expect(
+				accepts('add.issue', {id: '', name: 'x', parent: ID, rank: RANK}),
+			).toBe(false);
+		});
+
+		it('rebalance ranks that are not an object', () => {
+			expect(accepts('rebalance.children', {parent: ID, ranks: null})).toBe(
+				false,
+			);
+		});
+
+		it('rebalance ranks whose values are not ranks', () => {
+			expect(
+				accepts('rebalance.children', {parent: ID, ranks: {[ID]: 3}}),
+			).toBe(false);
+		});
+
+		it('a title that is not a string', () => {
+			expect(accepts('edit.title', {id: ID, name: {nested: true}})).toBe(false);
+		});
+
+		it('a description that is not a string', () => {
+			expect(accepts('edit.description', {id: ID, md: null})).toBe(false);
+		});
+
+		it('a payload that is not an object at all', () => {
+			expect(accepts('lock.node', 'nope')).toBe(false);
+			expect(accepts('lock.node', null)).toBe(false);
+		});
+	});
+});

--- a/source/test/git-error-shapes.test.ts
+++ b/source/test/git-error-shapes.test.ts
@@ -10,7 +10,6 @@ describe('isRemoteUnreachable', () => {
 			"fatal: unable to access 'https://x.invalid/r.git/': Could not resolve host: x.invalid",
 			'ssh: Could not resolve hostname x.invalid: nodename nor servname provided',
 			'fatal: unable to access: Failed to connect to example.com port 443: Connection refused',
-			'git ls-remote origin\nGit command timed out after 10000ms',
 		]) {
 			expect(isRemoteUnreachable(message)).toBe(true);
 		}
@@ -23,6 +22,10 @@ describe('isRemoteUnreachable', () => {
 			' ! [remote rejected] HEAD -> main (pre-receive hook declined)',
 			"fatal: '/tmp/gone' does not appear to be a git repository",
 			' ! [rejected] main -> main (non-fast-forward)',
+			// Our own cap, not the network's answer. Reported as offline it was
+			// a permanent, silent failure to publish: every later sync hit the
+			// same cap and the board went on saying it had merely saved locally.
+			'git fetch origin\nGit command timed out after 120000ms',
 		]) {
 			expect(isRemoteUnreachable(message)).toBe(false);
 		}

--- a/source/test/helpers/hostile-boot-runner.ts
+++ b/source/test/helpers/hostile-boot-runner.ts
@@ -1,0 +1,55 @@
+/**
+ * Loads and boots a board from an event directory, in a process of its own.
+ *
+ * Spawned rather than called: the failures this probes for are an uncaught
+ * throw out of replay and a walk that never terminates, and both take the
+ * process with them. A child can be killed; the test runner cannot.
+ *
+ * argv[2] is the state-branch root. Writes one JSON line to stdout.
+ */
+import {bootStateFromEventLog} from '../../lib/event/event-boot.js';
+import {loadMergedEventsWithUnreadable} from '../../lib/event/event-load.js';
+import {isFail} from '../../lib/model/result-types.js';
+import {getSafeState} from '../../lib/state/state.js';
+
+const report = (value: unknown) => {
+	process.stdout.write(JSON.stringify(value) + '\n');
+};
+
+const root = process.argv[2] ?? '';
+
+try {
+	const loaded = loadMergedEventsWithUnreadable(root);
+
+	if (isFail(loaded)) {
+		report({outcome: 'load-failed', message: loaded.message});
+		process.exit(0);
+	}
+
+	const booted = bootStateFromEventLog(
+		loaded.value.events,
+		loaded.value.unreadable,
+	);
+
+	const state = getSafeState();
+
+	report({
+		outcome: isFail(booted) ? 'boot-failed' : 'booted',
+		message: booted.message,
+		unreadable: loaded.value.unreadable.map(entry => entry.reason),
+		titles: isFail(state)
+			? []
+			: Object.values(state.value.nodes)
+					.filter(node => !node.isDeleted)
+					.map(node => node.title)
+					.sort(),
+	});
+} catch (error) {
+	report({
+		outcome: 'threw',
+		message: error instanceof Error ? error.message : String(error),
+		stack: error instanceof Error ? (error.stack ?? '').slice(0, 600) : '',
+	});
+}
+
+process.exit(0);

--- a/source/test/hostile-payload.test.ts
+++ b/source/test/hostile-payload.test.ts
@@ -111,7 +111,6 @@ const bootInChildProcess = (root: string): Promise<BootOutcome> =>
 				...process.env,
 				EPIQ_GLOBAL_DIR: root,
 				IS_LOCAL: 'true',
-				// The child would otherwise resolve the checkout as its project.
 				EPIQ_LOG_LEVEL: 'error',
 			},
 			cwd: root,

--- a/source/test/hostile-payload.test.ts
+++ b/source/test/hostile-payload.test.ts
@@ -1,0 +1,326 @@
+/**
+ * A peer's log line is arbitrary bytes. `hostile-log.test.ts` covers the
+ * envelope — a truncated line, a forged root, a duplicate id — because the
+ * envelope is the only part the loader parses.
+ *
+ * The payload is not parsed at all. `fromPersistedEvent` hands
+ * `entry[action]` to the materializer as-is, so a line that is valid JSON, at
+ * a supported schema version, naming an action this build knows, reaches a
+ * handler with whatever shape it likes. These cases ask what that costs.
+ *
+ * Every case asserts the same thing: the board still opens. A line that
+ * arrives over `merge=union` is in every clone permanently, so anything that
+ * stops the board here stops it for everybody, forever.
+ */
+import {spawn} from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {afterAll, describe, expect, it} from 'vitest';
+import {createDefaultEvents} from '../lib/event/event-boot.js';
+import {persist} from '../lib/event/event-persist.js';
+import {isFail} from '../lib/model/result-types.js';
+
+const RUNNER = fileURLToPath(
+	new URL('./helpers/hostile-boot-runner.ts', import.meta.url),
+);
+const TSX = fileURLToPath(
+	new URL('../../node_modules/.bin/tsx', import.meta.url),
+);
+
+// Generous: a cold `tsx` start plus a replay of a dozen events. Anything that
+// reaches this is not slow, it is not finishing.
+const BOOT_TIMEOUT_MS = 30_000;
+
+const AUTHOR = {
+	userId: '01JCOLLAB0000000000000000',
+	userName: 'ana',
+};
+const HOSTILE_LOG = '01JHOSTILE000000000000000.mallory.jsonl';
+
+const roots: string[] = [];
+
+afterAll(() => {
+	for (const root of roots) fs.rmSync(root, {recursive: true, force: true});
+});
+
+/** A state-branch root holding a normal, freshly initialized board. */
+const seedBoard = (): {root: string; edge: string; swimlaneId: string} => {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'epiq-hostile-payload-'));
+	roots.push(root);
+
+	const defaults = createDefaultEvents(AUTHOR);
+	if (isFail(defaults)) throw new Error(defaults.message);
+
+	let edge = '';
+	let swimlaneId = '';
+
+	for (const event of defaults.value) {
+		const written = persist({event, rootDir: root});
+		if (isFail(written)) throw new Error(written.message);
+
+		edge = written.value.entry.id[0];
+		if (event.action === 'add.swimlane' && !swimlaneId) {
+			swimlaneId = event.payload.id;
+		}
+	}
+
+	return {root, edge, swimlaneId};
+};
+
+/**
+ * Appends raw lines to a peer's log, chained after the real history so they
+ * order last. Ids are fixed and ascending, which is what a peer's own writer
+ * would have produced.
+ */
+const appendHostile = (
+	root: string,
+	edge: string,
+	payloads: Array<Record<string, unknown>>,
+): void => {
+	const logPath = path.join(root, '.epiq', 'events', HOSTILE_LOG);
+	let previous: string | null = edge;
+
+	for (const [index, payload] of payloads.entries()) {
+		const id = `01JZZZZZZZZZZZZZZZZZZZZZ${String(index).padStart(2, '0')}`;
+
+		fs.appendFileSync(
+			logPath,
+			JSON.stringify({v: 1, id: [id, previous], ...payload}) + '\n',
+			'utf8',
+		);
+
+		previous = id;
+	}
+};
+
+type BootOutcome =
+	| {outcome: 'booted' | 'boot-failed' | 'load-failed'; message: string}
+	| {outcome: 'threw'; message: string; stack?: string}
+	| {outcome: 'did-not-finish'; message: string};
+
+/**
+ * Boots the board in a child process. A run that has to be killed is the
+ * finding, not an infrastructure problem, so it is reported rather than thrown.
+ */
+const bootInChildProcess = (root: string): Promise<BootOutcome> =>
+	new Promise(resolve => {
+		const child = spawn(TSX, [RUNNER, root], {
+			env: {
+				...process.env,
+				EPIQ_GLOBAL_DIR: root,
+				IS_LOCAL: 'true',
+				// The child would otherwise resolve the checkout as its project.
+				EPIQ_LOG_LEVEL: 'error',
+			},
+			cwd: root,
+			stdio: ['ignore', 'pipe', 'pipe'],
+		});
+
+		let stdout = '';
+		let stderr = '';
+		let settled = false;
+
+		const finish = (value: BootOutcome) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			child.kill('SIGKILL');
+			resolve(value);
+		};
+
+		const timer = setTimeout(
+			() =>
+				finish({
+					outcome: 'did-not-finish',
+					message: `no result within ${BOOT_TIMEOUT_MS}ms`,
+				}),
+			BOOT_TIMEOUT_MS,
+		);
+
+		child.stdout.setEncoding('utf8');
+		child.stderr.setEncoding('utf8');
+		child.stdout.on('data', chunk => (stdout += chunk));
+		child.stderr.on('data', chunk => (stderr += chunk));
+
+		child.on('error', error =>
+			finish({outcome: 'threw', message: error.message}),
+		);
+
+		child.on('close', () => {
+			const line = stdout
+				.split('\n')
+				.map(entry => entry.trim())
+				.filter(Boolean)
+				.at(-1);
+
+			if (!line) {
+				finish({
+					outcome: 'threw',
+					message: `child produced no report\n${stderr.slice(-2000)}`,
+				});
+				return;
+			}
+
+			finish(JSON.parse(line) as BootOutcome);
+		});
+	});
+
+const bootWith = async (
+	build: (swimlaneId: string) => Array<Record<string, unknown>>,
+): Promise<BootOutcome> => {
+	const {root, edge, swimlaneId} = seedBoard();
+	appendHostile(root, edge, build(swimlaneId));
+
+	return bootInChildProcess(root);
+};
+
+const RANK_A = '400000000000000000000000';
+
+describe('a peer publishes a known action with a payload of its own shape', () => {
+	// The board is allowed to skip the event. It is not allowed to stop.
+	const opens = (outcome: BootOutcome) => outcome.outcome;
+
+	it('survives a rank that is not a string', async () => {
+		const outcome = await bootWith(swimlaneId => [
+			{
+				'add.issue': {
+					id: '01JISSUEHONEST0000000000A0',
+					name: 'honest neighbour',
+					parent: swimlaneId,
+					rank: RANK_A,
+				},
+			},
+			{
+				'add.issue': {
+					id: '01JISSUERANK00000000000000',
+					name: 'numeric rank',
+					parent: swimlaneId,
+					rank: 42,
+				},
+			},
+		]);
+
+		expect(opens(outcome), JSON.stringify(outcome)).toBe('booted');
+	});
+
+	it('survives a rank that is missing entirely', async () => {
+		const outcome = await bootWith(swimlaneId => [
+			{
+				'add.issue': {
+					id: '01JISSUEHONEST0000000000B0',
+					name: 'honest neighbour',
+					parent: swimlaneId,
+					rank: RANK_A,
+				},
+			},
+			{
+				'add.issue': {
+					id: '01JISSUENORANK000000000000',
+					name: 'no rank',
+					parent: swimlaneId,
+				},
+			},
+		]);
+
+		expect(opens(outcome), JSON.stringify(outcome)).toBe('booted');
+	});
+
+	// The cycle guard walks the parent chain to answer the question, so it is
+	// the first thing a cycle stops.
+	it('survives a move into a node that is its own parent', async () => {
+		const loop = '01JISSUESELFPARENT00000000';
+		const victim = '01JISSUEVICTIM000000000000';
+
+		const outcome = await bootWith(swimlaneId => [
+			{
+				'add.issue': {
+					id: loop,
+					name: 'self parented',
+					parent: loop,
+					rank: RANK_A,
+				},
+			},
+			{
+				'add.issue': {
+					id: victim,
+					name: 'about to be moved',
+					parent: swimlaneId,
+					rank: RANK_A,
+				},
+			},
+			{'move.node': {id: victim, parent: loop, rank: RANK_A}},
+		]);
+
+		expect(opens(outcome), JSON.stringify(outcome)).toBe('booted');
+	});
+
+	it('survives a rebalance whose ranks are not an object', async () => {
+		const outcome = await bootWith(swimlaneId => [
+			{'rebalance.children': {parent: swimlaneId, ranks: null}},
+		]);
+
+		expect(opens(outcome), JSON.stringify(outcome)).toBe('booted');
+	});
+
+	it('survives an id that is not a string', async () => {
+		const outcome = await bootWith(swimlaneId => [
+			{
+				'add.issue': {
+					id: 7,
+					name: 'numeric id',
+					parent: swimlaneId,
+					rank: RANK_A,
+				},
+			},
+		]);
+
+		expect(opens(outcome), JSON.stringify(outcome)).toBe('booted');
+	});
+
+	// `createNode` writes into the node map unconditionally, and the
+	// materializer's `isFail` branch can never fire on a duplicate. A second
+	// `add.*` naming a live id replaces that node wholesale — title, rank,
+	// parent, description, tags, assignees and its readonly flag.
+	it('does not let a second add replace a live node', async () => {
+		const victim = '01JISSUEVICTIMID0000000000';
+
+		const {root, edge, swimlaneId} = seedBoard();
+
+		appendHostile(root, edge, [
+			{
+				'add.issue': {
+					id: victim,
+					name: 'the-real-issue',
+					parent: swimlaneId,
+					rank: RANK_A,
+				},
+			},
+			{
+				'add.issue': {
+					id: victim,
+					name: 'overwritten',
+					parent: swimlaneId,
+					rank: RANK_A,
+				},
+			},
+		]);
+
+		const outcome = await bootInChildProcess(root);
+
+		expect(outcome.outcome, JSON.stringify(outcome)).toBe('booted');
+		expect(
+			(outcome as {titles?: string[]}).titles ?? [],
+			'the original issue after a duplicate add',
+		).toContain('the-real-issue');
+	});
+
+	it('survives a title that is not a string', async () => {
+		const outcome = await bootWith(swimlaneId => [
+			{'edit.title': {id: swimlaneId, name: {nested: true}}},
+		]);
+
+		expect(opens(outcome), JSON.stringify(outcome)).toBe('booted');
+	});
+});

--- a/source/test/log-restore.test.ts
+++ b/source/test/log-restore.test.ts
@@ -1,0 +1,163 @@
+/**
+ * The safety net around every git operation a sync runs.
+ *
+ * `withSyncLock` binds the processes that sync; nothing binds the processes
+ * that write. So while one process hands the worktree to git — a checkout, a
+ * `rebase --abort`, an autostash reverting the working copy to HEAD — another
+ * may be appending to the same directory. Lines that were on disk before and
+ * are not on disk after were lost by git; nothing removes one on purpose.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {afterEach, describe, expect, it} from 'vitest';
+import {
+	restoreDroppedEventLines,
+	snapshotEventLogs,
+} from '../git/log-integrity.js';
+
+const LOG = '01ksayra4ghekjp888wfbwbrdd.jola.jsonl';
+const OTHER_LOG = '01m1fd32e0323znxekcy8yk9jr.bo.jsonl';
+
+const dirs: string[] = [];
+
+afterEach(() => {
+	for (const dir of dirs) fs.rmSync(dir, {recursive: true, force: true});
+	dirs.length = 0;
+});
+
+const line = (n: number) =>
+	JSON.stringify({
+		v: 1,
+		id: [`01H${String(n).padStart(23, '0')}`, null],
+		'lock.node': {id: 'x'},
+	});
+
+const makeRoot = (): string => {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'epiq-log-restore-'));
+	dirs.push(root);
+	fs.mkdirSync(path.join(root, '.epiq', 'events'), {recursive: true});
+	return root;
+};
+
+const logPath = (root: string, name = LOG): string =>
+	path.join(root, '.epiq', 'events', name);
+
+const write = (root: string, lines: string[], name = LOG): void =>
+	fs.writeFileSync(logPath(root, name), lines.join('\n') + '\n');
+
+const read = (root: string, name = LOG): string[] =>
+	fs
+		.readFileSync(logPath(root, name), 'utf8')
+		.split('\n')
+		.filter(entry => entry.trim().length > 0);
+
+describe('snapshotEventLogs', () => {
+	it('reads every log in the events directory', () => {
+		const root = makeRoot();
+		write(root, [line(1), line(2)]);
+		write(root, [line(3)], OTHER_LOG);
+
+		const snapshot = snapshotEventLogs(root);
+
+		expect(snapshot.get(LOG)).toEqual([line(1), line(2)]);
+		expect(snapshot.get(OTHER_LOG)).toEqual([line(3)]);
+	});
+
+	it('is empty rather than failing when there is no worktree yet', () => {
+		expect(snapshotEventLogs('/does/not/exist').size).toBe(0);
+	});
+});
+
+describe('restoreDroppedEventLines', () => {
+	it('leaves an untouched log alone', () => {
+		const root = makeRoot();
+		write(root, [line(1), line(2)]);
+
+		const snapshot = snapshotEventLogs(root);
+
+		expect(restoreDroppedEventLines(root, snapshot)).toEqual([]);
+		expect(read(root)).toEqual([line(1), line(2)]);
+	});
+
+	// The autostash case: git reverts the working copy to HEAD and does not put
+	// it back.
+	it('puts back a line the log lost', () => {
+		const root = makeRoot();
+		write(root, [line(1), line(2), line(3)]);
+
+		const snapshot = snapshotEventLogs(root);
+		write(root, [line(1), line(3)]);
+
+		expect(restoreDroppedEventLines(root, snapshot)).toEqual([`${LOG} (1)`]);
+		expect(read(root).sort()).toEqual([line(1), line(2), line(3)].sort());
+	});
+
+	// `git rebase --abort` resets the worktree, and a checkout can remove a
+	// file another actor had never committed.
+	it('recreates a log the worktree lost entirely', () => {
+		const root = makeRoot();
+		write(root, [line(1), line(2)]);
+
+		const snapshot = snapshotEventLogs(root);
+		fs.rmSync(logPath(root));
+
+		expect(restoreDroppedEventLines(root, snapshot)).toEqual([`${LOG} (2)`]);
+		expect(read(root).sort()).toEqual([line(1), line(2)].sort());
+	});
+
+	// Order is not load-bearing — the loader derives it from refId — so a
+	// reordered log has lost nothing and must not be rewritten.
+	it('does not mind reordering', () => {
+		const root = makeRoot();
+		write(root, [line(1), line(2)]);
+
+		const snapshot = snapshotEventLogs(root);
+		write(root, [line(2), line(1)]);
+
+		expect(restoreDroppedEventLines(root, snapshot)).toEqual([]);
+		expect(read(root)).toEqual([line(2), line(1)]);
+	});
+
+	// A concurrent writer's line is not in the snapshot, so restoring must not
+	// disturb it — and lines pulled from a peer must survive too.
+	it('keeps lines that arrived while git held the worktree', () => {
+		const root = makeRoot();
+		write(root, [line(1), line(2)]);
+
+		const snapshot = snapshotEventLogs(root);
+		write(root, [line(1), line(9)]);
+
+		restoreDroppedEventLines(root, snapshot);
+
+		expect(read(root).sort()).toEqual([line(1), line(2), line(9)].sort());
+	});
+
+	it('splices onto a file git left without a trailing newline', () => {
+		const root = makeRoot();
+		write(root, [line(1), line(2)]);
+
+		const snapshot = snapshotEventLogs(root);
+		fs.writeFileSync(logPath(root), line(1));
+
+		restoreDroppedEventLines(root, snapshot);
+
+		expect(read(root)).toEqual([line(1), line(2)]);
+	});
+
+	it('restores each log independently', () => {
+		const root = makeRoot();
+		write(root, [line(1)]);
+		write(root, [line(2), line(3)], OTHER_LOG);
+
+		const snapshot = snapshotEventLogs(root);
+		write(root, [], OTHER_LOG);
+		fs.writeFileSync(logPath(root, OTHER_LOG), '');
+
+		expect(restoreDroppedEventLines(root, snapshot)).toEqual([
+			`${OTHER_LOG} (2)`,
+		]);
+		expect(read(root)).toEqual([line(1)]);
+		expect(read(root, OTHER_LOG).sort()).toEqual([line(2), line(3)].sort());
+	});
+});

--- a/source/test/log-restore.test.ts
+++ b/source/test/log-restore.test.ts
@@ -133,6 +133,22 @@ describe('restoreDroppedEventLines', () => {
 		expect(read(root).sort()).toEqual([line(1), line(2), line(9)].sort());
 	});
 
+	/**
+	 * A crash mid-append leaves a line with no id, which the loader quarantines
+	 * and no replica can order. Putting it back would only re-dirty the file
+	 * and give the next commit something to publish.
+	 */
+	it('does not put back a half-written line', () => {
+		const root = makeRoot();
+		fs.writeFileSync(logPath(root), `${line(1)}\n{"v":1,"id":["01H`);
+
+		const snapshot = snapshotEventLogs(root);
+		write(root, [line(1)]);
+
+		expect(restoreDroppedEventLines(root, snapshot)).toEqual([]);
+		expect(read(root)).toEqual([line(1)]);
+	});
+
 	it('splices onto a file git left without a trailing newline', () => {
 		const root = makeRoot();
 		write(root, [line(1), line(2)]);

--- a/source/test/rank-between.test.ts
+++ b/source/test/rank-between.test.ts
@@ -1,0 +1,60 @@
+import {describe, expect, it} from 'vitest';
+import {isFail} from '../lib/model/result-types.js';
+import {MAX_RANK, bigIntToHex, rankBetween} from '../lib/utils/rank.js';
+
+const hex = (value: bigint): string => {
+	const result = bigIntToHex(value);
+	if (isFail(result)) throw new Error(result.message);
+	return result.value;
+};
+
+const MID = hex(MAX_RANK / 2n);
+
+describe('rankBetween', () => {
+	it('lands between two neighbours', () => {
+		const result = rankBetween(hex(10n), hex(100n));
+
+		expect(isFail(result)).toBe(false);
+		if (isFail(result)) return;
+
+		expect(result.value > hex(10n)).toBe(true);
+		expect(result.value < hex(100n)).toBe(true);
+	});
+
+	it('uses the middle of the space when there are no neighbours', () => {
+		const result = rankBetween(undefined, undefined);
+
+		expect(isFail(result)).toBe(false);
+		if (isFail(result)) return;
+		expect(result.value).toBe(MID);
+	});
+
+	/**
+	 * Two clients appending to one lane while unsynced both read the same last
+	 * sibling and compute the same midpoint, so equal sibling ranks are ordinary
+	 * traffic rather than corruption.
+	 *
+	 * This used to return the middle of the whole space — a success — so
+	 * "move this after that one" silently put the node somewhere nobody asked
+	 * for, and `resolveMoveRank` never learned it needed a rebalance.
+	 */
+	it('refuses to place a node between two equal ranks', () => {
+		expect(isFail(rankBetween(hex(500n), hex(500n)))).toBe(true);
+	});
+
+	it('refuses neighbours that are the wrong way round', () => {
+		expect(isFail(rankBetween(hex(900n), hex(100n)))).toBe(true);
+	});
+
+	it('refuses to append after a sibling already at the ceiling', () => {
+		expect(isFail(rankBetween(hex(MAX_RANK), undefined))).toBe(true);
+	});
+
+	it('refuses to insert before a sibling already at the floor', () => {
+		expect(isFail(rankBetween(undefined, hex(0n)))).toBe(true);
+	});
+
+	it('still refuses adjacent neighbours with no room between them', () => {
+		expect(isFail(rankBetween(hex(1n), hex(2n)))).toBe(true);
+	});
+});

--- a/source/test/state-branch-staging.test.ts
+++ b/source/test/state-branch-staging.test.ts
@@ -1,0 +1,129 @@
+/**
+ * What a sync is allowed to put in a commit.
+ *
+ * `assertLogOnlyGrew` guards the event log at this boundary. These cover the
+ * two paths beside it that had no guard: the media directory, staged by glob
+ * so a missing blob committed its own deletion, and the storage-only repair,
+ * which committed with no pathspec and so took whatever was in the index.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import {describe, expect, it} from 'vitest';
+import {execGit} from '../git/git-utils.js';
+import {stageStateBranchMediaFiles} from '../git/git.js';
+import {ensureStateBranchIsStorageOnly} from '../git/git-storage.js';
+import {isFail} from '../lib/model/result-types.js';
+import {makeTempDir, useTempHome, writeFile} from './helpers/git-repo.js';
+
+useTempHome();
+
+const BLOB = `${'a'.repeat(64)}.png`;
+const EVENT_FILE = '.epiq/events/01ksayra4ghekjp888wfbwbrdd.jola.jsonl';
+
+const git = async (cwd: string, args: string[]): Promise<string> => {
+	const result = await execGit({args, cwd});
+	if (isFail(result))
+		throw new Error(`git ${args.join(' ')}\n${result.message}`);
+	return result.value.stdout;
+};
+
+const makeStateWorktree = async (): Promise<string> => {
+	const root = makeTempDir();
+
+	await git(root, ['init', '-q', '-b', 'epiq/state', '.']);
+	await git(root, ['config', 'user.name', 'Test User']);
+	await git(root, ['config', 'user.email', 'test@example.com']);
+
+	writeFile(path.join(root, '.epiq', 'media', BLOB), 'not really a png');
+	writeFile(path.join(root, EVENT_FILE), '{"v":1,"id":["A",null]}\n');
+
+	await git(root, ['add', '.epiq']);
+	await git(root, ['commit', '-qm', 'seed']);
+
+	return root;
+};
+
+/** Paths the index has staged relative to HEAD, with their status letters. */
+const staged = async (root: string): Promise<string[]> =>
+	(await git(root, ['diff', '--cached', '--name-status']))
+		.split('\n')
+		.map(entry => entry.trim())
+		.filter(Boolean);
+
+describe('stageStateBranchMediaFiles', () => {
+	it('stages a new blob', async () => {
+		const root = await makeStateWorktree();
+		const second = `${'b'.repeat(64)}.png`;
+
+		writeFile(path.join(root, '.epiq', 'media', second), 'another');
+
+		const result = await stageStateBranchMediaFiles({stateBranchRoot: root});
+		expect(isFail(result)).toBe(false);
+
+		expect(await staged(root)).toEqual([`A\t.epiq/media/${second}`]);
+	});
+
+	/**
+	 * Nothing removes a blob on purpose — `delete.issue.attachment` writes a
+	 * tombstone and keeps the bytes so a historical checkout can still render
+	 * them — so a gap here is damage. Committing it published that damage to
+	 * every clone, and the bytes have no other copy.
+	 */
+	it('does not commit a blob that has gone missing from the worktree', async () => {
+		const root = await makeStateWorktree();
+
+		fs.rmSync(path.join(root, '.epiq', 'media', BLOB));
+
+		const result = await stageStateBranchMediaFiles({stateBranchRoot: root});
+		expect(isFail(result)).toBe(false);
+
+		expect(await staged(root)).toEqual([]);
+	});
+});
+
+describe('ensureStateBranchIsStorageOnly', () => {
+	it('leaves a branch that already holds only .epiq alone', async () => {
+		const root = await makeStateWorktree();
+
+		const result = await ensureStateBranchIsStorageOnly(root);
+
+		expect(isFail(result)).toBe(false);
+		if (isFail(result)) return;
+		expect(result.value).toBe(false);
+	});
+
+	/**
+	 * This runs during bootstrap — before the pull, and before
+	 * `stageStateBranchOwnEventFile` gets anywhere near it — so anything it
+	 * sweeps up is published with no integrity check at all. A sync that died
+	 * between `git add` and `git commit` leaves exactly that in the index.
+	 */
+	it('commits only what it removed, not whatever else is staged', async () => {
+		const root = await makeStateWorktree();
+
+		await git(root, ['config', 'user.name', 'Test User']);
+		writeFile(path.join(root, 'README.md'), 'does not belong here\n');
+		await git(root, ['add', 'README.md']);
+		await git(root, ['commit', '-qm', 'stray file']);
+
+		// What a crashed sync leaves behind: staged, uncommitted log content.
+		writeFile(
+			path.join(root, EVENT_FILE),
+			'{"v":1,"id":["A",null]}\n{"x":1}\n',
+		);
+		await git(root, ['add', EVENT_FILE]);
+
+		const result = await ensureStateBranchIsStorageOnly(root);
+
+		expect(isFail(result)).toBe(false);
+		if (isFail(result)) return;
+		expect(result.value).toBe(true);
+
+		// The stray file is gone from HEAD...
+		const tracked = await git(root, ['ls-tree', '--name-only', 'HEAD']);
+		expect(tracked.split('\n').filter(Boolean)).toEqual(['.epiq']);
+
+		// ...and the log content is still only staged, never published.
+		expect(await staged(root)).toEqual([`M\t${EVENT_FILE}`]);
+	});
+});


### PR DESCRIPTION
A distributed-safety review of the event log and the sync path, and the fixes for what it turned up. Every board-affecting change was checked against every board in `~/.epiq-global` before landing.

## The gap the review found

The envelope (`v`, `id`) was the only part of a log line ever parsed. A line that is valid JSON, at a supported schema version, naming an action this build knows, reached its handler with any payload shape at all — and `merge=union` puts such a line in every clone, permanently, with no way to remove it.

Five ways that stopped the board for everybody, all reproduced before being fixed:

| payload | result |
|---|---|
| `add.issue` `rank: 42` | `TypeError` in `buildChildIndex`, thrown out of `derive` — uncaught, boot dies |
| `add.issue` no `rank` | same |
| `add.issue` `id: 7` | `id.slice is not a function` in `nodeRef` |
| `rebalance.children` `ranks: null` | `Object.entries` throws |
| self-parented node + a `move.node` into it | **process never terminates** — no ancestor walk had a visited set |

Plus: a second `add.*` naming a live node id replaced that node wholesale — title, rank, parent, description, tags, assignees, readonly flag.

## What landed

- **`Y8YK9JR`** A zod payload schema per action, checked where unknown actions are already quarantined. Loose, and requiring only what a handler dereferences, so an older epiq never quarantines what a newer one writes. Behind it: cycle-safe ancestor walks, and a handler throw becoming a skip rather than escaping replay.
- **`NGF95XR`** A creation event naming a live id, or itself as its parent, is a convergence skip. First writer wins.
- **`SYY8VC4`** A remote slower than the 10s cap read as *offline* — so the sync returned with no error at all and the work never published, forever. Timeouts are no longer "unreachable", and data-bound calls get 120s.
- **`5YCXBJQ`** `withSyncLock` binds the processes that sync; nothing binds the processes that write. The sync now snapshots the event logs and, in a `finally`, puts back any line git dropped — the same rule `assertLogOnlyGrew` enforces one boundary later.
- **`F39RXC2`** `rankBetween` returned the middle of the whole space when neighbours left no room, so a move landed somewhere nobody asked for. It now fails, which routes into the rebalance that already existed.
- **`HZGPGZP`** `git add .epiq/media` staged deletions, so a vanished attachment blob committed its own removal to every clone. `--ignore-removal`.
- **`A1NPGTQ`** The storage-branch repair committed with no pathspec, taking whatever else was in the index — before the pull, and before any integrity check.

## Verified against real history

The new loader was run read-only over all 14 boards under `~/.epiq-global`: **0 payload rejections, 0 duplicate creation ids, 0 self-parented nodes**. Nothing already written materializes differently.

That check earned its keep: the first draft required `add.issue.attachment.author` because the type declares it, and found an attachment on this board written without one. The handler never reads it. Requiring it would have made that attachment disappear from every clone — the exact damage the check exists to prevent.

## Tests

`hostile-payload` (7), `event-payload-schema` (19), `log-restore` (11), `rank-between` (7), `state-branch-staging` (4), and three new collab suites — `write-during-sync`, `killed-sync`, `slow-remote` — plus harness support for a second identity on one machine, aimed start times, and killing an actor mid-run. Every fix's test was confirmed red without it.

Full gate green: 1034 unit, 15 collab, 16 e2e, 99 GUI.

## Not done, deliberately

- **`5YCXBJQ` is not closed.** What landed removes the consequence, not the race. A real lock needs `persist` to become async first; blocking the event loop for a sync's git phase is not acceptable in the GUI server.
- **`VCE9WDC`** (boot/edge caching) moved back to Backlog — every proposed invalidation key is wrong under time travel, and nothing measured says it hurts. Reasoning is on the ticket.
- **`TBPKP07`** needs one board command this session lacked permission for; no code change is required.
