### PR TITLE
M5P2HR2 give the track the blank strip above it to be pressed on

### DIFF
--- a/source/gui/client/components/ScrubberLayout.tsx
+++ b/source/gui/client/components/ScrubberLayout.tsx
@@ -21,6 +21,7 @@ import {
 	Segment,
 	SeriesPresence,
 	TRACK_HEIGHT,
+	TRACK_HIT_PADDING,
 	VolumeBar,
 } from '../lib/scrubber';
 import {formatDateTime} from '../../../lib/utils/date.utils.js';
@@ -160,7 +161,7 @@ export const ScrubberLayout = ({
 				style={{
 					display: 'flex',
 					flexDirection: 'column',
-					gap: collapsed ? 0 : 8,
+					gap: collapsed ? 0 : TRACK_HIT_PADDING,
 				}}
 			>
 				<div
@@ -231,6 +232,22 @@ export const ScrubberLayout = ({
 							WebkitUserSelect: 'none',
 						}}
 					>
+						{/* The gap above the charts, made part of the track for the
+					    pointer and nothing else. Absolutely positioned so it draws
+					    nothing, takes no room, and leaves the scoped outline on the
+					    box it already framed — a padding here would carry that
+					    outline up with it. */}
+						<div
+							aria-hidden
+							style={{
+								position: 'absolute',
+								left: 0,
+								right: 0,
+								top: -TRACK_HIT_PADDING,
+								height: TRACK_HIT_PADDING,
+							}}
+						/>
+
 						{chart.hoveredSegment && (
 							<SegmentHighlight
 								segment={chart.hoveredSegment}

--- a/source/gui/client/lib/scrubber.ts
+++ b/source/gui/client/lib/scrubber.ts
@@ -37,6 +37,12 @@ export const EVENTS_SCATTER_HEIGHT = TRACK_HEIGHT + 16;
 export const EVENTS_MODE_VERTICAL_PADDING =
 	(EVENTS_MODE_TOTAL_HEIGHT - EVENTS_SCATTER_HEIGHT) / 2;
 
+// The blank strip between the controls row and the charts, which the track
+// claims for the pointer without drawing in it: aiming at the top of a tall bar
+// otherwise lands just over it, on nothing. It is exactly the gap, so the strip
+// reaches the controls and no further.
+export const TRACK_HIT_PADDING = 8;
+
 export const HOVER_HINT_WIDTH = 220;
 
 // Must stay fainter than the bucket highlight drawn over it.

--- a/source/test/e2e-gui/track-hit-area.pw.ts
+++ b/source/test/e2e-gui/track-hit-area.pw.ts
@@ -1,0 +1,70 @@
+import type {Page} from '@playwright/test';
+import {expect, test} from './fixtures.js';
+
+// The strip is positioned outside the track's own box, so the track's bounding
+// box still stops at the charts — anything above its top is the borrowed gap.
+const aboveTheCharts = async (page: Page) => {
+	const box = await page.getByTestId('scrubber-track').boundingBox();
+	if (!box) throw new Error('scrubber track is not on screen');
+
+	return {box, y: box.y - 4};
+};
+
+// Aiming at the top of a tall bar is the natural way to pick a busy stretch,
+// and it used to land just over it, on nothing at all.
+test('a drag begun in the air above the bars still zooms', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	const zoom = page.getByRole('button', {name: 'Zoom'});
+	await expect(zoom).toHaveAttribute('aria-pressed', 'false');
+
+	const {box, y} = await aboveTheCharts(page);
+
+	await page.mouse.move(box.x + box.width * 0.2, y);
+	await page.mouse.down();
+	await page.mouse.move(box.x + box.width * 0.6, y, {steps: 10});
+	await page.mouse.up();
+
+	await expect(zoom).toHaveAttribute('aria-pressed', 'true');
+
+	// The same stretch a drag across the bars themselves would have picked: the
+	// strip is full width and measured off the track, so only the y differs.
+	const params = new URLSearchParams(new URL(page.url()).search);
+	expect(params.get('from')).not.toBeNull();
+	expect(params.get('to')).not.toBeNull();
+
+	expect(pageErrors).toEqual([]);
+});
+
+// Borrowed, not taken from somewhere that was doing a job: the strip is exactly
+// the gap, so the controls above it keep every pixel they had.
+test('the borrowed strip does not swallow the controls above it', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	const week = page.getByRole('button', {name: 'Week', exact: true});
+	const before = await week.boundingBox();
+	if (!before) throw new Error('the scope row is not on screen');
+
+	// Its own bottom edge is the last row the strip must not reach.
+	await page.mouse.click(
+		before.x + before.width / 2,
+		before.y + before.height - 1,
+	);
+	await expect(week).toHaveAttribute('aria-pressed', 'true');
+
+	// And the row has not moved: the space came from the blank gap, not from
+	// the buttons.
+	expect(await week.boundingBox()).toEqual(before);
+
+	expect(pageErrors).toEqual([]);
+});


### PR DESCRIPTION
Closes M5P2HR2.

The track's hit area stopped at the top of the tallest bar, so aiming at the head of a busy stretch — the natural place to aim — landed a pixel over it, on nothing, and no drag or scrub began.

### The space it borrows

The strip between the controls row and the charts was doing nothing but separating them. The track now takes it for the pointer and goes on drawing nothing there.

`TRACK_HIT_PADDING` is both the parent's `gap` and the strip's height, so the strip fills exactly that dead space and reaches the controls row and no further — by construction rather than by a number that could drift apart from it.

### Why not `paddingTop`

Padding would have grown the track's own box, and the track carries the scoped outline at `outlineOffset: 5` — so a narrowed board would have gained a visibly taller outline. The strip is absolutely positioned instead, outside the layout box: reach without layout. The charts, the row above and the outline are all exactly where they were, which is the point.

### Checked, not assumed

- **The maths is untouched.** `fractionFromClientX` measures `trackRef` (the charts) and `fractionFromEvent` measures `event.currentTarget` (the track div). Both are full width, so a press in the strip resolves to the same moment as one on the bars — only y differs, and nothing reads y.
- **The needle.** Its grip is `top: 0; bottom: 0` on the track box and does not extend into the strip, so a press there starts a range drag; under the 6px threshold that resolves to a scrub at the needle's own x. Near enough a no-op, where before the press did nothing at all. A limit worth knowing rather than a regression.

### Verified

The drag-above-the-bars test was watched fail with the strip's height zeroed — Zoom stayed `aria-pressed="false"`, the drag doing nothing — and pass with it restored. The second test pins that the controls row keeps every pixel and does not move, so the space really did come from the blank gap.

Gate green on the pushed commit: lint, typechecks, 1051 unit, 17 TUI e2e, 15 collab, GUI Playwright.

One local GUI run had `board-gutter.pw.ts` fail on `board-switcher` never appearing — the app not loading in that worker, unrelated to a scrubber hit area, and green in isolation and on the gate.
