### PR TITLE
SAMSB2M keep the description inside its box

### DIFF
--- a/source/lib/components/InlineEditor.tsx
+++ b/source/lib/components/InlineEditor.tsx
@@ -6,6 +6,10 @@ import {nodes} from '../state/node-builder.js';
 import {useAppState} from '../state/state.js';
 import {theme} from '../theme/themes.js';
 import {truncateWithEllipsis} from '../utils/string.utils.js';
+import {
+	inlineEditorGutterWidth,
+	inlineEditorRowWidth,
+} from '../utils/inline-editor-layout.js';
 import {CursorUI} from './Cursor.js';
 import {ScrollBoxUI} from './ScrollBox.js';
 import {RenderedLineUI} from './MarkdownLinesUI.js';
@@ -97,7 +101,8 @@ export const InlineEditor: React.FC<Props> = ({
 
 	// Styled row for row, so the line numbers keep pointing at the text
 	// they name; a row wider than the box is cut, as before.
-	const rowWidth = maxWidth - 10;
+	const gutterWidth = inlineEditorGutterWidth(rows.length);
+	const rowWidth = inlineEditorRowWidth(maxWidth, rows.length);
 	const styledRows = useMemo(
 		() =>
 			classifyRows(rows).map((line): RenderedLine => {
@@ -127,7 +132,7 @@ export const InlineEditor: React.FC<Props> = ({
 					color={isSel ? theme.primary : theme.secondary2}
 					dimColor={!isSel}
 				>
-					{`${i + 1}   `.padStart(5, '\u00A0')}
+					{`${i + 1}   `.padStart(gutterWidth, '\u00A0')}
 				</Text>
 
 				{line.kind === 'blank' ? (
@@ -139,6 +144,7 @@ export const InlineEditor: React.FC<Props> = ({
 						<RenderedLineUI
 							line={line}
 							width={line.kind === 'code' ? rowWidth : 0}
+							wrap="truncate-end"
 						/>
 					</Box>
 				)}

--- a/source/lib/components/InlineEditor.tsx
+++ b/source/lib/components/InlineEditor.tsx
@@ -5,7 +5,7 @@ import {isSuccess} from '../model/result-types.js';
 import {nodes} from '../state/node-builder.js';
 import {useAppState} from '../state/state.js';
 import {theme} from '../theme/themes.js';
-import {truncateWithEllipsis} from '../utils/string.utils.js';
+import {truncateToWidth} from '../utils/string.utils.js';
 import {
 	inlineEditorGutterWidth,
 	inlineEditorRowWidth,
@@ -106,8 +106,8 @@ export const InlineEditor: React.FC<Props> = ({
 	const styledRows = useMemo(
 		() =>
 			classifyRows(rows).map((line): RenderedLine => {
-				if (line.kind === 'code') {
-					return {...line, text: truncateWithEllipsis(line.text, rowWidth)};
+				if (line.kind === 'code' || line.kind === 'caption') {
+					return {...line, text: truncateToWidth(line.text, rowWidth)};
 				}
 				if (line.kind === 'text' || line.kind === 'heading') {
 					const text = line.spans
@@ -115,7 +115,7 @@ export const InlineEditor: React.FC<Props> = ({
 						.join('');
 					return {
 						...line,
-						spans: inlineSpans(truncateWithEllipsis(text, rowWidth)),
+						spans: inlineSpans(truncateToWidth(text, rowWidth)),
 					};
 				}
 				return line;
@@ -128,12 +128,16 @@ export const InlineEditor: React.FC<Props> = ({
 
 		return (
 			<Box key={toInlineLineNodeId(id, i)}>
-				<Text
-					color={isSel ? theme.primary : theme.secondary2}
-					dimColor={!isSel}
-				>
-					{`${i + 1}   `.padStart(gutterWidth, '\u00A0')}
-				</Text>
+				{/* Never shrinks: a row that still overflows must cost the text
+				    its columns, not push the numbers onto a second line. */}
+				<Box flexShrink={0}>
+					<Text
+						color={isSel ? theme.primary : theme.secondary2}
+						dimColor={!isSel}
+					>
+						{`${i + 1}   `.padStart(gutterWidth, '\u00A0')}
+					</Text>
+				</Box>
 
 				{line.kind === 'blank' ? (
 					<Text backgroundColor={isSel ? 'gray' : undefined}>
@@ -159,6 +163,7 @@ export const InlineEditor: React.FC<Props> = ({
 				<Text color={selected ? theme.accent : theme.secondary2}>{label}</Text>
 			</Box>
 
+			{/* Margin, border and padding are counted in inline-editor-layout.ts */}
 			<Box
 				flexDirection="row"
 				borderStyle="round"

--- a/source/lib/components/MarkdownLinesUI.tsx
+++ b/source/lib/components/MarkdownLinesUI.tsx
@@ -1,10 +1,18 @@
-import {Box, Text} from 'ink';
+import {Box, Text, TextProps} from 'ink';
 import React from 'react';
 import {theme} from '../theme/themes.js';
 import {RenderedLine, Span} from '../utils/markdown-lite.js';
 
-const SpansUI = ({spans, bold}: {spans: Span[]; bold?: boolean}) => (
-	<Text color={theme.primary} bold={bold}>
+const SpansUI = ({
+	spans,
+	bold,
+	wrap,
+}: {
+	spans: Span[];
+	bold?: boolean;
+	wrap?: TextProps['wrap'];
+}) => (
+	<Text color={theme.primary} bold={bold} wrap={wrap}>
 		{spans.map((span, index) =>
 			span.code ? (
 				<Text key={index} color={theme.yellow}>
@@ -18,15 +26,18 @@ const SpansUI = ({spans, bold}: {spans: Span[]; bold?: boolean}) => (
 );
 
 // One rendered line. `width` is what a code line is padded to, so a fenced
-// block reads as a block rather than a ragged right edge.
+// block reads as a block rather than a ragged right edge. `wrap` is how a line
+// too wide for its box is handled.
 export const RenderedLineUI = ({
 	line,
 	width,
 	gutter = 0,
+	wrap,
 }: {
 	line: RenderedLine;
 	width: number;
 	gutter?: number;
+	wrap?: TextProps['wrap'];
 }) => {
 	switch (line.kind) {
 		case 'blank':
@@ -34,11 +45,15 @@ export const RenderedLineUI = ({
 		case 'fence':
 			return <Text color={theme.secondary2}>```</Text>;
 		case 'caption':
-			return <Text color={theme.accent}>{line.text}</Text>;
+			return (
+				<Text color={theme.accent} wrap={wrap}>
+					{line.text}
+				</Text>
+			);
 		case 'heading':
-			return <SpansUI spans={line.spans} bold />;
+			return <SpansUI spans={line.spans} bold wrap={wrap} />;
 		case 'text':
-			return <SpansUI spans={line.spans} />;
+			return <SpansUI spans={line.spans} wrap={wrap} />;
 		case 'code': {
 			const number =
 				gutter > 0
@@ -47,7 +62,11 @@ export const RenderedLineUI = ({
 					  ) + ' │ '
 					: '';
 			return (
-				<Text backgroundColor={theme.secondary} color={theme.primary}>
+				<Text
+					backgroundColor={theme.secondary}
+					color={theme.primary}
+					wrap={wrap}
+				>
 					{number}
 					{line.text.padEnd(Math.max(0, width - number.length))}
 				</Text>

--- a/source/lib/components/ScrollBox.tsx
+++ b/source/lib/components/ScrollBox.tsx
@@ -122,6 +122,7 @@ export const ScrollBoxUI: React.FC<Props> = ({
 				{visibleChildren}
 			</Box>
 
+			{/* Held even when idle, and counted in inline-editor-layout.ts */}
 			<Box flexDirection="column" width={1} height={scrollBarHeight}>
 				{Array.from({length: scrollBarHeight}).map((_, i) => (
 					<Text

--- a/source/lib/components/TicketUI.tsx
+++ b/source/lib/components/TicketUI.tsx
@@ -227,6 +227,7 @@ export const TicketUI: React.FC<Props> = ({ticket, height}) => {
 	};
 
 	return (
+		// The right padding is counted in inline-editor-layout.ts
 		<Box
 			width={maxWidth}
 			flexDirection="column"

--- a/source/lib/utils/inline-editor-layout.ts
+++ b/source/lib/utils/inline-editor-layout.ts
@@ -1,0 +1,19 @@
+// Everything the inline editor spends on chrome rather than text: the ticket
+// pane's right padding, the box's left margin, its border, its left padding,
+// and the scrollbar column the scroll box reserves.
+const CHROME_WIDTH = 6;
+
+const MIN_GUTTER_WIDTH = 5;
+
+// A line number followed by three spaces, every row sharing the widest
+// number's width so the text stays in one column.
+export const inlineEditorGutterWidth = (rowCount: number): number =>
+	Math.max(MIN_GUTTER_WIDTH, String(Math.max(rowCount, 1)).length + 3);
+
+// What is left for the row itself. A row wider than this wraps onto a second
+// terminal line, which pushes the rows below it past the box's border.
+export const inlineEditorRowWidth = (
+	maxWidth: number,
+	rowCount: number,
+): number =>
+	Math.max(0, maxWidth - CHROME_WIDTH - inlineEditorGutterWidth(rowCount));

--- a/source/lib/utils/string.utils.ts
+++ b/source/lib/utils/string.utils.ts
@@ -1,3 +1,5 @@
+import stringWidth from 'string-width';
+
 export function findOverlap(wordA: string, wordB: string): number {
 	const max = Math.min(wordA.length, wordB.length);
 	let overlap = 0;
@@ -19,6 +21,55 @@ export const truncateWithEllipsis = (value: string, width: number): string => {
 	}
 
 	return value.slice(0, width - ELLIPSIS.length) + ELLIPSIS;
+};
+
+const ANSI_SGR = /\u001B\[[0-9;]*m/;
+const RESET = '\u001B[0m';
+
+const graphemes = (value: string): string[] =>
+	[
+		...new Intl.Segmenter(undefined, {granularity: 'grapheme'}).segment(value),
+	].map(({segment}) => segment);
+
+// Truncates by what the terminal draws rather than by code units: styling
+// escapes cost no columns and a wide glyph costs two. A cut made while a style
+// is open closes it, so it cannot bleed into the rest of the frame.
+export const truncateToWidth = (value: string, width: number): string => {
+	const ELLIPSIS = '...';
+	if (width <= 0) return '';
+	if (stringWidth(value) <= width) return value;
+
+	if (width <= ELLIPSIS.length) {
+		return ELLIPSIS.slice(0, width);
+	}
+
+	const budget = width - ELLIPSIS.length;
+
+	let kept = '';
+	let used = 0;
+	let styled = false;
+
+	for (const part of value.split(/(\u001B\[[0-9;]*m)/)) {
+		if (part === '') continue;
+
+		if (ANSI_SGR.test(part)) {
+			kept += part;
+			styled = part !== RESET && part !== '\u001B[m';
+			continue;
+		}
+
+		for (const grapheme of graphemes(part)) {
+			const cost = stringWidth(grapheme);
+			if (used + cost > budget) {
+				return `${kept}${ELLIPSIS}${styled ? RESET : ''}`;
+			}
+
+			kept += grapheme;
+			used += cost;
+		}
+	}
+
+	return `${kept}${ELLIPSIS}${styled ? RESET : ''}`;
 };
 
 export const sanitizeInlineText = (value: unknown): string => {

--- a/source/test/inline-editor-layout.test.ts
+++ b/source/test/inline-editor-layout.test.ts
@@ -1,0 +1,39 @@
+import {describe, expect, it} from 'vitest';
+import {
+	inlineEditorGutterWidth,
+	inlineEditorRowWidth,
+} from '../lib/utils/inline-editor-layout.js';
+
+// What the inline editor is left with once the chrome around its rows is
+// paid for: the ticket pane's right padding, the box's left margin, its
+// border on both sides, its left padding, and the scroll box's scrollbar
+// column. A row wider than this wraps, and every wrapped row pushes the ones
+// below it past the box's bottom border.
+const usableWidth = (maxWidth: number) => maxWidth - (1 + 1 + 2 + 1 + 1);
+
+describe('inline editor layout', () => {
+	it('keeps a row and its gutter inside the box', () => {
+		for (const maxWidth of [80, 120, 197, 240]) {
+			for (const rowCount of [1, 9, 99, 100, 1000]) {
+				expect(
+					inlineEditorGutterWidth(rowCount) +
+						inlineEditorRowWidth(maxWidth, rowCount),
+				).toBe(usableWidth(maxWidth));
+			}
+		}
+	});
+
+	it('widens the gutter once the line numbers do, and takes it from the row', () => {
+		expect(inlineEditorGutterWidth(99)).toBe(5);
+		expect(inlineEditorGutterWidth(100)).toBe(6);
+		expect(inlineEditorGutterWidth(1000)).toBe(7);
+
+		expect(inlineEditorRowWidth(120, 99)).toBe(109);
+		expect(inlineEditorRowWidth(120, 100)).toBe(108);
+	});
+
+	it('never asks for a negative row width in a narrow terminal', () => {
+		expect(inlineEditorRowWidth(10, 1)).toBe(0);
+		expect(inlineEditorRowWidth(0, 1)).toBe(0);
+	});
+});

--- a/source/test/truncate-to-width.test.ts
+++ b/source/test/truncate-to-width.test.ts
@@ -1,0 +1,43 @@
+import {describe, expect, it} from 'vitest';
+import stringWidth from 'string-width';
+import {truncateToWidth} from '../lib/utils/string.utils.js';
+
+const RED = '\u001B[31m';
+const RESET = '\u001B[0m';
+
+describe('truncateToWidth', () => {
+	it('leaves a string that already fits alone', () => {
+		expect(truncateToWidth('short', 10)).toBe('short');
+		expect(truncateToWidth('exactly-10', 10)).toBe('exactly-10');
+	});
+
+	it('cuts to the width it is given, ellipsis included', () => {
+		expect(truncateToWidth('abcdefghij', 6)).toBe('abc...');
+		expect(truncateToWidth('abcdefghij', 3)).toBe('...');
+		expect(truncateToWidth('abcdefghij', 0)).toBe('');
+	});
+
+	// The event log is chalk-styled, so measuring in code units would spend most
+	// of a row on escapes nobody can see.
+	it('spends no columns on styling escapes', () => {
+		const styled = `${RED}${'a'.repeat(40)}${RESET}`;
+
+		expect(stringWidth(truncateToWidth(styled, 20))).toBe(20);
+		expect(truncateToWidth(styled, 20)).toContain('a'.repeat(17));
+	});
+
+	// A cut made mid-style would otherwise bleed into the rest of the frame.
+	it('closes a style it cuts inside of', () => {
+		expect(truncateToWidth(`${RED}${'a'.repeat(40)}`, 20)).toMatch(
+			/\u001B\[0m$/,
+		);
+		expect(truncateToWidth('a'.repeat(40), 20)).not.toContain('\u001B');
+	});
+
+	it('counts a wide glyph as the two columns it draws', () => {
+		expect(truncateToWidth('\u672c'.repeat(20), 11)).toBe(
+			'\u672c'.repeat(4) + '...',
+		);
+		expect(stringWidth(truncateToWidth('\u672c'.repeat(20), 11))).toBe(11);
+	});
+});


### PR DESCRIPTION
Long description lines were truncated one column too wide, so they wrapped onto a second terminal row. Every wrapped row pushed the ones below it down, and the last lines ended up drawn over the box's bottom border.

**The width.** A row gets `maxWidth` minus 6 columns of chrome — the ticket pane's right padding, the box's left margin, its border, its left padding, and the scrollbar column `ScrollBox` reserves whether or not it is scrolling — minus the line-number gutter. The old arithmetic spent 10 on a gutter of 5, one column short, and the gutter silently grew to 6 past 99 lines without the rows shrinking to match. `inline-editor-layout.ts` now derives both from the same numbers, and the three sites that own that chrome point back at it.

**The measurement.** Truncation compared `value.length` to the width, which counts UTF-16 code units. The same editor renders the Event log, whose lines are chalk-styled: each invisible escape was charged as ~10 columns, so a styled row was cut to a fraction of the box (40 `a`s in a 20-column budget came out 15 wide), and a cut landing inside a sequence could bleed styling into the frame. A CJK or emoji description had the mirror problem — measured 1, drawn 2. `truncateToWidth` measures with `string-width`, walks graphemes, skips escapes and closes a style it cuts inside of.

**The guards.** Rows render with `wrap="truncate-end"` and the gutter no longer shrinks, so a row that is still too wide is cut rather than wrapped — a future miscount cannot grow the box. `caption` rows are truncated alongside the others instead of relying on that guard alone.

Tests: `inline-editor-layout.test.ts` pins gutter + row width to the usable width at any terminal width and line count (fails on the old numbers); `truncate-to-width.test.ts` covers the escape, wide-glyph and mid-style cases.

Verified by driving a real TUI in a pty against a scratch project at 197 and 80 columns: before, `not...` and `language/fram...` wrapped onto rows of their own; after, every line sits on one row inside the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk9YRKERxwE5GQefaWM9AA