### PR TITLE
FJR4TPS ask for the timeline when the window changes, not when the ticket does

### DIFF
--- a/source/gui/client/components/TimeScrubber.tsx
+++ b/source/gui/client/components/TimeScrubber.tsx
@@ -233,6 +233,15 @@ export const TimeScrubber = ({
 	// The events this narrowing keeps. Null leaves every ticket's events in.
 	const issueOnly = ticketFocus ? selectedIssue.id : null;
 
+	// Which ticket the window is cut from, and null whenever it is not cut from
+	// one. Only while the narrowing is on does a different ticket mean a
+	// different window to ask the server for; listing the open ticket itself
+	// would refetch the whole timeline on every click between two of them,
+	// which is most clicks and none of them a change of window.
+	const ticketWindowKey = ticketFocus
+		? `${selectedIssue.id}:${selectedIssue.createdAt}`
+		: null;
+
 	// A dragged-out window stands in for the rolling one, and is the only kind
 	// with fixed bounds — every other is anchored to now.
 	const periodRange = ticketRange ?? zoom ?? getPeriodRange(scope, offset);
@@ -255,9 +264,7 @@ export const TimeScrubber = ({
 		offset,
 		zoom?.start,
 		zoom?.end,
-		ticketFocus,
-		selectedIssue?.id,
-		selectedIssue?.createdAt,
+		ticketWindowKey,
 		boardId,
 		allBoards,
 		connected,

--- a/source/test/e2e-gui/ticket-window.pw.ts
+++ b/source/test/e2e-gui/ticket-window.pw.ts
@@ -10,6 +10,30 @@ const ticketOnly = (page: Page) =>
 const scopeButton = (page: Page, name: string) =>
 	page.getByRole('button', {name, exact: true});
 
+// Counts the timeline replies the page is handed, so a test can say that
+// clicking around asked the server for nothing.
+const watchTimeline = async (page: Page) => {
+	const seen = {count: 0};
+
+	await page.routeWebSocket(/\/ws/, ws => {
+		const server = ws.connectToServer();
+
+		ws.onMessage(message => server.send(message));
+		server.onMessage(message => {
+			if (
+				typeof message === 'string' &&
+				message.startsWith('{"type":"timeline"')
+			) {
+				seen.count += 1;
+			}
+
+			ws.send(message);
+		});
+	});
+
+	return seen;
+};
+
 const addTicket = async (page: Page, title: string) => {
 	await page.getByTitle('Add issue').first().click();
 	await page.getByPlaceholder('issue name').fill(title);
@@ -118,6 +142,49 @@ test('it takes the board down to the one ticket, and the window box with it', as
 	await expect(ticketOnly(page)).not.toBeChecked();
 	await expect(card(other)).toBeVisible();
 	await expect(scopeOnly).toBeEnabled();
+
+	expect(pageErrors).toEqual([]);
+});
+
+// The window is the ticket's only while the narrowing is on. With it off, one
+// ticket is as good as another to the scrubber, and asking the server for the
+// whole timeline again on every click between two of them made selecting a
+// ticket crawl.
+test('selecting tickets asks for no timeline while the narrowing is off', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	const seen = await watchTimeline(page);
+
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	const first = `Quiet first ${Date.now()}`;
+	const second = `Quiet second ${Date.now()}`;
+	await addTicket(page, first);
+	await addTicket(page, second);
+
+	const card = (title: string) =>
+		page.locator('[draggable="true"]').filter({hasText: title}).first();
+
+	// Let everything creating the tickets set off settle before counting.
+	await page.waitForTimeout(1500);
+	const before = seen.count;
+
+	await card(first).click();
+	await expect(page).toHaveURL(/\/issue\//);
+	await card(second).click();
+	await card(first).click();
+	await page.waitForTimeout(1500);
+
+	expect(seen.count).toBe(before);
+
+	// And with it on, the ticket *is* the window, so switching does ask again.
+	await ticketOnly(page).click();
+	await expect(ticketOnly(page)).toBeChecked();
+	await page.waitForTimeout(1500);
+	expect(seen.count).toBeGreaterThan(before);
 
 	expect(pageErrors).toEqual([]);
 });


### PR DESCRIPTION
Closes FJR4TPS. A regression from 5NPENPY, found by spinning the board.

Clicking between tickets took seconds to update the selection, and two cards could be seen highlighted at once while it caught up.

### What was wrong

5NPENPY listed the open ticket among the things that send the scrubber back to the server:

```ts
}, [scope, offset, zoom?.start, zoom?.end,
    ticketFocus, selectedIssue?.id, selectedIssue?.createdAt, ...])
```

Those belong there only while **Ticket only** is on, when the ticket really is the window. With it off — most of the time — every click on a different ticket asked for the whole timeline again over a window that had not moved.

### The fix

One key stands for the window's ticket, and is `null` whenever the window is not cut from one:

```ts
const ticketWindowKey = ticketFocus
    ? `${selectedIssue.id}:${selectedIssue.createdAt}`
    : null;
```

Off, clicking between tickets asks for nothing. On, switching tickets still refetches, because then the window has genuinely changed — and toggling the box either way still flips the key, so entering and leaving the narrowing refetch as they must.

### Verified

The test counts timeline replies over the websocket and pins both halves. Watched fail first on the old dependency list, and it measured the bug exactly: **expected 6, received 9** — three clicks, three extra fetches, one per click. Green on the fix.

Locally and on the gate: lint, typechecks, 1062 unit, 112 GUI e2e, 17 TUI, 15 collab.

### Worth recording

This shared its symptom with something unrelated: three orphaned `hostile-boot-runner.ts` processes from the `sync-hardening-audit` worktree had been burning ~300% CPU for a day and a half. Killing those was necessary but not sufficient, and finding them first is what delayed finding this — the machine really was strained, and the code really was refetching.
