### PR TITLE
9Y5NAT1 keep the window somebody dragged out when they open a ticket

### DIFF
--- a/source/gui/client/lib/use-board-selection.ts
+++ b/source/gui/client/lib/use-board-selection.ts
@@ -11,6 +11,9 @@ import {
 	writeSelectionParams,
 } from './board-selection';
 
+// What a route change carries that neither the rebuilt query nor storage does.
+type CarriedKey = 'offset' | 'zoom' | 'windowOnly';
+
 // The URL wins when it says anything; a bare board link falls back to what
 // was last used here, and gets that written into the address bar so copying
 // it always hands over what is on screen. Either way storage follows the URL.
@@ -22,22 +25,30 @@ export const useBoardSelection = (): [
 
 	const fromUrl = hasSelectionParams(searchParams);
 
-	// The one narrowing storage does not keep, carried across the routes of
-	// this session instead: opening a ticket rebuilds the query from scratch,
-	// and a board narrowed to a window must not widen under the reader who
-	// clicked one of the cards it left showing. A reload still starts wide —
-	// hiding tickets is where somebody is, not a preference to restore.
-	const windowOnly = useRef(false);
+	// The three storage does not keep, carried across the routes of this
+	// session instead: opening a ticket rebuilds the query from scratch, and
+	// none of a board narrowed to a window, a stretch dragged out of the chart,
+	// or a window paged back off the present must come undone under the reader
+	// who clicked one of the cards it left showing. A reload still starts wide,
+	// unzoomed and at the present — where somebody is looking is a moment, not
+	// a preference to restore.
+	const carried = useRef<Pick<BoardSelection, CarriedKey>>({
+		offset: 0,
+		zoom: null,
+		windowOnly: false,
+	});
 
 	const selection = useMemo(() => {
 		const fromParams = readSelectionParams(searchParams);
 
-		return (
-			fromParams ?? {...readStoredSelection(), windowOnly: windowOnly.current}
-		);
+		return fromParams ?? {...readStoredSelection(), ...carried.current};
 	}, [searchParams]);
 
-	windowOnly.current = selection.windowOnly;
+	carried.current = {
+		offset: selection.offset,
+		zoom: selection.zoom,
+		windowOnly: selection.windowOnly,
+	};
 
 	useEffect(() => {
 		if (fromUrl) {

--- a/source/test/e2e-gui/scrubber-persistence.pw.ts
+++ b/source/test/e2e-gui/scrubber-persistence.pw.ts
@@ -23,3 +23,97 @@ test('the chart layout survives a reload', async ({page, appUrl}) => {
 	await expect(page.getByTestId('board-switcher')).toContainText('Default');
 	await expect(page.getByTestId('scatter-canvas')).toHaveCount(0);
 });
+
+// Storage deliberately does not keep a zoom, so the only thing carrying one
+// across a route is the query string. Opening a ticket used to rebuild that
+// query from scratch, which dropped the window and let the board fall back to
+// the stored scope underneath the reader.
+test('a dragged-out zoom survives opening a ticket', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	// The board seeds no tickets, so there has to be a card to open.
+	const title = `Zoom target ${Date.now()}`;
+	await page.getByTitle('Add issue').first().click();
+	await page.getByPlaceholder('issue name').fill(title);
+	await page.getByPlaceholder('issue name').press('Enter');
+	await expect(page.locator('aside')).toContainText(title);
+
+	// Back to the bare board, so the window dragged out below is the only
+	// thing the query carries.
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	const zoom = page.getByRole('button', {name: 'Zoom'});
+	await expect(zoom).toHaveAttribute('aria-pressed', 'false');
+
+	const track = page.getByTestId('scrubber-track');
+	const box = await track.boundingBox();
+	if (!box) throw new Error('scrubber track is not on screen');
+
+	const y = box.y + box.height / 2;
+	await page.mouse.move(box.x + box.width * 0.2, y);
+	await page.mouse.down();
+	await page.mouse.move(box.x + box.width * 0.6, y, {steps: 10});
+	await page.mouse.up();
+
+	await expect(zoom).toHaveAttribute('aria-pressed', 'true');
+
+	const dragged = new URL(page.url()).searchParams;
+	const from = dragged.get('from');
+	const to = dragged.get('to');
+	expect(from).not.toBeNull();
+	expect(to).not.toBeNull();
+
+	await page.locator('[draggable="true"]').filter({hasText: title}).click();
+	await expect(page).toHaveURL(/\/issue\//);
+
+	// The same window, not merely some window: a rebuilt query would leave Zoom
+	// unpressed, and a re-derived one could land on different bounds.
+	await expect(zoom).toHaveAttribute('aria-pressed', 'true');
+	const after = new URL(page.url()).searchParams;
+	expect(after.get('from')).toBe(from);
+	expect(after.get('to')).toBe(to);
+
+	expect(pageErrors).toEqual([]);
+});
+
+// The same fallback drops the offset, which storage pins to 0 for the same
+// reason it drops a zoom — so a board paged back to last week jumped to the
+// present the moment a card on it was opened.
+test('a paged-back window survives opening a ticket', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	const title = `Paged target ${Date.now()}`;
+	await page.getByTitle('Add issue').first().click();
+	await page.getByPlaceholder('issue name').fill(title);
+	await page.getByPlaceholder('issue name').press('Enter');
+	await expect(page.locator('aside')).toContainText(title);
+
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	await page.getByRole('button', {name: 'Week', exact: true}).click();
+	await page.getByTitle('Earlier').click();
+	await expect
+		.poll(() => new URL(page.url()).searchParams.get('offset'))
+		.toBe('1');
+
+	await page.locator('[draggable="true"]').filter({hasText: title}).click();
+	await expect(page).toHaveURL(/\/issue\//);
+
+	await expect
+		.poll(() => new URL(page.url()).searchParams.get('offset'))
+		.toBe('1');
+
+	expect(pageErrors).toEqual([]);
+});


### PR DESCRIPTION
Closes 9Y5NAT1.

Drag a window out on the timeline and the scope buttons unpress, Zoom reading as the active one. Click any ticket and the window is gone: the old scope button is pressed again and the board is back on the rolling period.

### Why

Opening a ticket builds its URL from scratch as `?tab=<tab>`, so every selection param goes with it — `from` and `to` above all. `useBoardSelection` then finds nothing to read, falls back to storage, and storage deliberately keeps neither a zoom nor an offset: *a stretch of last Tuesday is a moment, not a preference, and reopening the board a week later on it would be a surprise.* Sound for a reload; wrong for a route change the reader never asked to widen the board.

`windowOnly` already crossed that route in a `useRef`, added for this exact reason and commented as such. The zoom is the same kind of thing and was simply never given the same treatment.

### The fix

The three values storage does not keep now travel together in one ref rather than one ref for one of them. A reload still starts wide, unzoomed and at the present — the ref is the session, not a preference — and the URL still wins wherever it says anything, so a copied link means what it shows.

Spreading the carried values over `readStoredSelection()` skips `normalize`, which is safe: it forces `offset: 0` whenever a zoom is set or the scope is `all`, and the carried triple and the stored scope come from the same already-normalized selection, so the two cannot disagree.

### A second fault, same cause

`offset` is dropped by the same fallback, which pins it to `0`. A board paged back to last week jumped to the present the moment a card on it was opened. Found while fixing the reported one, confirmed with its own failing test, and fixed here because it is the same defect rather than a neighbouring one.

### Verified

Both regression tests were watched fail first, and on the fault rather than on the setup — an earlier draft failed on a `locator.click` timeout because the fixture seeds no tickets, which proved nothing. Red: Zoom `aria-pressed="false"` after the click, and `offset=1` becoming `null`. Green after the change.

Locally: **1051 unit**, **105 GUI e2e** (103 + these two), lint and GUI typecheck clean. Full pre-push gate passed on the pushed commit.
