### PR TITLE
R1PKGQJ give the description box the rows it can draw

### DIFF
--- a/source/lib/components/InlineEditor.tsx
+++ b/source/lib/components/InlineEditor.tsx
@@ -24,7 +24,8 @@ type Props = {
 	id: string;
 	label: string;
 	text: string;
-	height: number;
+	// Rows of text the box draws, its borders and label excluded.
+	rows: number;
 	selected: boolean;
 	maxWidth: number;
 };
@@ -78,7 +79,7 @@ export const InlineEditor: React.FC<Props> = ({
 	id,
 	label,
 	text,
-	height,
+	rows: rowCount,
 	selected,
 	maxWidth,
 }) => {
@@ -163,17 +164,20 @@ export const InlineEditor: React.FC<Props> = ({
 				<Text color={selected ? theme.accent : theme.secondary2}>{label}</Text>
 			</Box>
 
-			{/* Margin, border and padding are counted in inline-editor-layout.ts */}
+			{/* Margin, border and padding are counted in inline-editor-layout.ts.
+			    Clipped, so a terminal too short for the rows it was given cuts
+			    them rather than drawing them over the border. */}
 			<Box
 				flexDirection="row"
 				borderStyle="round"
 				borderColor={theme.secondary}
 				paddingLeft={1}
 				marginLeft={1}
+				overflowY="hidden"
 			>
 				<ScrollBoxUI
 					scrollByOne={true}
-					height={height - 3}
+					height={rowCount}
 					selectedIndex={selectedIndex}
 					itemHeight={1}
 				>

--- a/source/lib/components/TicketUI.tsx
+++ b/source/lib/components/TicketUI.tsx
@@ -11,6 +11,7 @@ import {CommentListUI} from './CommentListUI.js';
 import {CursorUI} from './Cursor.js';
 import {FieldListUI} from './FieldListUI.js';
 import {InlineEditor} from './InlineEditor.js';
+import {inlineEditorRowCount} from '../utils/inline-editor-layout.js';
 
 type Props = {
 	ticket: Ticket;
@@ -110,8 +111,7 @@ export const TicketUI: React.FC<Props> = ({ticket, height}) => {
 		const logValue =
 			logNode && isFieldNode(logNode) ? logNode.props.value ?? '' : '';
 
-		const commandPromptHeight = 3;
-		const editorHeight = height - commandPromptHeight;
+		const editorRows = inlineEditorRowCount(height);
 
 		return (
 			<Box
@@ -128,7 +128,7 @@ export const TicketUI: React.FC<Props> = ({ticket, height}) => {
 						text={logValue}
 						selected={false}
 						maxWidth={maxWidth}
-						height={editorHeight}
+						rows={editorRows}
 					/>
 				) : null}
 			</Box>
@@ -146,11 +146,7 @@ export const TicketUI: React.FC<Props> = ({ticket, height}) => {
 		0,
 	);
 
-	const spacing = 2;
-	const commandPromptHeight = 3;
-	const fieldListsHeight = fieldCount;
-	const editorHeight =
-		height - commandPromptHeight - fieldListsHeight - spacing;
+	const editorRows = inlineEditorRowCount(height, fieldCount);
 
 	const renderNode = (
 		child: ReturnType<typeof getRenderedChildren>[number],
@@ -165,7 +161,7 @@ export const TicketUI: React.FC<Props> = ({ticket, height}) => {
 					text={ticket.props.description ?? ''}
 					selected={selected}
 					maxWidth={maxWidth}
-					height={editorHeight}
+					rows={editorRows}
 				/>
 			);
 		}

--- a/source/lib/utils/inline-editor-layout.ts
+++ b/source/lib/utils/inline-editor-layout.ts
@@ -17,3 +17,16 @@ export const inlineEditorRowWidth = (
 	rowCount: number,
 ): number =>
 	Math.max(0, maxWidth - CHROME_WIDTH - inlineEditorGutterWidth(rowCount));
+
+// Rows the ticket pane spends around the editor rather than on text: its own
+// bottom padding, the editor's top padding, its label, and two borders.
+const CHROME_ROWS = 5;
+
+// A field below the editor costs its own row plus the blank one above it.
+const FIELD_ROWS = 2;
+
+// How many rows of text the box can draw. One row too many and the last of
+// them lands on the bottom border: the row list keeps the height it was given
+// while the box around it shrinks to the space that is left.
+export const inlineEditorRowCount = (height: number, fieldCount = 0): number =>
+	Math.max(1, height - CHROME_ROWS - FIELD_ROWS * fieldCount);

--- a/source/test/e2e/description-box.e2e.test.ts
+++ b/source/test/e2e/description-box.e2e.test.ts
@@ -1,0 +1,93 @@
+import path from 'node:path';
+import {beforeAll, describe, expect, it} from 'vitest';
+import {commonSteps} from './e2e-common-steps.js';
+import {ENTER, setupTui} from './e2e.helper.js';
+
+const testTimeout = 60_000;
+const EMPTY_CMD = 'for command line';
+
+// Writes a description longer and wider than the box, so both edges have to
+// hold (see fake-editor-long.sh).
+const fakeEditor = path.resolve(
+	process.cwd(),
+	'source/test/e2e/fake-editor-long.sh',
+);
+
+type Tui = ReturnType<typeof setupTui>;
+
+const run = async (tui: Tui, cmd: string, echo: string) => {
+	tui.input(cmd);
+	await tui.waitFor(echo, 4_000);
+	tui.input(ENTER);
+	await tui.waitFor(EMPTY_CMD, 5_000);
+};
+
+// The description box, as its border draws it: the top row, the rows between,
+// and the bottom row.
+const descriptionBox = (frame: string) => {
+	const lines = frame.split('\n').map(line => line.trimEnd());
+	const top = lines.findIndex(line => line.trimStart().startsWith('╭'));
+	const bottom = lines.findIndex(
+		(line, index) => index > top && line.trimStart().startsWith('╰'),
+	);
+
+	return {
+		top: lines[top] ?? '',
+		bottom: lines[bottom] ?? '',
+		inside: lines.slice(top + 1, bottom),
+	};
+};
+
+beforeAll(async () => {
+	const tui = setupTui();
+
+	try {
+		await commonSteps.configureInitialSettings(tui);
+	} finally {
+		await tui.destroy();
+	}
+});
+
+describe('TUI description box', () => {
+	// The rows were measured against more room than the box has, in both
+	// directions: a row wider than the box wrapped onto a second terminal line,
+	// and the box was handed more rows than its border could draw. Either way
+	// the description ended up written over the bottom border.
+	it(
+		'keeps a description that is too long and too wide inside its border',
+		async () => {
+			const tui = setupTui([], {env: {EDITOR: fakeEditor}});
+
+			try {
+				await commonSteps.init(tui);
+
+				tui.input(ENTER);
+				await tui.waitFor('Todo (0)');
+
+				await run(tui, ':config editor $EDITOR', 'config editor $EDITOR');
+				await run(tui, ':new issue Long description', 'new issue Long');
+				await tui.waitFor('Todo (1)', 4_000);
+				await run(tui, ':edit description', 'edit description');
+
+				tui.input(ENTER);
+				await tui.waitFor('Description (press e to edit)', 4_000);
+
+				const {top, bottom, inside} = descriptionBox(tui.output());
+
+				// Nothing but border on the row that closes the box.
+				expect(bottom.trimStart()).toMatch(/^╰─+╯$/);
+
+				// And every row between the borders is one row, closed on both
+				// sides — a wrapped row would leave a line with no border.
+				expect(inside.length).toBeGreaterThan(0);
+				for (const line of inside) {
+					expect(line.trimStart()).toMatch(/^│.*│$/);
+					expect(line.length).toBe(top.length);
+				}
+			} finally {
+				await tui.destroy();
+			}
+		},
+		testTimeout,
+	);
+});

--- a/source/test/e2e/fake-editor-long.sh
+++ b/source/test/e2e/fake-editor-long.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Deterministic editor stand-in that writes a description longer and wider than
+# the box can hold, so the rows below and to the right of it have to be cut.
+i=1
+: > "$1"
+while [ "$i" -le 30 ]; do
+	printf 'line %s: %s\n' "$i" "the quick brown fox jumps over the lazy dog and keeps on running well past the right hand edge of the box" >> "$1"
+	i=$((i + 1))
+done

--- a/source/test/inline-editor-layout.test.ts
+++ b/source/test/inline-editor-layout.test.ts
@@ -1,6 +1,7 @@
 import {describe, expect, it} from 'vitest';
 import {
 	inlineEditorGutterWidth,
+	inlineEditorRowCount,
 	inlineEditorRowWidth,
 } from '../lib/utils/inline-editor-layout.js';
 
@@ -35,5 +36,21 @@ describe('inline editor layout', () => {
 	it('never asks for a negative row width in a narrow terminal', () => {
 		expect(inlineEditorRowWidth(10, 1)).toBe(0);
 		expect(inlineEditorRowWidth(0, 1)).toBe(0);
+	});
+});
+
+describe('inline editor row count', () => {
+	// A 24-row terminal leaves the ticket pane 20 rows once the breadcrumb and
+	// the command line have theirs. The pane spends 5 on its own chrome and 2
+	// on each field below the box, so 5 rows of text are left.
+	it('leaves the chrome and the fields below the room they take', () => {
+		expect(inlineEditorRowCount(20, 5)).toBe(5);
+		expect(inlineEditorRowCount(20, 0)).toBe(15);
+		expect(inlineEditorRowCount(45, 5)).toBe(30);
+	});
+
+	it('asks for a row even in a terminal with no room for one', () => {
+		expect(inlineEditorRowCount(4, 5)).toBe(1);
+		expect(inlineEditorRowCount(0, 0)).toBe(1);
 	});
 });


### PR DESCRIPTION
Follow-up to SAMSB2M, which fixed the width of a description row but not how many rows the box is given. With a description longer than the box, the last row was still drawn on top of the bottom border — at every terminal height from 14 to 50.

**The arithmetic.** `TicketUI` charged `height - 3 (command prompt) - fieldCount - 2 (spacing)`. The command prompt had already been subtracted by `WorkspaceUI`; each field below the editor costs two rows (its own plus the blank above it), not one; and the pane's own bottom padding was not counted at all. The scroll box then rendered more rows than the border had room for, and because the row list keeps the height it was given while the box around it shrinks to what is left, the surplus landed on the border. `inlineEditorRowCount(height, fieldCount)` = `height - 5 - 2 * fieldCount` now, next to the width helper, and `InlineEditor` takes a `rows` count instead of a height it has to un-pad itself.

**The guard.** The box is `overflowY="hidden"`, so a terminal too short to hold even one row (below ~19 rows the fields alone fill the pane) cuts the rows instead of drawing them over the border.

**Verification.** Driven in a pty against a scratch project across 11 heights × 3 widths: before, the closing row carried text at every one; after, all 33 are clean. `description-box.e2e.test.ts` pins it in the suite — a real TUI, a 30-line description, and an assertion that the closing row is nothing but border, plus that every row between the borders is a single bordered line. Verified red on the SAMSB2M code: `expected '╰─ 3   line 3: the quick brown fox ju…' to match /^╰─+╯$/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nk9YRKERxwE5GQefaWM9AA