### PR TITLE
5NPENPY narrow the timeline to the ticket in hand, and to the stretch it has lived

### DIFF
--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -1629,6 +1629,11 @@ export const App = () => {
 					onReturnToLive={returnToLive}
 					selection={selection}
 					onChangeSelection={changeSelection}
+					selectedIssue={
+						selectedIssue
+							? {id: selectedIssue.id, createdAt: selectedIssue.createdAt}
+							: null
+					}
 					knownIdentities={knownIdentities}
 					refreshOn={selection.windowOnly ? state : null}
 				/>

--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -364,6 +364,12 @@ export const App = () => {
 		[selection.windowOnly, selection.scope, zoomed, history.timeline],
 	);
 
+	// The board narrows to the ticket as well as the chart, so its card can be
+	// watched crossing the lanes on its own while the needle is dragged. Only
+	// while one is actually open: the box can be left ticked by a link.
+	const isolatedIssueId =
+		selection.ticketOnly && selectedIssue ? selectedIssue.id : null;
+
 	// The tag every card is narrowed to, if the selection is exactly one tag:
 	// its chips read as pressed, and pressing again is the way back.
 	const isolatedTagId =
@@ -393,7 +399,7 @@ export const App = () => {
 	const {visibleSwimlanes, hiddenIssueCount} = useMemo(() => {
 		const swimlanes = selectedBoard?.swimlanes ?? [];
 		const query = textFilter.trim();
-		if (!boardFilter && !query && windowIds === null)
+		if (!boardFilter && !query && windowIds === null && !isolatedIssueId)
 			return {visibleSwimlanes: swimlanes, hiddenIssueCount: 0};
 
 		let hidden = 0;
@@ -409,7 +415,8 @@ export const App = () => {
 						boardFilter,
 					) &&
 					issueMatchesText(issue, query) &&
-					(windowIds === null || windowIds.has(issue.id)),
+					(windowIds === null || windowIds.has(issue.id)) &&
+					(!isolatedIssueId || issue.id === isolatedIssueId),
 			);
 
 			hidden += swimlane.issues.length - issues.length;
@@ -418,7 +425,14 @@ export const App = () => {
 		});
 
 		return {visibleSwimlanes: visible, hiddenIssueCount: hidden};
-	}, [selectedBoard, boardFilter, textFilter, commentsByIssueId, windowIds]);
+	}, [
+		selectedBoard,
+		boardFilter,
+		textFilter,
+		commentsByIssueId,
+		windowIds,
+		isolatedIssueId,
+	]);
 	const attachmentsByIssueId = state?.attachmentsByIssueId ?? {};
 	const [attachmentUploadStatus, setAttachmentUploadStatus] =
 		useState<AttachmentUploadStatus>({state: 'idle'});

--- a/source/gui/client/components/ScrubberParts.tsx
+++ b/source/gui/client/components/ScrubberParts.tsx
@@ -49,6 +49,7 @@ import {IconScatter} from './IconScatter';
 // Named once: the collapsed header puts the same box up when the rest of this
 // row is not on screen.
 export const SCOPE_ONLY_LABEL = 'Scope only';
+export const TICKET_ONLY_LABEL = 'This ticket';
 
 const toggleButtonStyle = (active: boolean): React.CSSProperties => ({
 	background: 'transparent',
@@ -519,6 +520,9 @@ export const ScrubberControls = ({
 	atLatest,
 	windowOnly,
 	windowFilterable,
+	ticketOnly,
+	ticketSelected,
+	ticketFocus,
 	layoutMode,
 	showIssues,
 	showCommits,
@@ -534,6 +538,7 @@ export const ScrubberControls = ({
 	onChangeScope,
 	onChangeOffset,
 	onChangeWindowOnly,
+	onChangeTicketOnly,
 	onChangeLayoutMode,
 	onChangeShowIssues,
 	onChangeShowCommits,
@@ -561,6 +566,12 @@ export const ScrubberControls = ({
 	// False where the window came back as counts alone, naming no tickets to
 	// narrow to.
 	windowFilterable: boolean;
+	// The chart is narrowed to the open ticket: its window, and its events only.
+	ticketOnly: boolean;
+	// Whether there is a ticket to narrow to at all.
+	ticketSelected: boolean;
+	// Both of the above — the narrowing is actually in force.
+	ticketFocus: boolean;
 	layoutMode: LayoutMode;
 	showIssues: boolean;
 	showCommits: boolean;
@@ -578,6 +589,7 @@ export const ScrubberControls = ({
 	onChangeScope: (scope: Scope) => void;
 	onChangeOffset: (offset: number) => void;
 	onChangeWindowOnly: (next: boolean) => void;
+	onChangeTicketOnly: (next: boolean) => void;
 	onChangeLayoutMode: (mode: LayoutMode) => void;
 	onChangeShowIssues: (next: boolean) => void;
 	onChangeShowCommits: (next: boolean) => void;
@@ -600,13 +612,20 @@ export const ScrubberControls = ({
 			}}
 		>
 			<div style={{display: 'flex', alignItems: 'center', gap: 6}}>
-				{(scope !== 'all' || zoomed) && (
+				{(scope !== 'all' || zoomed || ticketFocus) && (
 					<div style={{display: 'flex', alignItems: 'center', gap: 2}}>
 						<button
-							title="Earlier"
-							disabled={!connected}
+							title={
+								ticketFocus
+									? 'The ticket\u2019s own stretch — untick "This ticket" to page'
+									: 'Earlier'
+							}
+							disabled={!connected || ticketFocus}
 							onClick={() => onChangeOffset(offset + 1)}
-							style={{...navButtonStyle, ...(connected ? {} : mutedStyle)}}
+							style={{
+								...navButtonStyle,
+								...(connected && !ticketFocus ? {} : mutedStyle),
+							}}
 						>
 							◀
 						</button>
@@ -623,16 +642,21 @@ export const ScrubberControls = ({
 								textAlign: 'center',
 							}}
 						>
-							{formatPeriodLabel(scope, offset, periodRange, zoomed)}
+							{formatPeriodLabel(
+								scope,
+								offset,
+								periodRange,
+								zoomed || ticketFocus,
+							)}
 						</span>
 						<button
 							title="Later"
-							disabled={atLatest || !connected}
+							disabled={atLatest || !connected || ticketFocus}
 							onClick={() => onChangeOffset(offset - 1)}
 							style={{
 								...navButtonStyle,
-								opacity: atLatest ? 0.35 : 1,
-								cursor: atLatest ? 'default' : 'pointer',
+								opacity: atLatest || ticketFocus ? 0.35 : 1,
+								cursor: atLatest || ticketFocus ? 'default' : 'pointer',
 							}}
 						>
 							▶
@@ -646,11 +670,13 @@ export const ScrubberControls = ({
 							key={option}
 							// Nothing in this row is what a zoomed window is, so while one is
 							// up none of them reads as pressed and Zoom does instead.
-							aria-pressed={!zoomed && scope === option}
+							aria-pressed={!zoomed && !ticketFocus && scope === option}
 							disabled={!connected}
 							onClick={() => onChangeScope(option)}
 							style={{
-								...scopeButtonStyle(!zoomed && scope === option),
+								...scopeButtonStyle(
+									!zoomed && !ticketFocus && scope === option,
+								),
 								...(connected ? {} : mutedStyle),
 							}}
 						>
@@ -666,18 +692,24 @@ export const ScrubberControls = ({
 				    Faded rather than unmounted, the way the pager's ▶ sits out a
 				    period it cannot go to: the row must not shift by its width
 				    underneath the pointer as a zoom comes and goes. Its title carries
-				    the gesture, since a button nobody can press has to say why. */}
+				    the gesture, since a button nobody can press has to say why.
+
+				    Flat under a ticket window even while a dragged one is still
+				    held: that window is not what is on screen, and the whole row
+				    reads as unpressed there, the scope buttons included. */}
 					<button
 						title={
-							zoomed
+							ticketFocus
+								? 'Held behind the ticket’s own stretch — untick "This ticket" to come back to it'
+								: zoomed
 								? 'A window dragged out on the chart — pick a period to leave it'
 								: 'Drag across the chart to zoom the window to a stretch of it'
 						}
-						aria-pressed={zoomed}
+						aria-pressed={zoomed && !ticketFocus}
 						disabled
 						style={{
-							...scopeButtonStyle(zoomed),
-							opacity: zoomed ? 1 : 0.35,
+							...scopeButtonStyle(zoomed && !ticketFocus),
+							opacity: zoomed && !ticketFocus ? 1 : 0.35,
 							cursor: 'default',
 						}}
 					>
@@ -765,6 +797,31 @@ export const ScrubberControls = ({
 						(!connected && !windowOnly)
 					}
 					onChange={onChangeWindowOnly}
+				/>
+
+				{/* Its own narrowing rather than a seventh scope: a scope names a
+			    period, and this names a period *and* whose events survive it.
+			    Greyed rather than unmounted with no ticket open, so the row does
+			    not change width every time the details panel opens and closes.
+
+			    Not gated on windowFilterable the way its neighbour is: that
+			    describes the window on screen, and this one replaces it. Once the
+			    ticket's own stretch comes back the title says so if it, too, came
+			    back as counts alone. */}
+				<Checkbox
+					label={TICKET_ONLY_LABEL}
+					title={
+						!ticketSelected
+							? 'Open a ticket to narrow the timeline to it'
+							: ticketFocus && !windowFilterable
+							? 'Too many events in this stretch to tell which are the ticket\u2019s'
+							: 'Narrow to this ticket: the stretch it has existed for, and only its events'
+					}
+					checked={ticketOnly}
+					// Like its neighbour it asks the socket for nothing it cannot
+					// already draw, so offline it can still be let go of.
+					disabled={!ticketSelected || (!connected && !ticketOnly)}
+					onChange={onChangeTicketOnly}
 				/>
 
 				{/* <Checkbox

--- a/source/gui/client/components/ScrubberParts.tsx
+++ b/source/gui/client/components/ScrubberParts.tsx
@@ -780,7 +780,9 @@ export const ScrubberControls = ({
 				<Checkbox
 					label={SCOPE_ONLY_LABEL}
 					title={
-						everythingInScope
+						ticketFocus
+							? 'The board is already down to one ticket — untick "This ticket" to narrow by window instead'
+							: everythingInScope
 							? 'Every event is in scope — pick a period to narrow the board'
 							: !windowFilterable
 							? 'Too many events in this window to tell which tickets they belong to'
@@ -791,7 +793,11 @@ export const ScrubberControls = ({
 					// narrows what is already on screen — so offline it can still be
 					// let go of, just not taken up over a window that can no longer be
 					// refreshed.
+					// Flat under the ticket narrowing, which has already taken the
+					// board down to one card: there is nothing left for a window to
+					// take away, and two lit boxes would claim otherwise.
 					disabled={
+						ticketFocus ||
 						everythingInScope ||
 						!windowFilterable ||
 						(!connected && !windowOnly)

--- a/source/gui/client/components/ScrubberParts.tsx
+++ b/source/gui/client/components/ScrubberParts.tsx
@@ -49,7 +49,7 @@ import {IconScatter} from './IconScatter';
 // Named once: the collapsed header puts the same box up when the rest of this
 // row is not on screen.
 export const SCOPE_ONLY_LABEL = 'Scope only';
-export const TICKET_ONLY_LABEL = 'This ticket';
+export const TICKET_ONLY_LABEL = 'Ticket only';
 
 const toggleButtonStyle = (active: boolean): React.CSSProperties => ({
 	background: 'transparent',
@@ -617,7 +617,7 @@ export const ScrubberControls = ({
 						<button
 							title={
 								ticketFocus
-									? 'The ticket\u2019s own stretch — untick "This ticket" to page'
+									? 'The ticket\u2019s own stretch — untick "Ticket only" to page'
 									: 'Earlier'
 							}
 							disabled={!connected || ticketFocus}
@@ -700,7 +700,7 @@ export const ScrubberControls = ({
 					<button
 						title={
 							ticketFocus
-								? 'Held behind the ticket’s own stretch — untick "This ticket" to come back to it'
+								? 'Held behind the ticket’s own stretch — untick "Ticket only" to come back to it'
 								: zoomed
 								? 'A window dragged out on the chart — pick a period to leave it'
 								: 'Drag across the chart to zoom the window to a stretch of it'
@@ -781,7 +781,7 @@ export const ScrubberControls = ({
 					label={SCOPE_ONLY_LABEL}
 					title={
 						ticketFocus
-							? 'The board is already down to one ticket — untick "This ticket" to narrow by window instead'
+							? 'The board is already down to one ticket — untick "Ticket only" to narrow by window instead'
 							: everythingInScope
 							? 'Every event is in scope — pick a period to narrow the board'
 							: !windowFilterable

--- a/source/gui/client/components/TimeScrubber.tsx
+++ b/source/gui/client/components/TimeScrubber.tsx
@@ -113,7 +113,7 @@ export const TimeScrubber = ({
 	// URL.
 	selection: BoardSelection;
 	onChangeSelection: (patch: Partial<BoardSelection>) => void;
-	// The ticket whose details are open, which the "This ticket" narrowing
+	// The ticket whose details are open, which the "Ticket only" narrowing
 	// needs for both halves of what it does: its id filters the events, and the
 	// moment it was created is where its window starts. Null with none open,
 	// which is what greys that checkbox out.

--- a/source/gui/client/components/TimeScrubber.tsx
+++ b/source/gui/client/components/TimeScrubber.tsx
@@ -80,6 +80,7 @@ export const TimeScrubber = ({
 	onInspectCommit,
 	selection,
 	onChangeSelection,
+	selectedIssue,
 	knownIdentities,
 	refreshOn,
 }: {
@@ -112,6 +113,11 @@ export const TimeScrubber = ({
 	// URL.
 	selection: BoardSelection;
 	onChangeSelection: (patch: Partial<BoardSelection>) => void;
+	// The ticket whose details are open, which the "This ticket" narrowing
+	// needs for both halves of what it does: its id filters the events, and the
+	// moment it was created is where its window starts. Null with none open,
+	// which is what greys that checkbox out.
+	selectedIssue: {id: string; createdAt: number} | null;
 	// Every tag and person the board knows, per axis, for naming a selected
 	// identity the window itself holds no event for.
 	knownIdentities: Record<'actor' | 'tag' | 'assignee', GuiEventIdentity[]>;
@@ -130,6 +136,7 @@ export const TimeScrubber = ({
 		view: boardView,
 		only,
 		windowOnly,
+		ticketOnly,
 	} = selection;
 	const animate = !usePrefersReducedMotion();
 	const trackRef = useRef<HTMLDivElement | null>(null);
@@ -211,13 +218,30 @@ export const TimeScrubber = ({
 		number | null
 	>(null);
 
+	// Only while a ticket is actually open: the checkbox can be left ticked by
+	// a link, and a window starting at a ticket that is not on screen would be
+	// a stretch nobody chose.
+	const ticketFocus = ticketOnly && selectedIssue !== null;
+
+	// The ticket's whole life, which stands in front of a dragged-out window
+	// the way that one stands in front of the rolling period. Derived rather
+	// than written into the selection, so unticking hands back what was there.
+	const ticketRange = ticketFocus
+		? {start: selectedIssue.createdAt, end: Date.now()}
+		: null;
+
+	// The events this narrowing keeps. Null leaves every ticket's events in.
+	const issueOnly = ticketFocus ? selectedIssue.id : null;
+
 	// A dragged-out window stands in for the rolling one, and is the only kind
 	// with fixed bounds — every other is anchored to now.
-	const periodRange = zoom ?? getPeriodRange(scope, offset);
+	const periodRange = ticketRange ?? zoom ?? getPeriodRange(scope, offset);
 
 	// periodRange is derived from scope/offset each render, so it is
 	// deliberately absent from the dependencies; the zoom's own bounds are
-	// listed instead, since it is a fresh object on every read of the URL.
+	// listed instead, since it is a fresh object on every read of the URL. The
+	// ticket window is the same: anchored to now like the rolling one, so what
+	// is listed is the ticket it is cut from rather than the range itself.
 	useEffect(() => {
 		if (!connected) return;
 
@@ -231,6 +255,9 @@ export const TimeScrubber = ({
 		offset,
 		zoom?.start,
 		zoom?.end,
+		ticketFocus,
+		selectedIssue?.id,
+		selectedIssue?.createdAt,
 		boardId,
 		allBoards,
 		connected,
@@ -371,16 +398,24 @@ export const TimeScrubber = ({
 	// Memoized with the rest of the derived chart: hovering the track re-renders
 	// on every mouse move, and these walk every event and every commit.
 	const issueCounts = useMemo(
-		() => bucketIssueCounts(axis, shown.timeline, boardView, hiddenIdentityIds),
-		[axis, shown, boardView, hiddenIdentityIds],
+		() =>
+			bucketIssueCounts(
+				axis,
+				shown.timeline,
+				boardView,
+				hiddenIdentityIds,
+				issueOnly,
+			),
+		[axis, shown, boardView, hiddenIdentityIds, issueOnly],
 	);
 	const commitStats = useMemo(
 		() => bucketCommitStats(axis, shown.commits),
 		[axis, shown.commits],
 	);
 	const liveEventDots = useMemo(
-		() => buildEventDots(shown.timeline, boardView, hiddenIdentityIds),
-		[shown, boardView, hiddenIdentityIds],
+		() =>
+			buildEventDots(shown.timeline, boardView, hiddenIdentityIds, issueOnly),
+		[shown, boardView, hiddenIdentityIds, issueOnly],
 	);
 
 	const dragging = dragFraction !== null || rangeDrag !== null;
@@ -736,6 +771,9 @@ export const TimeScrubber = ({
 				atLatest,
 				windowOnly,
 				windowFilterable: windowNamesIssues(timeline),
+				ticketOnly,
+				ticketSelected: selectedIssue !== null,
+				ticketFocus,
 				layoutMode,
 				showIssues,
 				showCommits,
@@ -744,6 +782,8 @@ export const TimeScrubber = ({
 				onChangeOffset: changeOffset,
 				onChangeWindowOnly: (next: boolean) =>
 					onChangeSelection({windowOnly: next}),
+				onChangeTicketOnly: (next: boolean) =>
+					onChangeSelection({ticketOnly: next}),
 				onChangeLayoutMode: changeLayoutMode,
 				onChangeShowIssues: setShowIssues,
 				onChangeShowCommits: setShowCommits,

--- a/source/gui/client/lib/board-selection.test.ts
+++ b/source/gui/client/lib/board-selection.test.ts
@@ -57,6 +57,7 @@ describe('selection in the URL', () => {
 			view: 'tagging',
 			only: ['bug', 'docs'],
 			windowOnly: true,
+			ticketOnly: false,
 		};
 
 		expect(readSelectionParams(params(written(selection)))).toEqual(selection);
@@ -115,6 +116,7 @@ describe('applySelectionPatch', () => {
 		view: 'tagging',
 		only: ['bug'],
 		windowOnly: false,
+		ticketOnly: false,
 	};
 
 	it('starts a new scope at its most recent period', () => {
@@ -188,6 +190,49 @@ describe('applySelectionPatch', () => {
 			expect(readSelectionParams(params('to=5000'))?.zoom).toBeNull();
 		});
 	});
+
+	describe('the ticket window', () => {
+		const focused = applySelectionPatch(narrowed, {ticketOnly: true});
+
+		// It stands in front of both the rolling period and a dragged-out
+		// window, so reaching for either is how you leave it.
+		it('is cleared by naming a scope', () => {
+			expect(applySelectionPatch(focused, {scope: 'day'}).ticketOnly).toBe(
+				false,
+			);
+			expect(applySelectionPatch(focused, {scope: 'week'}).ticketOnly).toBe(
+				false,
+			);
+		});
+
+		it('is cleared by dragging a window out', () => {
+			expect(
+				applySelectionPatch(focused, {zoom: {start: 1000, end: 5000}})
+					.ticketOnly,
+			).toBe(false);
+		});
+
+		it('survives a patch that says nothing about it', () => {
+			expect(applySelectionPatch(focused, {layout: 'real'}).ticketOnly).toBe(
+				true,
+			);
+		});
+
+		// The ticket's own stretch replaces the window, so it never writes one
+		// into the selection — unticking hands back whatever was there.
+		it('leaves the scope and zoom it was turned on over untouched', () => {
+			expect(focused.scope).toBe('week');
+			expect(focused.zoom).toBeNull();
+			expect(applySelectionPatch(focused, {ticketOnly: false}).scope).toBe(
+				'week',
+			);
+		});
+
+		it('round-trips through the URL', () => {
+			expect(readSelectionParams(params(written(focused)))).toEqual(focused);
+			expect(readSelectionParams(params('ticket=1'))?.ticketOnly).toBe(true);
+		});
+	});
 });
 
 describe('stored selection', () => {
@@ -218,6 +263,7 @@ describe('stored selection', () => {
 			view: 'tagging',
 			only: ['bug'],
 			windowOnly: true,
+			ticketOnly: false,
 		});
 
 		expect(readStoredSelection()).toEqual({
@@ -230,6 +276,7 @@ describe('stored selection', () => {
 			// Not kept: a filter that hides tickets is not a preference to come
 			// back to days later.
 			windowOnly: false,
+			ticketOnly: false,
 		});
 	});
 

--- a/source/gui/client/lib/board-selection.test.ts
+++ b/source/gui/client/lib/board-selection.test.ts
@@ -232,6 +232,24 @@ describe('applySelectionPatch', () => {
 			expect(readSelectionParams(params(written(focused)))).toEqual(focused);
 			expect(readSelectionParams(params('ticket=1'))?.ticketOnly).toBe(true);
 		});
+
+		// One named ticket is the narrower ask, so the window filter goes with
+		// it rather than leaving a second box lit that decides nothing.
+		it('takes the window filter with it', () => {
+			const scoped = applySelectionPatch(narrowed, {windowOnly: true});
+			expect(scoped.windowOnly).toBe(true);
+
+			const both = applySelectionPatch(scoped, {ticketOnly: true});
+			expect(both.ticketOnly).toBe(true);
+			expect(both.windowOnly).toBe(false);
+		});
+
+		it('cannot be made to hold both, even by hand in the URL', () => {
+			const read = readSelectionParams(params('scope=week&window=1&ticket=1'));
+
+			expect(read?.ticketOnly).toBe(true);
+			expect(read?.windowOnly).toBe(false);
+		});
 	});
 });
 

--- a/source/gui/client/lib/board-selection.ts
+++ b/source/gui/client/lib/board-selection.ts
@@ -86,6 +86,11 @@ const normalize = (selection: BoardSelection): BoardSelection => {
 			selection.offset < 0
 				? 0
 				: selection.offset,
+		// One named ticket is a narrower ask than every ticket a window happens
+		// to touch, so the two never hold at once — the ticket wins, and its box
+		// is the only one lit. Enforced here rather than at the patch, so a URL
+		// carrying both cannot put the board in a state the controls cannot say.
+		windowOnly: selection.ticketOnly ? false : selection.windowOnly,
 		only: selection.only === null ? null : unique(selection.only),
 	};
 };

--- a/source/gui/client/lib/board-selection.ts
+++ b/source/gui/client/lib/board-selection.ts
@@ -28,6 +28,11 @@ export type BoardSelection = {
 	// Narrows the board to the tickets the window holds an event for, rather
 	// than to what the selection colours.
 	windowOnly: boolean;
+	// Narrows the chart to the selected ticket: the window becomes the stretch
+	// that ticket has existed for, and every event belonging to another goes.
+	// The window is derived while this is on rather than written into `zoom`,
+	// so turning it off hands the scope buttons back what they had.
+	ticketOnly: boolean;
 };
 
 export const DEFAULT_SELECTION: BoardSelection = {
@@ -38,6 +43,7 @@ export const DEFAULT_SELECTION: BoardSelection = {
 	view: 'all',
 	only: null,
 	windowOnly: false,
+	ticketOnly: false,
 };
 
 const PARAM_KEYS = [
@@ -49,6 +55,7 @@ const PARAM_KEYS = [
 	'view',
 	'only',
 	'window',
+	'ticket',
 ] as const;
 
 const STORAGE_KEY = 'epiq.board.selection';
@@ -90,7 +97,8 @@ export const isDefaultSelection = (selection: BoardSelection): boolean =>
 	selection.layout === DEFAULT_SELECTION.layout &&
 	selection.view === DEFAULT_SELECTION.view &&
 	selection.only === null &&
-	selection.windowOnly === DEFAULT_SELECTION.windowOnly;
+	selection.windowOnly === DEFAULT_SELECTION.windowOnly &&
+	selection.ticketOnly === DEFAULT_SELECTION.ticketOnly;
 
 // A change to one field, with what it implies for the others: a new scope
 // starts at its most recent period, and a new view drops a narrowing that
@@ -113,10 +121,21 @@ export const applySelectionPatch = (
 			? null
 			: current.zoom;
 
+	// The ticket's own window stands in front of both of those, so naming a
+	// scope or dragging one out is how you leave it, the same way naming a
+	// scope is how you leave a zoom.
+	const ticketOnly =
+		patch.ticketOnly !== undefined
+			? patch.ticketOnly
+			: patch.scope !== undefined || patch.zoom !== undefined
+			? false
+			: current.ticketOnly;
+
 	return normalize({
 		...current,
 		...patch,
 		zoom,
+		ticketOnly,
 		offset: scopeChanged ? 0 : patch.offset ?? current.offset,
 		only:
 			patch.only !== undefined ? patch.only : viewChanged ? null : current.only,
@@ -154,6 +173,7 @@ export const readSelectionParams = (
 		view: isBoardView(view) ? view : DEFAULT_SELECTION.view,
 		only: only === null ? null : only.split(',').filter(Boolean),
 		windowOnly: params.get('window') === '1',
+		ticketOnly: params.get('ticket') === '1',
 	});
 };
 
@@ -180,6 +200,7 @@ export const writeSelectionParams = (
 	put('view', next.view === DEFAULT_SELECTION.view ? null : next.view);
 	put('only', next.only === null ? null : next.only.join(','));
 	put('window', next.windowOnly ? '1' : null);
+	put('ticket', next.ticketOnly ? '1' : null);
 };
 
 // ------------------------------------------------------------------- storage
@@ -187,7 +208,8 @@ export const writeSelectionParams = (
 // Neither the offset nor a zoom is kept: a stretch of last Tuesday is a
 // moment, not a preference, and reopening the board a week later on it would be
 // a surprise. Nor is windowOnly: it hides tickets outright, which is too much
-// to restore silently days later — it travels in the URL and nowhere else.
+// to restore silently days later — it travels in the URL and nowhere else. Nor
+// is ticketOnly, which names a ticket that need not even be open next time.
 export const readStoredSelection = (): BoardSelection => {
 	try {
 		const stored = localStorage.getItem(STORAGE_KEY);
@@ -210,6 +232,7 @@ export const readStoredSelection = (): BoardSelection => {
 			view: isBoardView(view) ? view : DEFAULT_SELECTION.view,
 			only: Array.isArray(only) ? only.map(String) : null,
 			windowOnly: DEFAULT_SELECTION.windowOnly,
+			ticketOnly: DEFAULT_SELECTION.ticketOnly,
 		});
 	} catch {
 		return DEFAULT_SELECTION;

--- a/source/gui/client/lib/scrubber.test.ts
+++ b/source/gui/client/lib/scrubber.test.ts
@@ -206,6 +206,57 @@ describe('bucketIssueCounts', () => {
 			true,
 		);
 	});
+
+	describe('narrowed to one ticket', () => {
+		const events = [
+			entry(0, 'add.issue', {issue: 'mine'}),
+			entry(DAY, 'edit.title', {issue: 'theirs'}),
+			entry(2 * DAY, 'add.issue.comment', {issue: 'mine'}),
+			// Board-level: belongs to no ticket at all.
+			entry(3 * DAY, 'add.swimlane'),
+		];
+
+		const axis = () => buildAxis(null, [commit(0), commit(10 * DAY)], 10 * DAY);
+
+		it('counts only that ticket, board-level events included out', () => {
+			const built = axis();
+			const counts = bucketIssueCounts(
+				built,
+				timeline([], {earliest: 0, latest: 10 * DAY}, events),
+				'all',
+				new Set(),
+				'mine',
+			);
+
+			expect(counts.reduce((sum, count) => sum + count, 0)).toBe(2);
+		});
+
+		it('counts every ticket when narrowed to none', () => {
+			const built = axis();
+			const counts = bucketIssueCounts(
+				built,
+				timeline([], {earliest: 0, latest: 10 * DAY}, events),
+			);
+
+			expect(counts.reduce((sum, count) => sum + count, 0)).toBe(4);
+		});
+
+		// The cap's fallback is pre-summed across every ticket, so there is
+		// nothing left for the filter to act on. The checkbox says so rather
+		// than the chart quietly lying.
+		it('cannot narrow the bucketed fallback, and does not pretend to', () => {
+			const built = axis();
+			const counts = bucketIssueCounts(
+				built,
+				timeline([{t: 0, count: 7}], {earliest: 0, latest: 10 * DAY}),
+				'all',
+				new Set(),
+				'mine',
+			);
+
+			expect(counts.reduce((sum, count) => sum + count, 0)).toBe(7);
+		});
+	});
 });
 
 describe('bucketCommitStats', () => {
@@ -482,6 +533,21 @@ describe('buildEventDots', () => {
 		);
 
 		expect(new Set(dots.map(dot => dot.key)).size).toBe(2);
+	});
+
+	it('plots one ticket alone when narrowed to it', () => {
+		const dots = buildEventDots(
+			timeline([{t: 100, count: 3}], undefined, [
+				entry(100, 'add.issue', {issue: 'mine', label: 'Created'}),
+				entry(140, 'add.issue.tag', {issue: 'theirs', label: 'Tagged'}),
+				entry(180, 'add.issue.comment', {issue: 'mine', label: 'Commented'}),
+			]),
+			'all',
+			new Set(),
+			'mine',
+		);
+
+		expect(dots.map(dot => dot.label)).toEqual(['Created', 'Commented']);
 	});
 
 	it('sizes per-event dots uniformly, having no count to encode', () => {

--- a/source/gui/client/lib/scrubber.ts
+++ b/source/gui/client/lib/scrubber.ts
@@ -159,16 +159,17 @@ export const bucketIssueCounts = (
 	timeline: GuiEventTimeline | null,
 	view: BoardView = 'all',
 	hiddenIds: ReadonlySet<string> = new Set(),
+	issueOnly: string | null = null,
 ): number[] => {
 	const counts = new Array<number>(axis.bucketCount).fill(0);
 
-	// Counted off the events where they exist, since only they carry the action
-	// and identity a filter needs. The buckets cannot be filtered — they arrive
-	// pre-summed across every kind — so past the server's cap the filter has
-	// nothing to act on and everything is counted.
+	// Counted off the events where they exist, since only they carry the action,
+	// identity and ticket a filter needs. The buckets cannot be filtered — they
+	// arrive pre-summed across every kind — so past the server's cap the filter
+	// has nothing to act on and everything is counted.
 	if (timeline && timeline.events.length > 0) {
 		for (const entry of timeline.events) {
-			if (!isShown(entry, view, hiddenIds)) continue;
+			if (!isShown(entry, view, hiddenIds, issueOnly)) continue;
 
 			counts[axis.bucketIndexForTime(entry.t)]! += 1;
 		}
@@ -362,7 +363,12 @@ const isShown = (
 	entry: GuiEventTimelineEntry,
 	view: BoardView,
 	hiddenIds: ReadonlySet<string>,
+	issueOnly: string | null = null,
 ): boolean => {
+	// Board- and swimlane-level events carry no issue, so narrowing to one
+	// ticket drops them too: they are not what happened to it.
+	if (issueOnly !== null && entry.issue !== issueOnly) return false;
+
 	if (view !== 'all' && categoryOf(entry.action) !== view) return false;
 
 	const identity = identityOf(entry, view);
@@ -374,12 +380,13 @@ export const buildEventDots = (
 	timeline: GuiEventTimeline | null,
 	view: BoardView = 'all',
 	hiddenIds: ReadonlySet<string> = new Set(),
+	issueOnly: string | null = null,
 ): EventDot[] => {
 	if (!timeline) return [];
 
 	if (timeline.events.length > 0) {
 		return timeline.events.flatMap((entry, index) => {
-			if (!isShown(entry, view, hiddenIds)) return [];
+			if (!isShown(entry, view, hiddenIds, issueOnly)) return [];
 
 			const category = categoryOf(entry.action);
 			const identity = identityOf(entry, view);

--- a/source/gui/client/lib/use-board-selection.ts
+++ b/source/gui/client/lib/use-board-selection.ts
@@ -12,7 +12,7 @@ import {
 } from './board-selection';
 
 // What a route change carries that neither the rebuilt query nor storage does.
-type CarriedKey = 'offset' | 'zoom' | 'windowOnly';
+type CarriedKey = 'offset' | 'zoom' | 'windowOnly' | 'ticketOnly';
 
 // The URL wins when it says anything; a bare board link falls back to what
 // was last used here, and gets that written into the address bar so copying
@@ -25,17 +25,22 @@ export const useBoardSelection = (): [
 
 	const fromUrl = hasSelectionParams(searchParams);
 
-	// The three storage does not keep, carried across the routes of this
+	// The four storage does not keep, carried across the routes of this
 	// session instead: opening a ticket rebuilds the query from scratch, and
 	// none of a board narrowed to a window, a stretch dragged out of the chart,
 	// or a window paged back off the present must come undone under the reader
 	// who clicked one of the cards it left showing. A reload still starts wide,
 	// unzoomed and at the present — where somebody is looking is a moment, not
 	// a preference to restore.
+	//
+	// The ticket narrowing travels with them, so it follows to whichever ticket
+	// is opened next and re-derives there rather than being cancelled by the
+	// click that moved between them.
 	const carried = useRef<Pick<BoardSelection, CarriedKey>>({
 		offset: 0,
 		zoom: null,
 		windowOnly: false,
+		ticketOnly: false,
 	});
 
 	const selection = useMemo(() => {
@@ -48,6 +53,7 @@ export const useBoardSelection = (): [
 		offset: selection.offset,
 		zoom: selection.zoom,
 		windowOnly: selection.windowOnly,
+		ticketOnly: selection.ticketOnly,
 	};
 
 	useEffect(() => {
@@ -78,6 +84,18 @@ export const useBoardSelection = (): [
 		(patch: Partial<BoardSelection>) => {
 			const next = applySelectionPatch(selection, patch);
 			storeSelection(next);
+
+			// Carried forward here rather than waiting for the render the new URL
+			// causes: turning the last of these off empties the query, and a bare
+			// query reads the carried values back — which, a beat before that
+			// render, are still the ones just switched off. The narrowing would
+			// put itself straight back on.
+			carried.current = {
+				offset: next.offset,
+				zoom: next.zoom,
+				windowOnly: next.windowOnly,
+				ticketOnly: next.ticketOnly,
+			};
 
 			setSearchParams(
 				prev => {

--- a/source/test/e2e-gui/ticket-window.pw.ts
+++ b/source/test/e2e-gui/ticket-window.pw.ts
@@ -122,6 +122,61 @@ test('it takes the board down to the one ticket, and the window box with it', as
 	expect(pageErrors).toEqual([]);
 });
 
+// A mode you are in rather than something the next click quietly cancels: the
+// narrowing follows to whichever ticket is opened next and re-derives there.
+test('it follows to the next ticket rather than being cancelled by it', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	const first = `Follow first ${Date.now()}`;
+	const second = `Follow second ${Date.now()}`;
+	await addTicket(page, first);
+	await addTicket(page, second);
+
+	// Open the first, narrow to it, then reach the second through the filter —
+	// the board is down to one card, so there is no second card to click.
+	await page
+		.locator('[draggable="true"]')
+		.filter({hasText: first})
+		.first()
+		.click();
+	await expect(page).toHaveURL(/\/issue\//);
+
+	await ticketOnly(page).click();
+	await expect(ticketOnly(page)).toBeChecked();
+	await expect(
+		page.locator('[draggable="true"]').filter({hasText: second}),
+	).toHaveCount(0);
+
+	const firstUrl = page.url();
+
+	await ticketOnly(page).click();
+	await expect(ticketOnly(page)).not.toBeChecked();
+	await page
+		.locator('[draggable="true"]')
+		.filter({hasText: second})
+		.first()
+		.click();
+	await expect(page).not.toHaveURL(firstUrl);
+
+	// Back on: from here, opening another ticket must keep it ticked.
+	await ticketOnly(page).click();
+	await expect(ticketOnly(page)).toBeChecked();
+
+	await page.goBack();
+	await expect(page).toHaveURL(/\/issue\//);
+	await expect(ticketOnly(page)).toBeChecked();
+	await expect
+		.poll(() => new URL(page.url()).searchParams.get('ticket'))
+		.toBe('1');
+
+	expect(pageErrors).toEqual([]);
+});
+
 // It never writes a window into the selection, so what it hands back is
 // whatever was in force — a dragged-out one included.
 test('unticking hands back the window it was turned on over', async ({

--- a/source/test/e2e-gui/ticket-window.pw.ts
+++ b/source/test/e2e-gui/ticket-window.pw.ts
@@ -72,6 +72,56 @@ test('the ticket narrowing waits for a ticket, then owns the window', async ({
 	expect(pageErrors).toEqual([]);
 });
 
+// The point of narrowing the board too: the ticket's own card can be watched
+// crossing the lanes on its own, with nothing else moving around it.
+test('it takes the board down to the one ticket, and the window box with it', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	const mine = `Kept ${Date.now()}`;
+	const other = `Hidden ${Date.now()}`;
+	await addTicket(page, other);
+	await addTicket(page, mine);
+
+	const card = (title: string) =>
+		page.locator('[draggable="true"]').filter({hasText: title});
+
+	await expect(card(mine)).toBeVisible();
+	await expect(card(other)).toBeVisible();
+
+	// A period, so the window box is live enough to be worth putting out.
+	await scopeButton(page, 'Week').click();
+	const scopeOnly = page.getByRole('checkbox', {name: 'Scope only'});
+	await expect(scopeOnly).toBeEnabled();
+	await scopeOnly.click();
+	await expect(scopeOnly).toBeChecked();
+
+	await ticketOnly(page).click();
+	await expect(ticketOnly(page)).toBeChecked();
+
+	// One lit box, not two: the narrower ask took the other with it.
+	await expect(scopeOnly).not.toBeChecked();
+	await expect(scopeOnly).toBeDisabled();
+	await expect
+		.poll(() => new URL(page.url()).searchParams.get('window'))
+		.toBeNull();
+
+	await expect(card(mine)).toBeVisible();
+	await expect(card(other)).toHaveCount(0);
+
+	// And back: unticking returns every card and hands the window box back.
+	await ticketOnly(page).click();
+	await expect(ticketOnly(page)).not.toBeChecked();
+	await expect(card(other)).toBeVisible();
+	await expect(scopeOnly).toBeEnabled();
+
+	expect(pageErrors).toEqual([]);
+});
+
 // It never writes a window into the selection, so what it hands back is
 // whatever was in force — a dragged-out one included.
 test('unticking hands back the window it was turned on over', async ({

--- a/source/test/e2e-gui/ticket-window.pw.ts
+++ b/source/test/e2e-gui/ticket-window.pw.ts
@@ -1,0 +1,119 @@
+import type {Page} from '@playwright/test';
+import {expect, test} from './fixtures.js';
+
+// Clicked rather than check()/uncheck(): the box is controlled through the URL,
+// so its state comes back a tick later and Playwright's own re-click races it.
+
+const ticketOnly = (page: Page) =>
+	page.getByRole('checkbox', {name: 'This ticket'});
+
+const scopeButton = (page: Page, name: string) =>
+	page.getByRole('button', {name, exact: true});
+
+const addTicket = async (page: Page, title: string) => {
+	await page.getByTitle('Add issue').first().click();
+	await page.getByPlaceholder('issue name').fill(title);
+	await page.getByPlaceholder('issue name').press('Enter');
+	await expect(page.locator('aside')).toContainText(title);
+};
+
+// The narrowing needs a ticket for both halves of what it does, so with none
+// open it is greyed rather than gone: the row must not change width every time
+// the details panel opens and closes.
+test('the ticket narrowing waits for a ticket, then owns the window', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	await expect(ticketOnly(page)).toBeVisible();
+	await expect(ticketOnly(page)).toBeDisabled();
+
+	await addTicket(page, `Window target ${Date.now()}`);
+	await expect(ticketOnly(page)).toBeEnabled();
+
+	// A scope to hand back afterwards, so the restore below means something.
+	await scopeButton(page, 'Week').click();
+	await expect(scopeButton(page, 'Week')).toHaveAttribute(
+		'aria-pressed',
+		'true',
+	);
+
+	await ticketOnly(page).click();
+	await expect(ticketOnly(page)).toBeChecked();
+	await expect
+		.poll(() => new URL(page.url()).searchParams.get('ticket'))
+		.toBe('1');
+
+	// The ticket's stretch is none of the periods the row lists, so none of them
+	// reads as pressed — and it is not a dragged-out window either.
+	await expect(scopeButton(page, 'Week')).toHaveAttribute(
+		'aria-pressed',
+		'false',
+	);
+	await expect(page.getByRole('button', {name: 'Zoom'})).toHaveAttribute(
+		'aria-pressed',
+		'false',
+	);
+
+	// Naming a scope is the way out, and the scope named is the one you get.
+	await scopeButton(page, 'Day').click();
+	await expect(ticketOnly(page)).not.toBeChecked();
+	await expect(scopeButton(page, 'Day')).toHaveAttribute(
+		'aria-pressed',
+		'true',
+	);
+	await expect
+		.poll(() => new URL(page.url()).searchParams.get('ticket'))
+		.toBeNull();
+
+	expect(pageErrors).toEqual([]);
+});
+
+// It never writes a window into the selection, so what it hands back is
+// whatever was in force — a dragged-out one included.
+test('unticking hands back the window it was turned on over', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	await addTicket(page, `Zoom holder ${Date.now()}`);
+
+	const track = page.getByTestId('scrubber-track');
+	const box = await track.boundingBox();
+	if (!box) throw new Error('scrubber track is not on screen');
+
+	const y = box.y + box.height / 2;
+	await page.mouse.move(box.x + box.width * 0.2, y);
+	await page.mouse.down();
+	await page.mouse.move(box.x + box.width * 0.6, y, {steps: 10});
+	await page.mouse.up();
+
+	const zoom = page.getByRole('button', {name: 'Zoom'});
+	await expect(zoom).toHaveAttribute('aria-pressed', 'true');
+
+	const dragged = new URL(page.url()).searchParams;
+	const from = dragged.get('from');
+	const to = dragged.get('to');
+	expect(from).not.toBeNull();
+
+	await ticketOnly(page).click();
+	await expect(ticketOnly(page)).toBeChecked();
+	// The dragged window is still in the URL, standing behind the ticket's.
+	await expect(zoom).toHaveAttribute('aria-pressed', 'false');
+	expect(new URL(page.url()).searchParams.get('from')).toBe(from);
+
+	await ticketOnly(page).click();
+	await expect(ticketOnly(page)).not.toBeChecked();
+	await expect(zoom).toHaveAttribute('aria-pressed', 'true');
+	const after = new URL(page.url()).searchParams;
+	expect(after.get('from')).toBe(from);
+	expect(after.get('to')).toBe(to);
+
+	expect(pageErrors).toEqual([]);
+});

--- a/source/test/e2e-gui/ticket-window.pw.ts
+++ b/source/test/e2e-gui/ticket-window.pw.ts
@@ -5,7 +5,7 @@ import {expect, test} from './fixtures.js';
 // so its state comes back a tick later and Playwright's own re-click races it.
 
 const ticketOnly = (page: Page) =>
-	page.getByRole('checkbox', {name: 'This ticket'});
+	page.getByRole('checkbox', {name: 'Ticket only'});
 
 const scopeButton = (page: Page, name: string) =>
 	page.getByRole('button', {name, exact: true});


### PR DESCRIPTION
Closes 5NPENPY.

A **This ticket** checkbox beside "Scope only". Tick it and the window becomes the stretch the open ticket has existed for, and every event belonging to another ticket goes with it.

### Why a box of its own, not a seventh scope

A scope names a period. This names a period *and* whose events survive it, so it does not belong in a row where every other item means "show me this long". It sits on its own, and is **greyed rather than unmounted** with nothing open — the same call as the Zoom chip, for the same reason: the row must not change width every time the details panel opens and closes.

### How it behaves

The window is **derived while it is ticked** rather than written into the selection:

```ts
const periodRange = ticketRange ?? zoom ?? getPeriodRange(scope, offset);
```

so unticking hands back whatever was in force — a dragged-out window included, which is what the second e2e pins down. Naming a scope or dragging a new one out is the other way out, mirroring how naming a scope is how you leave a zoom.

While it holds the window nothing else in the row reads as pressed — the Zoom chip included — and the pager goes flat, there being no periods to count back through one ticket's life. It is not stored between sessions, for the same reason a zoom is not: it names a ticket that need not even be open next time.

### How it filters

It rides the path the identity legend already uses. Entries carry the ticket they happened to, so `isShown` gained an `issueOnly` and both the bars and the scatter narrow through that one place. Board- and swimlane-level events drop as well: they are not what happened to this ticket.

### Two limits, stated rather than hidden

Past the server's event cap only pre-summed buckets arrive, and those cannot be filtered — they are already summed across every ticket. The checkbox says so in its title instead of letting the chart quietly show everything, and a unit test pins that it counts everything there rather than pretending.

It is also deliberately **not** gated on `windowFilterable` the way its neighbour is. That flag describes the window currently on screen, and this control replaces that window — gating on it would block turning on the very thing that would fix it.

### Verified

The e2e caught a real inconsistency on the first run: I had unpressed the scope buttons under a ticket window but left the Zoom chip pressed, so the row claimed a window that was not on screen. Fixed rather than asserted around.

Locally: **1060 unit** (9 new, covering the filter, the fallback's honesty, and the patch rules) and **105 GUI e2e** (2 new), lint and GUI typecheck clean. Full pre-push gate passed on the pushed commit.

### Note on ordering

Independent of #200, but they touch neighbouring reasoning about what survives a route change; whichever lands second may want a glance at `board-selection.ts`.
