### PR TITLE
2M8RHZ0 Scope only: narrow the board to the timeline's window

### DIFF
--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -67,7 +67,11 @@ import {
 	GuiSwimlane,
 	GuiUser,
 } from './lib/gui-state.model';
-import {buildBoardFilter, issuePassesBoardFilter} from './lib/scrubber';
+import {
+	buildBoardFilter,
+	issuePassesBoardFilter,
+	windowIssueIds,
+} from './lib/scrubber';
 import {Input} from './components/FormPrimitives';
 import {useBoardSelection} from './lib/use-board-selection';
 import {sendSocketJson} from './lib/socket-send';
@@ -342,6 +346,14 @@ export const App = () => {
 		[selection.view, selection.only],
 	);
 
+	// The tickets the scrubber's window has an event for, once the board has
+	// been narrowed to them. Null while it has not, and where the window is one
+	// the server answered with counts alone.
+	const windowIds = useMemo(
+		() => (selection.windowOnly ? windowIssueIds(history.timeline) : null),
+		[selection.windowOnly, history.timeline],
+	);
+
 	// The tag every card is narrowed to, if the selection is exactly one tag:
 	// its chips read as pressed, and pressing again is the way back.
 	const isolatedTagId =
@@ -371,7 +383,7 @@ export const App = () => {
 	const {visibleSwimlanes, hiddenIssueCount} = useMemo(() => {
 		const swimlanes = selectedBoard?.swimlanes ?? [];
 		const query = textFilter.trim();
-		if (!boardFilter && !query)
+		if (!boardFilter && !query && windowIds === null)
 			return {visibleSwimlanes: swimlanes, hiddenIssueCount: 0};
 
 		let hidden = 0;
@@ -385,7 +397,9 @@ export const App = () => {
 							comment => comment.author.id,
 						),
 						boardFilter,
-					) && issueMatchesText(issue, query),
+					) &&
+					issueMatchesText(issue, query) &&
+					(windowIds === null || windowIds.has(issue.id)),
 			);
 
 			hidden += swimlane.issues.length - issues.length;
@@ -394,7 +408,7 @@ export const App = () => {
 		});
 
 		return {visibleSwimlanes: visible, hiddenIssueCount: hidden};
-	}, [selectedBoard, boardFilter, textFilter, commentsByIssueId]);
+	}, [selectedBoard, boardFilter, textFilter, commentsByIssueId, windowIds]);
 	const attachmentsByIssueId = state?.attachmentsByIssueId ?? {};
 	const [attachmentUploadStatus, setAttachmentUploadStatus] =
 		useState<AttachmentUploadStatus>({state: 'idle'});

--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -69,6 +69,7 @@ import {
 } from './lib/gui-state.model';
 import {
 	buildBoardFilter,
+	isPeriodWindow,
 	issuePassesBoardFilter,
 	windowIssueIds,
 } from './lib/scrubber';
@@ -346,12 +347,21 @@ export const App = () => {
 		[selection.view, selection.only],
 	);
 
+	const zoomed = selection.zoom !== null;
+
 	// The tickets the scrubber's window has an event for, once the board has
 	// been narrowed to them. Null while it has not, and where the window is one
 	// the server answered with counts alone.
+	//
+	// The period test is the same one that greys the box: a narrowing left on
+	// from a period the user has since left must not go on hiding tickets from
+	// under a control that can no longer be pressed.
 	const windowIds = useMemo(
-		() => (selection.windowOnly ? windowIssueIds(history.timeline) : null),
-		[selection.windowOnly, history.timeline],
+		() =>
+			selection.windowOnly && isPeriodWindow(selection.scope, zoomed)
+				? windowIssueIds(history.timeline)
+				: null,
+		[selection.windowOnly, selection.scope, zoomed, history.timeline],
 	);
 
 	// The tag every card is narrowed to, if the selection is exactly one tag:
@@ -1620,6 +1630,7 @@ export const App = () => {
 					selection={selection}
 					onChangeSelection={changeSelection}
 					knownIdentities={knownIdentities}
+					refreshOn={selection.windowOnly ? state : null}
 				/>
 
 				{/* Dimmed while offline so the board reads as inert. The topbar stays at

--- a/source/gui/client/components/Checkbox.tsx
+++ b/source/gui/client/components/Checkbox.tsx
@@ -34,6 +34,9 @@ export const Checkbox = ({
 				color,
 				cursor: disabled ? 'not-allowed' : 'pointer',
 				opacity: disabled ? 0.4 : 1,
+				// A label that wraps takes the row's height with it.
+				whiteSpace: 'nowrap',
+				flexShrink: 0,
 			}}
 		>
 			<span

--- a/source/gui/client/components/ScrubberLayout.tsx
+++ b/source/gui/client/components/ScrubberLayout.tsx
@@ -16,6 +16,7 @@ import {
 	hourFractionForTime,
 	LayoutMode,
 	ScrubberAxis,
+	SCOPED_OUTLINE_COLOR,
 	SCRUBBER_KEYFRAMES,
 	Segment,
 	SeriesPresence,
@@ -108,6 +109,9 @@ export type ScrubberChart = {
 	hoveredSegment: Segment | null;
 	// Nothing can be asked for with the socket down.
 	connected: boolean;
+	// The board below is narrowed to this window, so the timeline is not only a
+	// picture of it but the control hiding the tickets that are missing.
+	scoped: boolean;
 	// Null when the moment it marks is outside the window, which is drawn as no
 	// needle at all rather than one clamped to an edge it is not at.
 	thumbFraction: number | null;
@@ -196,6 +200,14 @@ export const ScrubberLayout = ({
 							// Crosshair, not a hand: a press picks a moment but a drag picks
 							// out a range, and the pointer has to say the second is on offer.
 							cursor: chart.connected ? 'crosshair' : 'default',
+							// Outline rather than a border: it takes up no space, so
+							// narrowing the board cannot reflow the charts under the
+							// pointer that just clicked.
+							outline: chart.scoped
+								? `1px solid ${SCOPED_OUTLINE_COLOR}`
+								: undefined,
+							outlineOffset: 5,
+							borderRadius: 4,
 							// A drag must never turn into a native text selection or a drag
 							// of the axis labels underneath the pointer.
 							userSelect: 'none',

--- a/source/gui/client/components/ScrubberLayout.tsx
+++ b/source/gui/client/components/ScrubberLayout.tsx
@@ -35,12 +35,14 @@ import {
 	ScrubberHeader,
 	ScrubberHoverHint,
 	ScrubberNeedle,
+	SCOPE_ONLY_LABEL,
 	SegmentHighlight,
 	SeriesLayer,
 	TrackBaseline,
 	VolumeBars,
 } from './ScrubberParts';
 import {Panel} from './Panel';
+import {Checkbox} from './Checkbox';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -176,7 +178,22 @@ export const ScrubberLayout = ({
 						onToggleCollapsed={onToggleCollapsed}
 					/>
 
-					{!collapsed && <ScrubberControls {...controls} />}
+					{collapsed ? (
+						// The narrowing outlives the chart it belongs to — a link can
+						// arrive with the scrubber shut, and collapsing it is remembered
+						// — so its box comes up here rather than leaving the board
+						// hiding tickets behind a control nobody can see.
+						controls.windowOnly && (
+							<Checkbox
+								label={SCOPE_ONLY_LABEL}
+								title="Show every ticket again"
+								checked
+								onChange={controls.onChangeWindowOnly}
+							/>
+						)
+					) : (
+						<ScrubberControls {...controls} />
+					)}
 				</div>
 
 				{!collapsed && (

--- a/source/gui/client/components/ScrubberParts.tsx
+++ b/source/gui/client/components/ScrubberParts.tsx
@@ -18,6 +18,7 @@ import {
 	FADE_IN_ANIMATION,
 	formatPeriodLabel,
 	HOVER_HINT_WIDTH,
+	isPeriodWindow,
 	LayoutMode,
 	NEEDLE_COLOR,
 	NEEDLE_GRIP_WIDTH,
@@ -583,9 +584,7 @@ export const ScrubberControls = ({
 	onToggleCategoriesExpanded: () => void;
 	onSetIdentitiesExpanded: (next: boolean) => void;
 }) => {
-	// "All time" with no zoom is the whole log, so narrowing the board to what
-	// is in it would hide nothing.
-	const everythingInScope = scope === 'all' && !zoomed;
+	const everythingInScope = !isPeriodWindow(scope, zoomed);
 
 	return (
 		<div

--- a/source/gui/client/components/ScrubberParts.tsx
+++ b/source/gui/client/components/ScrubberParts.tsx
@@ -512,6 +512,8 @@ export const ScrubberControls = ({
 	periodRange,
 	zoomed,
 	atLatest,
+	windowOnly,
+	windowFilterable,
 	layoutMode,
 	showIssues,
 	showCommits,
@@ -526,6 +528,7 @@ export const ScrubberControls = ({
 	onReturnToLive,
 	onChangeScope,
 	onChangeOffset,
+	onChangeWindowOnly,
 	onChangeLayoutMode,
 	onChangeShowIssues,
 	onChangeShowCommits,
@@ -548,6 +551,11 @@ export const ScrubberControls = ({
 	// The window already reaches the present, so there is nothing later to page
 	// to.
 	atLatest: boolean;
+	// The board is narrowed to the tickets this window has an event for.
+	windowOnly: boolean;
+	// False where the window came back as counts alone, naming no tickets to
+	// narrow to.
+	windowFilterable: boolean;
 	layoutMode: LayoutMode;
 	showIssues: boolean;
 	showCommits: boolean;
@@ -564,6 +572,7 @@ export const ScrubberControls = ({
 	onReturnToLive: () => void;
 	onChangeScope: (scope: Scope) => void;
 	onChangeOffset: (offset: number) => void;
+	onChangeWindowOnly: (next: boolean) => void;
 	onChangeLayoutMode: (mode: LayoutMode) => void;
 	onChangeShowIssues: (next: boolean) => void;
 	onChangeShowCommits: (next: boolean) => void;
@@ -667,6 +676,32 @@ export const ScrubberControls = ({
 					Zoom
 				</button>
 			</div>
+
+			{/* Bordered rather than underlined like the row beside it: it narrows
+			    the board below rather than naming the window, and must not read as
+			    a seventh period.
+
+			    Nothing to match on where the server capped the window — its
+			    buckets carry counts, not the tickets they counted — so it says so
+			    rather than emptying the board. */}
+			<button
+				title={
+					!windowFilterable
+						? 'Too many events in this window to tell which tickets they belong to'
+						: windowOnly
+						? 'Showing only tickets with activity in this window'
+						: 'Show only tickets with activity in this window'
+				}
+				aria-pressed={windowOnly}
+				disabled={!connected || !windowFilterable}
+				onClick={() => onChangeWindowOnly(!windowOnly)}
+				style={{
+					...toggleButtonStyle(windowOnly),
+					...(connected && windowFilterable ? {} : mutedStyle),
+				}}
+			>
+				In window
+			</button>
 		</div>
 
 		<div style={{display: 'flex', gap: 2}}>

--- a/source/gui/client/components/ScrubberParts.tsx
+++ b/source/gui/client/components/ScrubberParts.tsx
@@ -46,6 +46,10 @@ import {IconChevronDown} from './IconChevronDown';
 import {IconChevronRight} from './IconChevronRight';
 import {IconScatter} from './IconScatter';
 
+// Named once: the collapsed header puts the same box up when the rest of this
+// row is not on screen.
+export const SCOPE_ONLY_LABEL = 'Scope only';
+
 const toggleButtonStyle = (active: boolean): React.CSSProperties => ({
 	background: 'transparent',
 	border: `1px solid ${active ? GUI_THEME.accent : GUI_THEME.dim}`,
@@ -742,7 +746,7 @@ export const ScrubberControls = ({
 			    is, which narrows nothing, so it goes flat instead of pretending
 			    to. */}
 				<Checkbox
-					label="Scope only"
+					label={SCOPE_ONLY_LABEL}
 					title={
 						everythingInScope
 							? 'Every event is in scope — pick a period to narrow the board'
@@ -751,7 +755,15 @@ export const ScrubberControls = ({
 							: 'Show only tickets with activity in the selected window'
 					}
 					checked={windowOnly}
-					disabled={!connected || !windowFilterable || everythingInScope}
+					// Unlike its neighbours it asks the socket for nothing — it
+					// narrows what is already on screen — so offline it can still be
+					// let go of, just not taken up over a window that can no longer be
+					// refreshed.
+					disabled={
+						everythingInScope ||
+						!windowFilterable ||
+						(!connected && !windowOnly)
+					}
 					onChange={onChangeWindowOnly}
 				/>
 

--- a/source/gui/client/components/ScrubberParts.tsx
+++ b/source/gui/client/components/ScrubberParts.tsx
@@ -582,75 +582,80 @@ export const ScrubberControls = ({
 	onOnlyIdentity: (id: string) => void;
 	onToggleCategoriesExpanded: () => void;
 	onSetIdentitiesExpanded: (next: boolean) => void;
-}) => (
-	<div
-		style={{
-			display: 'flex',
-			alignItems: 'center',
-			justifyContent: 'flex-end',
-			gap: 12,
-		}}
-	>
-		<div style={{display: 'flex', alignItems: 'center', gap: 6}}>
-			{(scope !== 'all' || zoomed) && (
-				<div style={{display: 'flex', alignItems: 'center', gap: 2}}>
-					<button
-						title="Earlier"
-						disabled={!connected}
-						onClick={() => onChangeOffset(offset + 1)}
-						style={{...navButtonStyle, ...(connected ? {} : mutedStyle)}}
-					>
-						◀
-					</button>
-					<span
-						style={{
-							fontSize: 10,
-							color: GUI_THEME.dim,
-							whiteSpace: 'nowrap',
-							overflow: 'hidden',
-							// Fixed, not min, so the changing label never shifts the
-							// buttons around it.
-							width: 88,
-							flexShrink: 0,
-							textAlign: 'center',
-						}}
-					>
-						{formatPeriodLabel(scope, offset, periodRange, zoomed)}
-					</span>
-					<button
-						title="Later"
-						disabled={atLatest || !connected}
-						onClick={() => onChangeOffset(offset - 1)}
-						style={{
-							...navButtonStyle,
-							opacity: atLatest ? 0.35 : 1,
-							cursor: atLatest ? 'default' : 'pointer',
-						}}
-					>
-						▶
-					</button>
-				</div>
-			)}
+}) => {
+	// "All time" with no zoom is the whole log, so narrowing the board to what
+	// is in it would hide nothing.
+	const everythingInScope = scope === 'all' && !zoomed;
 
-			<div style={{display: 'flex', gap: 2}}>
-				{SCOPES.map(option => (
-					<button
-						key={option}
-						// Nothing in this row is what a zoomed window is, so while one is
-						// up none of them reads as pressed and Zoom does instead.
-						aria-pressed={!zoomed && scope === option}
-						disabled={!connected}
-						onClick={() => onChangeScope(option)}
-						style={{
-							...scopeButtonStyle(!zoomed && scope === option),
-							...(connected ? {} : mutedStyle),
-						}}
-					>
-						{scopeButtonLabel(option)}
-					</button>
-				))}
+	return (
+		<div
+			style={{
+				display: 'flex',
+				alignItems: 'center',
+				justifyContent: 'flex-end',
+				gap: 12,
+			}}
+		>
+			<div style={{display: 'flex', alignItems: 'center', gap: 6}}>
+				{(scope !== 'all' || zoomed) && (
+					<div style={{display: 'flex', alignItems: 'center', gap: 2}}>
+						<button
+							title="Earlier"
+							disabled={!connected}
+							onClick={() => onChangeOffset(offset + 1)}
+							style={{...navButtonStyle, ...(connected ? {} : mutedStyle)}}
+						>
+							◀
+						</button>
+						<span
+							style={{
+								fontSize: 10,
+								color: GUI_THEME.dim,
+								whiteSpace: 'nowrap',
+								overflow: 'hidden',
+								// Fixed, not min, so the changing label never shifts the
+								// buttons around it.
+								width: 88,
+								flexShrink: 0,
+								textAlign: 'center',
+							}}
+						>
+							{formatPeriodLabel(scope, offset, periodRange, zoomed)}
+						</span>
+						<button
+							title="Later"
+							disabled={atLatest || !connected}
+							onClick={() => onChangeOffset(offset - 1)}
+							style={{
+								...navButtonStyle,
+								opacity: atLatest ? 0.35 : 1,
+								cursor: atLatest ? 'default' : 'pointer',
+							}}
+						>
+							▶
+						</button>
+					</div>
+				)}
 
-				{/* Only ever the current state, never a way in: a window is zoomed by
+				<div style={{display: 'flex', gap: 2}}>
+					{SCOPES.map(option => (
+						<button
+							key={option}
+							// Nothing in this row is what a zoomed window is, so while one is
+							// up none of them reads as pressed and Zoom does instead.
+							aria-pressed={!zoomed && scope === option}
+							disabled={!connected}
+							onClick={() => onChangeScope(option)}
+							style={{
+								...scopeButtonStyle(!zoomed && scope === option),
+								...(connected ? {} : mutedStyle),
+							}}
+						>
+							{scopeButtonLabel(option)}
+						</button>
+					))}
+
+					{/* Only ever the current state, never a way in: a window is zoomed by
 				    dragging one out on the chart, and left by naming any period to
 				    its left. It sits at the end of the row because it is not a period
 				    on the same scale as the rest.
@@ -659,114 +664,107 @@ export const ScrubberControls = ({
 				    period it cannot go to: the row must not shift by its width
 				    underneath the pointer as a zoom comes and goes. Its title carries
 				    the gesture, since a button nobody can press has to say why. */}
+					<button
+						title={
+							zoomed
+								? 'A window dragged out on the chart — pick a period to leave it'
+								: 'Drag across the chart to zoom the window to a stretch of it'
+						}
+						aria-pressed={zoomed}
+						disabled
+						style={{
+							...scopeButtonStyle(zoomed),
+							opacity: zoomed ? 1 : 0.35,
+							cursor: 'default',
+						}}
+					>
+						Zoom
+					</button>
+				</div>
+			</div>
+
+			<div style={{display: 'flex', gap: 2}}>
 				<button
-					title={
-						zoomed
-							? 'A window dragged out on the chart — pick a period to leave it'
-							: 'Drag across the chart to zoom the window to a stretch of it'
-					}
-					aria-pressed={zoomed}
-					disabled
+					title="Volume — how much happened, per equal-width period, with no empty gaps for quiet stretches"
+					aria-label="Volume"
+					aria-pressed={layoutMode === 'even'}
+					disabled={!connected}
+					onClick={() => onChangeLayoutMode('even')}
 					style={{
-						...scopeButtonStyle(zoomed),
-						opacity: zoomed ? 1 : 0.35,
-						cursor: 'default',
+						...iconToggleButtonStyle(layoutMode === 'even'),
+						...(connected ? {} : mutedStyle),
 					}}
 				>
-					Zoom
+					<IconBars size={13} />
+				</button>
+				<button
+					title="Events — individual events by exact moment, x is elapsed time and y is time of day"
+					aria-label="Events"
+					aria-pressed={layoutMode === 'real'}
+					disabled={!connected}
+					onClick={() => onChangeLayoutMode('real')}
+					style={{
+						...iconToggleButtonStyle(layoutMode === 'real'),
+						...(connected ? {} : mutedStyle),
+					}}
+				>
+					<IconScatter size={13} />
 				</button>
 			</div>
 
-			{/* Bordered rather than underlined like the row beside it: it narrows
-			    the board below rather than naming the window, and must not read as
-			    a seventh period.
+			<div style={{display: 'flex', gap: 12, alignItems: 'center'}}>
+				<Checkbox
+					label="Code"
+					checked={showCommits}
+					activeColor={GUI_THEME.green}
+					disabled={!connected}
+					onChange={onChangeShowCommits}
+				/>
+				<BoardSeriesGroup
+					connected={connected}
+					showIssues={showIssues}
+					view={boardView}
+					identities={identities}
+					hiddenIds={hiddenIdentityIds}
+					expanded={categoriesExpanded}
+					identitiesExpanded={identitiesExpanded}
+					filtered={categoriesFiltered}
+					onChangeShowIssues={onChangeShowIssues}
+					onChangeView={onChangeBoardView}
+					onToggleIdentity={onToggleIdentity}
+					onOnlyIdentity={onOnlyIdentity}
+					onToggleExpanded={onToggleCategoriesExpanded}
+					onSetIdentitiesExpanded={onSetIdentitiesExpanded}
+				/>
 
-			    Nothing to match on where the server capped the window — its
-			    buckets carry counts, not the tickets they counted — so it says so
-			    rather than emptying the board. */}
-			<button
-				title={
-					!windowFilterable
-						? 'Too many events in this window to tell which tickets they belong to'
-						: windowOnly
-						? 'Showing only tickets with activity in this window'
-						: 'Show only tickets with activity in this window'
-				}
-				aria-pressed={windowOnly}
-				disabled={!connected || !windowFilterable}
-				onClick={() => onChangeWindowOnly(!windowOnly)}
-				style={{
-					...toggleButtonStyle(windowOnly),
-					...(connected && windowFilterable ? {} : mutedStyle),
-				}}
-			>
-				In window
-			</button>
-		</div>
+				{/* Beside the series checkboxes rather than by the scope row, so every
+			    narrowing on this bar is in one place. The window it names is the
+			    one those buttons select — under "All" that is every event there
+			    is, which narrows nothing, so it goes flat instead of pretending
+			    to. */}
+				<Checkbox
+					label="Scope only"
+					title={
+						everythingInScope
+							? 'Every event is in scope — pick a period to narrow the board'
+							: !windowFilterable
+							? 'Too many events in this window to tell which tickets they belong to'
+							: 'Show only tickets with activity in the selected window'
+					}
+					checked={windowOnly}
+					disabled={!connected || !windowFilterable || everythingInScope}
+					onChange={onChangeWindowOnly}
+				/>
 
-		<div style={{display: 'flex', gap: 2}}>
-			<button
-				title="Volume — how much happened, per equal-width period, with no empty gaps for quiet stretches"
-				aria-label="Volume"
-				aria-pressed={layoutMode === 'even'}
-				disabled={!connected}
-				onClick={() => onChangeLayoutMode('even')}
-				style={{
-					...iconToggleButtonStyle(layoutMode === 'even'),
-					...(connected ? {} : mutedStyle),
-				}}
-			>
-				<IconBars size={13} />
-			</button>
-			<button
-				title="Events — individual events by exact moment, x is elapsed time and y is time of day"
-				aria-label="Events"
-				aria-pressed={layoutMode === 'real'}
-				disabled={!connected}
-				onClick={() => onChangeLayoutMode('real')}
-				style={{
-					...iconToggleButtonStyle(layoutMode === 'real'),
-					...(connected ? {} : mutedStyle),
-				}}
-			>
-				<IconScatter size={13} />
-			</button>
-		</div>
-
-		<div style={{display: 'flex', gap: 12, alignItems: 'center'}}>
-			<Checkbox
-				label="Code"
-				checked={showCommits}
-				activeColor={GUI_THEME.green}
-				disabled={!connected}
-				onChange={onChangeShowCommits}
-			/>
-			<BoardSeriesGroup
-				connected={connected}
-				showIssues={showIssues}
-				view={boardView}
-				identities={identities}
-				hiddenIds={hiddenIdentityIds}
-				expanded={categoriesExpanded}
-				identitiesExpanded={identitiesExpanded}
-				filtered={categoriesFiltered}
-				onChangeShowIssues={onChangeShowIssues}
-				onChangeView={onChangeBoardView}
-				onToggleIdentity={onToggleIdentity}
-				onOnlyIdentity={onOnlyIdentity}
-				onToggleExpanded={onToggleCategoriesExpanded}
-				onSetIdentitiesExpanded={onSetIdentitiesExpanded}
-			/>
-
-			{/* <Checkbox
+				{/* <Checkbox
 				label="All boards"
 				checked={allBoards}
 				activeColor={GUI_THEME.accent}
 				onChange={onChangeAllBoards}
 			/> */}
-		</div>
+			</div>
 
-		{/* Present while live too, as the status of the board rather than a way
+			{/* Present while live too, as the status of the board rather than a way
 		    back to it, so entering history never resizes the row.
 
 		    "Now" only over a window that runs up to the present, though. It sits
@@ -774,35 +772,36 @@ export const ScrubberControls = ({
 		    naming that end — and over a window paged back or dragged out, that
 		    end is not now. "Resume" is unaffected: it is an action, not a claim
 		    about the far end. The slot holds its width either way. */}
-		<button
-			onClick={onReturnToLive}
-			disabled={!isScrubbing}
-			title={
-				isScrubbing ? 'Leave history and follow the board again' : undefined
-			}
-			style={{
-				background: 'transparent',
-				border: `1px solid ${
-					isScrubbing ? GUI_THEME.accent : GUI_THEME.transparent
-				}`,
-				color: isScrubbing ? GUI_THEME.accent : GUI_THEME.dim,
-				borderRadius: 6,
-				fontFamily: 'inherit',
-				width: 60,
-				display: 'inline-flex',
-				alignItems: 'center',
-				justifyContent: isScrubbing ? 'center' : 'flex-end',
-				fontSize: 10,
-				padding: '2px 8px',
-				cursor: isScrubbing ? 'pointer' : 'default',
-				whiteSpace: 'nowrap',
-				flexShrink: 0,
-			}}
-		>
-			{isScrubbing ? 'Resume' : atLatest ? 'Now' : ''}
-		</button>
-	</div>
-);
+			<button
+				onClick={onReturnToLive}
+				disabled={!isScrubbing}
+				title={
+					isScrubbing ? 'Leave history and follow the board again' : undefined
+				}
+				style={{
+					background: 'transparent',
+					border: `1px solid ${
+						isScrubbing ? GUI_THEME.accent : GUI_THEME.transparent
+					}`,
+					color: isScrubbing ? GUI_THEME.accent : GUI_THEME.dim,
+					borderRadius: 6,
+					fontFamily: 'inherit',
+					width: 60,
+					display: 'inline-flex',
+					alignItems: 'center',
+					justifyContent: isScrubbing ? 'center' : 'flex-end',
+					fontSize: 10,
+					padding: '2px 8px',
+					cursor: isScrubbing ? 'pointer' : 'default',
+					whiteSpace: 'nowrap',
+					flexShrink: 0,
+				}}
+			>
+				{isScrubbing ? 'Resume' : atLatest ? 'Now' : ''}
+			</button>
+		</div>
+	);
+};
 
 export const ScrubberHeader = ({
 	collapsed,

--- a/source/gui/client/components/TimeScrubber.tsx
+++ b/source/gui/client/components/TimeScrubber.tsx
@@ -44,6 +44,7 @@ import {
 	useExitTransition,
 	usePersistedFlag,
 	usePrefersReducedMotion,
+	windowNamesIssues,
 } from '../lib/scrubber';
 import {HintContent, ScrubberLayout} from './ScrubberLayout';
 import {ScatterLayer, ScatterPoint} from './ScrubberParts';
@@ -120,6 +121,7 @@ export const TimeScrubber = ({
 		layout: layoutMode,
 		view: boardView,
 		only,
+		windowOnly,
 	} = selection;
 	const animate = !usePrefersReducedMotion();
 	const trackRef = useRef<HTMLDivElement | null>(null);
@@ -723,12 +725,16 @@ export const TimeScrubber = ({
 				periodRange,
 				zoomed: zoom !== null,
 				atLatest,
+				windowOnly,
+				windowFilterable: windowNamesIssues(timeline),
 				layoutMode,
 				showIssues,
 				showCommits,
 				allBoards,
 				onChangeScope: changeScope,
 				onChangeOffset: changeOffset,
+				onChangeWindowOnly: (next: boolean) =>
+					onChangeSelection({windowOnly: next}),
 				onChangeLayoutMode: changeLayoutMode,
 				onChangeShowIssues: setShowIssues,
 				onChangeShowCommits: setShowCommits,

--- a/source/gui/client/components/TimeScrubber.tsx
+++ b/source/gui/client/components/TimeScrubber.tsx
@@ -81,6 +81,7 @@ export const TimeScrubber = ({
 	selection,
 	onChangeSelection,
 	knownIdentities,
+	refreshOn,
 }: {
 	timeline: GuiEventTimeline | null;
 	commits: GuiCommitEntry[];
@@ -114,6 +115,12 @@ export const TimeScrubber = ({
 	// Every tag and person the board knows, per axis, for naming a selected
 	// identity the window itself holds no event for.
 	knownIdentities: Record<'actor' | 'tag' | 'assignee', GuiEventIdentity[]>;
+	// Anything whose identity changing means the window has to be asked for
+	// again. The window is otherwise fetched only when it moves, which is fine
+	// while it is just a picture — but once it decides which tickets the board
+	// shows, a ticket filed since the last fetch is missing from it, and would
+	// be hidden from the board it has just joined.
+	refreshOn: unknown;
 }) => {
 	const {
 		scope,
@@ -228,6 +235,7 @@ export const TimeScrubber = ({
 		allBoards,
 		connected,
 		socketEpoch,
+		refreshOn,
 	]);
 
 	const changeLayoutMode = (next: LayoutMode) =>

--- a/source/gui/client/components/TimeScrubber.tsx
+++ b/source/gui/client/components/TimeScrubber.tsx
@@ -42,6 +42,7 @@ import {
 	Scope,
 	segmentAt,
 	useExitTransition,
+	isPeriodWindow,
 	usePersistedFlag,
 	usePrefersReducedMotion,
 	windowNamesIssues,
@@ -755,6 +756,13 @@ export const TimeScrubber = ({
 				onSetIdentitiesExpanded: setIdentitiesExpanded,
 			}}
 			chart={{
+				// Only where it is actually hiding something: ticked over a window
+				// that narrows nothing draws no outline, the way the box itself goes
+				// flat there.
+				scoped:
+					windowOnly &&
+					isPeriodWindow(scope, zoom !== null) &&
+					windowNamesIssues(timeline),
 				trackRef,
 				axis,
 				layoutMode,

--- a/source/gui/client/lib/board-selection.test.ts
+++ b/source/gui/client/lib/board-selection.test.ts
@@ -209,7 +209,7 @@ describe('stored selection', () => {
 		expect(readStoredSelection()).toEqual(DEFAULT_SELECTION);
 	});
 
-	it('keeps everything but the moment in time — the offset and the zoom', () => {
+	it('keeps everything but the moment in time, and the ticket filter', () => {
 		storeSelection({
 			scope: 'month',
 			offset: 4,
@@ -227,7 +227,9 @@ describe('stored selection', () => {
 			layout: 'real',
 			view: 'tagging',
 			only: ['bug'],
-			windowOnly: true,
+			// Not kept: a filter that hides tickets is not a preference to come
+			// back to days later.
+			windowOnly: false,
 		});
 	});
 

--- a/source/gui/client/lib/board-selection.test.ts
+++ b/source/gui/client/lib/board-selection.test.ts
@@ -56,6 +56,7 @@ describe('selection in the URL', () => {
 			layout: 'real',
 			view: 'tagging',
 			only: ['bug', 'docs'],
+			windowOnly: true,
 		};
 
 		expect(readSelectionParams(params(written(selection)))).toEqual(selection);
@@ -113,6 +114,7 @@ describe('applySelectionPatch', () => {
 		layout: 'even',
 		view: 'tagging',
 		only: ['bug'],
+		windowOnly: false,
 	};
 
 	it('starts a new scope at its most recent period', () => {
@@ -215,6 +217,7 @@ describe('stored selection', () => {
 			layout: 'real',
 			view: 'tagging',
 			only: ['bug'],
+			windowOnly: true,
 		});
 
 		expect(readStoredSelection()).toEqual({
@@ -224,6 +227,7 @@ describe('stored selection', () => {
 			layout: 'real',
 			view: 'tagging',
 			only: ['bug'],
+			windowOnly: true,
 		});
 	});
 

--- a/source/gui/client/lib/board-selection.ts
+++ b/source/gui/client/lib/board-selection.ts
@@ -25,6 +25,9 @@ export type BoardSelection = {
 	// hidden ones, so it says what to show without knowing what else exists.
 	// Null when nothing is hidden; [] when everything is.
 	only: readonly string[] | null;
+	// Narrows the board to the tickets the window holds an event for, rather
+	// than to what the selection colours.
+	windowOnly: boolean;
 };
 
 export const DEFAULT_SELECTION: BoardSelection = {
@@ -34,6 +37,7 @@ export const DEFAULT_SELECTION: BoardSelection = {
 	layout: 'even',
 	view: 'all',
 	only: null,
+	windowOnly: false,
 };
 
 const PARAM_KEYS = [
@@ -44,6 +48,7 @@ const PARAM_KEYS = [
 	'layout',
 	'view',
 	'only',
+	'window',
 ] as const;
 
 const STORAGE_KEY = 'epiq.board.selection';
@@ -84,7 +89,8 @@ export const isDefaultSelection = (selection: BoardSelection): boolean =>
 	selection.zoom === null &&
 	selection.layout === DEFAULT_SELECTION.layout &&
 	selection.view === DEFAULT_SELECTION.view &&
-	selection.only === null;
+	selection.only === null &&
+	selection.windowOnly === DEFAULT_SELECTION.windowOnly;
 
 // A change to one field, with what it implies for the others: a new scope
 // starts at its most recent period, and a new view drops a narrowing that
@@ -147,6 +153,7 @@ export const readSelectionParams = (
 		layout: isLayoutMode(layout) ? layout : DEFAULT_SELECTION.layout,
 		view: isBoardView(view) ? view : DEFAULT_SELECTION.view,
 		only: only === null ? null : only.split(',').filter(Boolean),
+		windowOnly: params.get('window') === '1',
 	});
 };
 
@@ -172,6 +179,7 @@ export const writeSelectionParams = (
 	put('layout', next.layout === DEFAULT_SELECTION.layout ? null : next.layout);
 	put('view', next.view === DEFAULT_SELECTION.view ? null : next.view);
 	put('only', next.only === null ? null : next.only.join(','));
+	put('window', next.windowOnly ? '1' : null);
 };
 
 // ------------------------------------------------------------------- storage
@@ -187,7 +195,10 @@ export const readStoredSelection = (): BoardSelection => {
 		const parsed: unknown = JSON.parse(stored);
 		if (typeof parsed !== 'object' || parsed === null) return DEFAULT_SELECTION;
 
-		const {scope, layout, view, only} = parsed as Record<string, unknown>;
+		const {scope, layout, view, only, windowOnly} = parsed as Record<
+			string,
+			unknown
+		>;
 
 		return normalize({
 			scope: isScope(String(scope))
@@ -200,6 +211,7 @@ export const readStoredSelection = (): BoardSelection => {
 				: DEFAULT_SELECTION.layout,
 			view: isBoardView(view) ? view : DEFAULT_SELECTION.view,
 			only: Array.isArray(only) ? only.map(String) : null,
+			windowOnly: windowOnly === true,
 		});
 	} catch {
 		return DEFAULT_SELECTION;
@@ -208,10 +220,10 @@ export const readStoredSelection = (): BoardSelection => {
 
 export const storeSelection = (selection: BoardSelection): void => {
 	try {
-		const {scope, layout, view, only} = selection;
+		const {scope, layout, view, only, windowOnly} = selection;
 		localStorage.setItem(
 			STORAGE_KEY,
-			JSON.stringify({scope, layout, view, only}),
+			JSON.stringify({scope, layout, view, only, windowOnly}),
 		);
 	} catch {
 		// Storage unavailable: the URL still carries the selection.

--- a/source/gui/client/lib/board-selection.ts
+++ b/source/gui/client/lib/board-selection.ts
@@ -186,7 +186,8 @@ export const writeSelectionParams = (
 
 // Neither the offset nor a zoom is kept: a stretch of last Tuesday is a
 // moment, not a preference, and reopening the board a week later on it would be
-// a surprise.
+// a surprise. Nor is windowOnly: it hides tickets outright, which is too much
+// to restore silently days later — it travels in the URL and nowhere else.
 export const readStoredSelection = (): BoardSelection => {
 	try {
 		const stored = localStorage.getItem(STORAGE_KEY);
@@ -195,10 +196,7 @@ export const readStoredSelection = (): BoardSelection => {
 		const parsed: unknown = JSON.parse(stored);
 		if (typeof parsed !== 'object' || parsed === null) return DEFAULT_SELECTION;
 
-		const {scope, layout, view, only, windowOnly} = parsed as Record<
-			string,
-			unknown
-		>;
+		const {scope, layout, view, only} = parsed as Record<string, unknown>;
 
 		return normalize({
 			scope: isScope(String(scope))
@@ -211,7 +209,7 @@ export const readStoredSelection = (): BoardSelection => {
 				: DEFAULT_SELECTION.layout,
 			view: isBoardView(view) ? view : DEFAULT_SELECTION.view,
 			only: Array.isArray(only) ? only.map(String) : null,
-			windowOnly: windowOnly === true,
+			windowOnly: DEFAULT_SELECTION.windowOnly,
 		});
 	} catch {
 		return DEFAULT_SELECTION;
@@ -220,10 +218,10 @@ export const readStoredSelection = (): BoardSelection => {
 
 export const storeSelection = (selection: BoardSelection): void => {
 	try {
-		const {scope, layout, view, only, windowOnly} = selection;
+		const {scope, layout, view, only} = selection;
 		localStorage.setItem(
 			STORAGE_KEY,
-			JSON.stringify({scope, layout, view, only, windowOnly}),
+			JSON.stringify({scope, layout, view, only}),
 		);
 	} catch {
 		// Storage unavailable: the URL still carries the selection.

--- a/source/gui/client/lib/gui-state.model.ts
+++ b/source/gui/client/lib/gui-state.model.ts
@@ -100,6 +100,9 @@ export type GuiEventTimelineEntry = {
 	actor: GuiEventIdentity | null;
 	tag: GuiEventIdentity | null;
 	assignee: GuiEventIdentity | null;
+	// The ticket the event happened to, for the board's window filter. Null for
+	// board- and swimlane-level events.
+	issue: string | null;
 };
 
 export type GuiEventTimeline = {

--- a/source/gui/client/lib/scrubber.test.ts
+++ b/source/gui/client/lib/scrubber.test.ts
@@ -31,6 +31,8 @@ import {
 	SCOPES,
 	SCRUBBER_KEYFRAMES,
 	segmentAt,
+	windowIssueIds,
+	windowNamesIssues,
 } from './scrubber';
 
 const DAY = 24 * 60 * 60 * 1000;
@@ -63,6 +65,7 @@ const entry = (
 	actor: null,
 	tag: null,
 	assignee: null,
+	issue: null,
 	...extra,
 });
 
@@ -795,6 +798,53 @@ describe('board filter', () => {
 
 	it('passes everything through when there is no filter', () => {
 		expect(issuePassesBoardFilter(issue(), [], null)).toBe(true);
+	});
+});
+
+describe('windowIssueIds', () => {
+	const touching = (t: number, issue: string | null) =>
+		entry(t, 'add.issue.tag', {issue});
+
+	it('is the set of tickets the window has an event for', () => {
+		const ids = windowIssueIds(
+			timeline([], undefined, [
+				touching(1, 'issue-1'),
+				touching(2, 'issue-2'),
+				touching(3, 'issue-1'),
+			]),
+		);
+
+		expect(ids && [...ids].sort()).toEqual(['issue-1', 'issue-2']);
+	});
+
+	it('skips the events that happened to no ticket', () => {
+		const ids = windowIssueIds(
+			timeline([], undefined, [touching(1, null), touching(2, 'issue-1')]),
+		);
+
+		expect(ids && [...ids]).toEqual(['issue-1']);
+	});
+
+	it('narrows nothing before a timeline has arrived', () => {
+		expect(windowIssueIds(null)).toBeNull();
+	});
+
+	it('narrows nothing where the server answered with counts alone', () => {
+		// Past its event cap the server sends buckets and no events, so there is
+		// no way to tell which tickets they counted.
+		expect(windowIssueIds(timeline([{t: 1, count: 40}]))).toBeNull();
+	});
+
+	it('narrows to nothing over a window where nothing happened', () => {
+		expect(windowIssueIds(timeline([]))?.size).toBe(0);
+	});
+
+	it('tells a capped window from a quiet one, so the toggle stays escapable', () => {
+		// Both name no tickets, but only the capped one is unfilterable — a
+		// quiet window has to stay togglable, or a narrowed board over it
+		// cannot be widened again.
+		expect(windowNamesIssues(timeline([{t: 1, count: 40}]))).toBe(false);
+		expect(windowNamesIssues(timeline([]))).toBe(true);
 	});
 });
 

--- a/source/gui/client/lib/scrubber.ts
+++ b/source/gui/client/lib/scrubber.ts
@@ -44,6 +44,10 @@ export const SEGMENT_HIGHLIGHT_COLOR = 'rgba(122, 157, 214, 0.14)';
 export const BUCKET_HIGHLIGHT_COLOR = 'rgba(255, 255, 255, 0.06)';
 export const NEEDLE_COLOR = 'rgba(255, 255, 255, 0.62)';
 
+// Ties the board's narrowing to the window doing it: the accent the checkbox
+// wears while it is on, dimmed to sit around a chart rather than in a row.
+export const SCOPED_OUTLINE_COLOR = 'rgba(118, 212, 255, 0.45)';
+
 // Brighter than either highlight: this one is being drawn by hand and has to
 // read against whatever it is dragged over.
 export const RANGE_SELECTION_COLOR = 'rgba(122, 157, 214, 0.22)';
@@ -611,6 +615,11 @@ const SCOPE_RECENT_LABELS: Record<Exclude<Scope, 'all'>, string> = {
 
 export const isScope = (value: string | null): value is Scope =>
 	(SCOPES as readonly string[]).includes(value ?? '');
+
+// Whether the window is a period at all. "All time" with no zoom is the whole
+// log, so narrowing anything to it would narrow nothing.
+export const isPeriodWindow = (scope: Scope, zoomed: boolean): boolean =>
+	scope !== 'all' || zoomed;
 
 export const getPeriodRange = (
 	scope: Scope,

--- a/source/gui/client/lib/scrubber.ts
+++ b/source/gui/client/lib/scrubber.ts
@@ -892,6 +892,31 @@ export const buildBoardFilter = (
 	return {axis, visibleIds: new Set(only)};
 };
 
+// Whether the window says which tickets its events belong to. Past the
+// server's cap it answers with bucket counts alone, which name none — as
+// against a quiet window, which names none because nothing happened.
+export const windowNamesIssues = (timeline: GuiEventTimeline | null): boolean =>
+	timeline === null ||
+	timeline.events.length > 0 ||
+	timeline.buckets.length === 0;
+
+// Ticket ids the window holds an event for, which is what the window filter
+// narrows the board to. Null where the board cannot be narrowed at all: before
+// a timeline has arrived, and where the window names no tickets it counted.
+export const windowIssueIds = (
+	timeline: GuiEventTimeline | null,
+): Set<string> | null => {
+	if (timeline === null || !windowNamesIssues(timeline)) return null;
+
+	const ids = new Set<string>();
+
+	for (const entry of timeline.events) {
+		if (entry.issue !== null) ids.add(entry.issue);
+	}
+
+	return ids;
+};
+
 // Read off the board's own state, which is already the state at the needle —
 // so a filtered board answers "who/what, as of here", matching the moment the
 // scrubber is parked on rather than the events inside the window.

--- a/source/gui/client/lib/use-board-selection.ts
+++ b/source/gui/client/lib/use-board-selection.ts
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useMemo} from 'react';
+import {useCallback, useEffect, useMemo, useRef} from 'react';
 import {useSearchParams} from 'react-router-dom';
 import {
 	applySelectionPatch,
@@ -21,10 +21,23 @@ export const useBoardSelection = (): [
 	const [searchParams, setSearchParams] = useSearchParams();
 
 	const fromUrl = hasSelectionParams(searchParams);
-	const selection = useMemo(
-		() => readSelectionParams(searchParams) ?? readStoredSelection(),
-		[searchParams],
-	);
+
+	// The one narrowing storage does not keep, carried across the routes of
+	// this session instead: opening a ticket rebuilds the query from scratch,
+	// and a board narrowed to a window must not widen under the reader who
+	// clicked one of the cards it left showing. A reload still starts wide —
+	// hiding tickets is where somebody is, not a preference to restore.
+	const windowOnly = useRef(false);
+
+	const selection = useMemo(() => {
+		const fromParams = readSelectionParams(searchParams);
+
+		return (
+			fromParams ?? {...readStoredSelection(), windowOnly: windowOnly.current}
+		);
+	}, [searchParams]);
+
+	windowOnly.current = selection.windowOnly;
 
 	useEffect(() => {
 		if (fromUrl) {

--- a/source/mcp/epiq-time-travel.ts
+++ b/source/mcp/epiq-time-travel.ts
@@ -146,36 +146,53 @@ const tagOf = (event: AppEvent): string | undefined => {
 		: payload?.tag;
 };
 
-// Ticket ids, taken from the log's own add.issue events: a payload's `id`
-// names a node of some kind, and nothing else in it says which kind.
-const buildIssueIdIndex = (events: AppEvent[]): Set<string> => {
-	const ids = new Set<string>();
+// Which ids are tickets, and what hangs off what: a payload's `id` names a node
+// of some kind, and nothing else in it says which kind. Built as the scan
+// proceeds, like filterEventsForBoard's.
+type IssueIndex = {
+	issueIds: Set<string>;
+	parentById: Map<string, string>;
+};
+
+const buildIssueIndex = (events: AppEvent[]): IssueIndex => {
+	const issueIds = new Set<string>();
+	const parentById = new Map<string, string>();
 
 	for (const event of events) {
-		if (event.action !== 'add.issue') continue;
+		const payload = event.payload as {id?: string; parent?: string} | undefined;
+		const id = payload?.id;
+		if (!id) continue;
 
-		const payload = event.payload as {id?: string} | undefined;
-
-		if (payload?.id) ids.add(payload.id);
+		if (event.action === 'add.issue') issueIds.add(id);
+		if (payload.parent) parentById.set(id, payload.parent);
 	}
 
-	return ids;
+	return {issueIds, parentById};
 };
 
 // Which ticket an event is about. Comments and attachments name it as `issue`,
-// their own `id` being the comment's; everything else that happens to a ticket
-// carries it as `id`.
+// their own `id` being the comment's; anything else that happened under a
+// ticket — the ticket itself, or a field node hanging off it — is found by
+// walking up from the id the event carries.
 const issueOf = (
 	event: AppEvent,
-	issueIds: ReadonlySet<string>,
+	{issueIds, parentById}: IssueIndex,
 ): string | null => {
 	const payload = event.payload as {id?: string; issue?: string} | undefined;
 
 	if (payload?.issue) return payload.issue;
 
-	return payload?.id !== undefined && issueIds.has(payload.id)
-		? payload.id
-		: null;
+	const seen = new Set<string>();
+	let current = payload?.id;
+
+	while (current !== undefined && !seen.has(current)) {
+		if (issueIds.has(current)) return current;
+
+		seen.add(current);
+		current = parentById.get(current);
+	}
+
+	return null;
 };
 
 // The TUI's phrasing minus the details that need state. A renamed tag reads
@@ -326,7 +343,7 @@ export const getEventTimeline = async (
 
 	// Over the unscoped log too, so an issue whose board changed since its
 	// add.issue is still recognised as an issue.
-	const issueIds = buildIssueIdIndex(eventsResult.value);
+	const issueIndex = buildIssueIndex(eventsResult.value);
 
 	// Effective times over the full log, not the board-scoped subset, so a
 	// poisoned id's dot lands where the scrub/checkout path will cut.
@@ -351,7 +368,7 @@ export const getEventTimeline = async (
 						t,
 						action: event.action,
 						label: describeTimelineEvent(event, names),
-						issue: issueOf(event, issueIds),
+						issue: issueOf(event, issueIndex),
 						...identitiesFor(event, names),
 					},
 			  ];

--- a/source/mcp/epiq-time-travel.ts
+++ b/source/mcp/epiq-time-travel.ts
@@ -107,6 +107,9 @@ export type EventTimelineEntry = {
 	// the scatter colours a tagging or assigning dot by.
 	tag: EventIdentity | null;
 	assignee: EventIdentity | null;
+	// The ticket the event happened to, where it happened to one. Null for
+	// board- and swimlane-level events, which belong to no ticket.
+	issue: string | null;
 };
 
 // Tag and contributor names come from the log's own create events rather than
@@ -141,6 +144,38 @@ const tagOf = (event: AppEvent): string | undefined => {
 	return event.action === 'tombstone.tag' || event.action === 'restore.tag'
 		? payload?.id
 		: payload?.tag;
+};
+
+// Ticket ids, taken from the log's own add.issue events: a payload's `id`
+// names a node of some kind, and nothing else in it says which kind.
+const buildIssueIdIndex = (events: AppEvent[]): Set<string> => {
+	const ids = new Set<string>();
+
+	for (const event of events) {
+		if (event.action !== 'add.issue') continue;
+
+		const payload = event.payload as {id?: string} | undefined;
+
+		if (payload?.id) ids.add(payload.id);
+	}
+
+	return ids;
+};
+
+// Which ticket an event is about. Comments and attachments name it as `issue`,
+// their own `id` being the comment's; everything else that happens to a ticket
+// carries it as `id`.
+const issueOf = (
+	event: AppEvent,
+	issueIds: ReadonlySet<string>,
+): string | null => {
+	const payload = event.payload as {id?: string; issue?: string} | undefined;
+
+	if (payload?.issue) return payload.issue;
+
+	return payload?.id !== undefined && issueIds.has(payload.id)
+		? payload.id
+		: null;
 };
 
 // The TUI's phrasing minus the details that need state. A renamed tag reads
@@ -289,6 +324,10 @@ export const getEventTimeline = async (
 	// ULIDs where it means "bug" or "jola".
 	const names = buildNameIndex(eventsResult.value);
 
+	// Over the unscoped log too, so an issue whose board changed since its
+	// add.issue is still recognised as an issue.
+	const issueIds = buildIssueIdIndex(eventsResult.value);
+
 	// Effective times over the full log, not the board-scoped subset, so a
 	// poisoned id's dot lands where the scrub/checkout path will cut.
 	const effectiveTimes = toEffectiveUlidTimes(
@@ -312,6 +351,7 @@ export const getEventTimeline = async (
 						t,
 						action: event.action,
 						label: describeTimelineEvent(event, names),
+						issue: issueOf(event, issueIds),
 						...identitiesFor(event, names),
 					},
 			  ];

--- a/source/test/e2e-gui/window-filter.pw.ts
+++ b/source/test/e2e-gui/window-filter.pw.ts
@@ -13,11 +13,58 @@ const addTicket = async (page: Page, title: string) => {
 
 const HOUR_MS = 60 * 60 * 1000;
 
+// Long enough that an assertion made at a third of it cannot be satisfied by
+// the reply instead of by the page.
+const REPLY_DELAY_MS = 2400;
+
 // A dragged-out window, which is the only kind with fixed bounds — every other
 // is anchored to now, and a stretch that is over is what makes the filter say
 // something.
 const zoomed = (boardUrl: string, from: number, to: number) =>
 	`${boardUrl}?window=1&from=${from}&to=${to}`;
+
+// Counts the window replies the page has been handed, and can hold them back.
+// The timeline is what the filter reads, so a test about a stale one has to
+// know when the fresh one lands — otherwise a reply still in flight arrives
+// after the change under test and the assertion passes on the wrong data.
+const watchTimeline = async (page: Page, delayMs = 0) => {
+	const seen = {count: 0};
+
+	await page.routeWebSocket(/\/ws/, ws => {
+		const server = ws.connectToServer();
+
+		ws.onMessage(message => server.send(message));
+		server.onMessage(async message => {
+			if (
+				typeof message === 'string' &&
+				message.startsWith('{"type":"timeline"')
+			) {
+				seen.count += 1;
+				if (delayMs > 0) {
+					await new Promise(resolve => setTimeout(resolve, delayMs));
+				}
+			}
+
+			ws.send(message);
+		});
+	});
+
+	return {
+		// Resolves once a reply has arrived and no further one has followed it,
+		// so what is on screen is the window that was asked for.
+		settled: async () => {
+			let previous = -1;
+
+			await expect
+				.poll(() => {
+					const stable = seen.count > 0 && seen.count === previous;
+					previous = seen.count;
+					return stable;
+				})
+				.toBe(true);
+		},
+	};
+};
 
 test('the scope filter narrows the board to what the window holds, and lets go again', async ({
 	page,
@@ -67,6 +114,96 @@ test('the scope filter narrows the board to what the window holds, and lets go a
 	// the empty board above was the filter and not a board still loading.
 	await scopeOnly.click();
 	await expect(card(page, title)).toHaveCount(0);
+
+	expect(pageErrors).toEqual([]);
+});
+
+test('a ticket filed while the filter is on joins the board it belongs to', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	const timeline = await watchTimeline(page);
+
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+	const boardUrl = page.url();
+
+	// A window that runs up to now, and is narrowing the board already.
+	await page.goto(`${boardUrl}?scope=day&window=1`);
+	await expect(page.getByRole('checkbox', {name: 'Scope only'})).toBeChecked();
+	await timeline.settled();
+
+	// Filing a ticket does not move the window, and the window is what the
+	// filter reads — so unless it is asked for again the new ticket is in the
+	// board's state and missing from the timeline that decides what shows.
+	const title = `Filed while filtering ${Date.now()}`;
+	await addTicket(page, title);
+
+	// Opening the new ticket rebuilds the query for its own route, which must
+	// not quietly drop the narrowing on the way.
+	await expect(page).toHaveURL(/window=1/);
+	await expect(card(page, title)).toBeVisible();
+
+	expect(pageErrors).toEqual([]);
+});
+
+test('leaving the period puts every ticket back, box and all', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	// Held back so the answer for "All" is still in flight when the assertion
+	// runs: what is on screen then is the board deciding for itself, off the
+	// window it is leaving, rather than the new window's data covering for it.
+	const timeline = await watchTimeline(page, REPLY_DELAY_MS);
+
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+	const boardUrl = page.url();
+
+	const title = `Left behind ${Date.now()}`;
+	await addTicket(page, title);
+
+	const now = Date.now();
+	await page.goto(zoomed(boardUrl, now - 3 * HOUR_MS, now - 2 * HOUR_MS));
+	await timeline.settled();
+	await expect(card(page, title)).toHaveCount(0);
+
+	// "All" is every event there is, so there is nothing left to narrow to and
+	// the box goes flat. It must not go on hiding tickets from under a control
+	// that can no longer be pressed — not even for the round trip.
+	await page.getByRole('button', {name: 'All', exact: true}).click();
+	await expect(card(page, title)).toBeVisible({timeout: REPLY_DELAY_MS / 3});
+	await expect(page.getByRole('checkbox', {name: 'Scope only'})).toBeDisabled();
+
+	expect(pageErrors).toEqual([]);
+});
+
+test('collapsing the scrubber keeps the filter reachable', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+	const boardUrl = page.url();
+
+	const title = `Collapsed ${Date.now()}`;
+	await addTicket(page, title);
+
+	const now = Date.now();
+	await page.goto(zoomed(boardUrl, now - 3 * HOUR_MS, now - 2 * HOUR_MS));
+	await expect(card(page, title)).toHaveCount(0);
+
+	await page.getByTitle('Hide time travel').click();
+	await expect(page.getByTestId('scrubber-track')).toHaveCount(0);
+
+	// The chart is gone but its narrowing is not, so the box has to be here.
+	const scopeOnly = page.getByRole('checkbox', {name: 'Scope only'});
+	await expect(scopeOnly).toBeVisible();
+	await scopeOnly.click();
+	await expect(card(page, title)).toBeVisible();
 
 	expect(pageErrors).toEqual([]);
 });

--- a/source/test/e2e-gui/window-filter.pw.ts
+++ b/source/test/e2e-gui/window-filter.pw.ts
@@ -1,0 +1,60 @@
+import type {Page} from '@playwright/test';
+import {expect, test} from './fixtures.js';
+
+const card = (page: Page, title: string) =>
+	page.locator('[draggable="true"]').filter({hasText: title});
+
+const addTicket = async (page: Page, title: string) => {
+	await page.getByTitle('Add issue').first().click();
+	await page.getByPlaceholder('issue name').fill(title);
+	await page.getByPlaceholder('issue name').press('Enter');
+	await expect(page.locator('aside')).toContainText(title);
+};
+
+const HOUR_MS = 60 * 60 * 1000;
+
+// A dragged-out window, which is the only kind with fixed bounds — every
+// other is anchored to now, and a stretch that is over is what makes the
+// filter say something.
+const zoomed = (boardUrl: string, from: number, to: number) =>
+	`${boardUrl}?window=1&from=${from}&to=${to}`;
+
+test('the window filter narrows the board to what the window holds, and lets go again', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+	const boardUrl = page.url();
+
+	const title = `Windowed ${Date.now()}`;
+	await addTicket(page, title);
+
+	const now = Date.now();
+	const toggle = page.getByRole('button', {name: 'In window'});
+
+	// A window the ticket was filed inside: narrowed, and still there.
+	await page.goto(zoomed(boardUrl, now - HOUR_MS, now + HOUR_MS));
+	await expect(toggle).toHaveAttribute('aria-pressed', 'true');
+	await expect(card(page, title)).toBeVisible();
+
+	// A stretch that ended before the repository existed holds no event, so
+	// it holds no ticket either.
+	await page.goto(zoomed(boardUrl, now - 3 * HOUR_MS, now - 2 * HOUR_MS));
+	await expect(card(page, title)).toHaveCount(0);
+
+	// And the way back out is the button itself: a quiet window must not
+	// leave it disabled over an empty board.
+	await expect(toggle).toBeEnabled();
+	await toggle.click();
+	await expect(card(page, title)).toBeVisible();
+	await expect(page).not.toHaveURL(/window=1/);
+
+	// Pressed again on the same page, the ticket goes away a second time — so
+	// the empty board above was the filter and not a board still loading.
+	await toggle.click();
+	await expect(card(page, title)).toHaveCount(0);
+
+	expect(pageErrors).toEqual([]);
+});

--- a/source/test/e2e-gui/window-filter.pw.ts
+++ b/source/test/e2e-gui/window-filter.pw.ts
@@ -13,13 +13,13 @@ const addTicket = async (page: Page, title: string) => {
 
 const HOUR_MS = 60 * 60 * 1000;
 
-// A dragged-out window, which is the only kind with fixed bounds — every
-// other is anchored to now, and a stretch that is over is what makes the
-// filter say something.
+// A dragged-out window, which is the only kind with fixed bounds — every other
+// is anchored to now, and a stretch that is over is what makes the filter say
+// something.
 const zoomed = (boardUrl: string, from: number, to: number) =>
 	`${boardUrl}?window=1&from=${from}&to=${to}`;
 
-test('the window filter narrows the board to what the window holds, and lets go again', async ({
+test('the scope filter narrows the board to what the window holds, and lets go again', async ({
 	page,
 	appUrl,
 	pageErrors,
@@ -27,33 +27,36 @@ test('the window filter narrows the board to what the window holds, and lets go 
 	await page.goto(appUrl);
 	await expect(page.getByTestId('board-switcher')).toContainText('Default');
 	const boardUrl = page.url();
+	const scopeOnly = page.getByRole('checkbox', {name: 'Scope only'});
+
+	// Under "All" the window is the whole log, so there is nothing to narrow.
+	await expect(scopeOnly).toBeDisabled();
 
 	const title = `Windowed ${Date.now()}`;
 	await addTicket(page, title);
 
 	const now = Date.now();
-	const toggle = page.getByRole('button', {name: 'In window'});
 
 	// A window the ticket was filed inside: narrowed, and still there.
 	await page.goto(zoomed(boardUrl, now - HOUR_MS, now + HOUR_MS));
-	await expect(toggle).toHaveAttribute('aria-pressed', 'true');
+	await expect(scopeOnly).toBeChecked();
 	await expect(card(page, title)).toBeVisible();
 
-	// A stretch that ended before the repository existed holds no event, so
-	// it holds no ticket either.
+	// A stretch that ended before the repository existed holds no event, so it
+	// holds no ticket either.
 	await page.goto(zoomed(boardUrl, now - 3 * HOUR_MS, now - 2 * HOUR_MS));
 	await expect(card(page, title)).toHaveCount(0);
 
-	// And the way back out is the button itself: a quiet window must not
-	// leave it disabled over an empty board.
-	await expect(toggle).toBeEnabled();
-	await toggle.click();
+	// And the way back out is the box itself: a quiet window must not leave it
+	// disabled over an empty board.
+	await expect(scopeOnly).toBeEnabled();
+	await scopeOnly.click();
 	await expect(card(page, title)).toBeVisible();
 	await expect(page).not.toHaveURL(/window=1/);
 
-	// Pressed again on the same page, the ticket goes away a second time — so
+	// Ticked again on the same page, the ticket goes away a second time — so
 	// the empty board above was the filter and not a board still loading.
-	await toggle.click();
+	await scopeOnly.click();
 	await expect(card(page, title)).toHaveCount(0);
 
 	expect(pageErrors).toEqual([]);

--- a/source/test/e2e-gui/window-filter.pw.ts
+++ b/source/test/e2e-gui/window-filter.pw.ts
@@ -41,6 +41,11 @@ test('the scope filter narrows the board to what the window holds, and lets go a
 	await page.goto(zoomed(boardUrl, now - HOUR_MS, now + HOUR_MS));
 	await expect(scopeOnly).toBeChecked();
 	await expect(card(page, title)).toBeVisible();
+	// The timeline is outlined while it is the thing doing the hiding.
+	await expect(page.getByTestId('scrubber-track')).toHaveCSS(
+		'outline-style',
+		'solid',
+	);
 
 	// A stretch that ended before the repository existed holds no event, so it
 	// holds no ticket either.
@@ -53,6 +58,10 @@ test('the scope filter narrows the board to what the window holds, and lets go a
 	await scopeOnly.click();
 	await expect(card(page, title)).toBeVisible();
 	await expect(page).not.toHaveURL(/window=1/);
+	await expect(page.getByTestId('scrubber-track')).not.toHaveCSS(
+		'outline-style',
+		'solid',
+	);
 
 	// Ticked again on the same page, the ticket goes away a second time — so
 	// the empty board above was the filter and not a board still loading.

--- a/source/test/epiq-time-travel.test.ts
+++ b/source/test/epiq-time-travel.test.ts
@@ -295,6 +295,58 @@ describe('epiq-time-travel', () => {
 				'add.issue.comment',
 			);
 		});
+		it('names the ticket each event happened to, and none for the rest', async () => {
+			const baseTime = 1_700_000_000_000;
+			const events = [
+				{
+					id: ulid(baseTime),
+					action: 'add.board',
+					payload: {id: 'board-1', name: 'Default'},
+				},
+				{
+					id: ulid(baseTime + 1_000),
+					action: 'add.swimlane',
+					payload: {id: 'lane-1', parent: 'board-1', name: 'Backlog'},
+				},
+				{
+					id: ulid(baseTime + 2_000),
+					action: 'add.issue',
+					payload: {id: 'issue-1', parent: 'lane-1', name: 'Ship v2'},
+				},
+				{
+					id: ulid(baseTime + 3_000),
+					action: 'close.issue',
+					payload: {id: 'issue-1', parent: 'lane-1', rank: 'a'},
+				},
+				{
+					id: ulid(baseTime + 4_000),
+					action: 'add.issue.comment',
+					payload: {id: 'comment-1', issue: 'issue-1', md: 'hi'},
+				},
+			];
+
+			vi.mocked(loadMergedEvents).mockReturnValue(
+				succeeded('events', events as never),
+			);
+
+			const result = await getEventTimeline({boardId: 'board-1'});
+
+			expect(isSuccess(result)).toBe(true);
+			if (isFail(result)) return;
+
+			expect(
+				result.value.events.map(entry => [entry.action, entry.issue]),
+			).toEqual([
+				// A board and a swimlane happened to no ticket, and the lane's
+				// own id must not be mistaken for one.
+				['add.board', null],
+				['add.swimlane', null],
+				['add.issue', 'issue-1'],
+				['close.issue', 'issue-1'],
+				// The comment's own id is `id`; the ticket it hangs off is `issue`.
+				['add.issue.comment', 'issue-1'],
+			]);
+		});
 
 		it('names a tag under a board scope, where create.tag itself is out of scope', async () => {
 			const baseTime = 1_700_000_000_000;

--- a/source/test/epiq-time-travel.test.ts
+++ b/source/test/epiq-time-travel.test.ts
@@ -323,6 +323,16 @@ describe('epiq-time-travel', () => {
 					action: 'add.issue.comment',
 					payload: {id: 'comment-1', issue: 'issue-1', md: 'hi'},
 				},
+				{
+					id: ulid(baseTime + 5_000),
+					action: 'add.field',
+					payload: {id: 'field-1', parent: 'issue-1', name: 'points'},
+				},
+				{
+					id: ulid(baseTime + 6_000),
+					action: 'edit.title',
+					payload: {id: 'field-1', name: 'story points'},
+				},
 			];
 
 			vi.mocked(loadMergedEvents).mockReturnValue(
@@ -345,6 +355,10 @@ describe('epiq-time-travel', () => {
 				['close.issue', 'issue-1'],
 				// The comment's own id is `id`; the ticket it hangs off is `issue`.
 				['add.issue.comment', 'issue-1'],
+				// A field node, and an edit naming the field rather than the ticket:
+				// both are found by walking up to the ticket they hang off.
+				['add.field', 'issue-1'],
+				['edit.title', 'issue-1'],
 			]);
 		});
 


### PR DESCRIPTION
Closes 2M8RHZ0.

A **"Scope only"** checkbox in the scrubber's checkbox row that narrows the board to the tickets the selected window holds an event for — filed, moved, retitled, tagged, assigned, commented on, closed. Activity, not creation date: a ticket filed last month but touched this week stays visible under "Last 7 days".

### How

- `EventTimelineEntry` gains `issue`, resolved from the payload — `issue` for comments and attachments, otherwise by walking the parent chain up to the nearest ticket, so a field node's own events count for the ticket they hang off.
- `windowIssueIds` turns the window's events into the ids the board keeps; App ANDs that with the existing identity and text filters.
- Selection field `windowOnly`, URL `window=1`. Not persisted — hiding tickets is where somebody is, not a preference — but carried across this session's routes, since opening a ticket rebuilds the query and would otherwise widen the board under the click.

### Where it goes flat

- **"All" with no zoom**: the window is the whole log, so narrowing to it would hide nothing.
- **Past the server's 20k-event cap**: the timeline comes back as bucket counts, which name no tickets.

A *quiet* window is neither — it empties the board and the box stays live, or there would be no way back out. `windowNamesIssues` is what separates those two, and the board reads the same `isPeriodWindow` test the box does, so a narrowing can never outlive the control for it. While it is actually hiding something the timeline is outlined in the accent the box wears; the outline takes no space, so switching it on cannot reflow the charts under the pointer.

### Tests

Unit: the entry's ticket id (including through `parent`), the id set, the capped/quiet split, the URL round-trip and the storage drop. `window-filter.pw.ts` covers narrowing and letting go, a ticket filed while the filter is on, leaving the period, and the collapsed scrubber — each checked failing without its fix, two of them holding the timeline reply back so they assert the page's own decision rather than the reply that would have covered for it.

Follow-ups from the review, both pre-existing: NEAS92W (drop index resolved against unfiltered lanes) and ZT733PV (nothing shows how many tickets a filter hides).
