### PR TITLE
8XVSGBM Theatre mode: play the board's history as a movie

### DIFF
--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -1739,162 +1739,184 @@ export const App = () => {
 						transition: 'opacity 160ms ease',
 					}}
 				>
-					{theatre && theatreLogOpen && (
-						<TheatreLog entries={theatreLogEntries(theatre, playback.cursor)} />
-					)}
-
-					{/* Vertical overflow is hidden here: the swimlanes size themselves to
-				    this box, so anything spilling out would put a second scrollbar on
-				    the page next to the columns' own. */}
-					<main
-						onClick={clearPicked}
+					{/* The log and the board are their own row inside this one, which
+					    turns into a column for a bottom-docked panel. Without it the
+					    log would stack above the board rather than beside it, as a
+					    band the crawl has no height to run in. With no log open this
+					    is one flex child holding another, which lays out exactly as
+					    the board did on its own. */}
+					<div
 						style={{
-							padding: '0 0 0 30px',
-							flex: 1,
-							minHeight: 0,
 							display: 'flex',
-							flexDirection: 'column',
+							flex: 1,
+							minWidth: 0,
+							minHeight: 0,
 							overflow: 'hidden',
 						}}
 					>
-						<div
-							style={{
-								padding: '20px 10px',
-								display: 'flex',
-								alignItems: 'center',
-								gap: 10,
-								...(theatre ? DIMMED_WHILE_PLAYING : {}),
-							}}
-						>
-							<Dropdown
-								testId="board-switcher"
-								label="Board:"
-								value={
-									selectedBoard
-										? {
-												id: selectedBoard.id,
-												label: selectedBoard.title,
-										  }
-										: null
-								}
-								items={
-									state?.boards.map(board => ({
-										id: board.id,
-										label: board.title,
-									})) ?? []
-								}
-								placeholder="Loading..."
-								onSelect={selectBoard}
+						{theatre && theatreLogOpen && (
+							<TheatreLog
+								entries={theatreLogEntries(theatre, playback.cursor)}
 							/>
+						)}
 
-							<Input
-								data-testid="text-filter"
-								type="search"
-								value={textFilter}
-								placeholder="filter by ref or title"
-								aria-label="Filter tickets by ref or title"
-								spellCheck={false}
-								onChange={event => setTextFilter(event.target.value)}
-								onKeyDown={event => {
-									if (event.key === 'Escape') {
-										setTextFilter('');
-										event.currentTarget.blur();
-									}
-								}}
-								style={{width: 220, padding: '5px 10px', fontSize: 12}}
-							/>
-						</div>
-
-						{/* Scrolling sideways is this row's job; scrolling down is each
-					    column's. Both on one element gives a page-level vertical bar
-					    alongside each column's own. */}
-						<div
+						{/* Vertical overflow is hidden here: the swimlanes size themselves to
+				    this box, so anything spilling out would put a second scrollbar on
+				    the page next to the columns' own. */}
+						<main
+							onClick={clearPicked}
 							style={{
-								display: 'flex',
-								gap: 8,
+								padding: '0 0 0 30px',
 								flex: 1,
+								// Beside the log it has to be able to give up the width the
+								// panel takes; a flex item's default floor is its content.
+								minWidth: 0,
 								minHeight: 0,
-								overflowX: 'auto',
-								overflowY: 'hidden',
-								// Lit, but not touchable: the board is what a movie is
-								// watched on, and the panel a click would open is closed for
-								// the duration anyway.
-								pointerEvents: theatre ? 'none' : undefined,
-								// The player floats over the board, and a column running
-								// under it would play its last cards behind the transport.
-								// Reserved rather than overlaid, so the whole picture stays
-								// in view.
-								paddingBottom: theatre ? THEATRE_PLAYER_CLEARANCE : 0,
-								transition: 'padding-bottom 240ms ease',
+								display: 'flex',
+								flexDirection: 'column',
+								overflow: 'hidden',
 							}}
 						>
-							{shownSwimlanes.map(swimlane => (
-								<SwimlaneColumn
-									key={swimlane.id}
-									swimlane={swimlane}
-									selected={false}
-									selectedIssueId={selectedIssue?.id ?? null}
-									commentsByIssueId={commentsByIssueId}
-									dragOver={dragOverSwimlaneId === swimlane.id}
-									dropIndex={
-										dropTarget?.swimlaneId === swimlane.id
-											? dropTarget.index
-											: null
-									}
-									onSelectIssue={selectIssue}
-									onSelectIssueComments={selectIssueComments}
-									isolatedTagId={isolatedTagId}
-									onFilterByTag={filterByTag}
-									onCreateIssue={openCreateIssueModal}
-									onRenameSwimlane={openRenameSwimlane}
-									onDeleteSwimlane={setDeleteSwimlaneId}
-									dropSide={
-										swimlaneDropEdge?.swimlaneId === swimlane.id
-											? swimlaneDropEdge.side
-											: null
-									}
-									onSwimlaneDragOver={(swimlaneId, side) =>
-										setSwimlaneDropEdge({swimlaneId, side})
-									}
-									onSwimlaneDragEnd={() => setSwimlaneDropEdge(null)}
-									onDropSwimlane={dropSwimlane}
-									onDropIssue={(issueId, swimlaneId, targetIndex) => {
-										const moving = pickedIssueIds.includes(issueId)
-											? pickedIssueIds
-											: [issueId];
-
-										moveIssue(state, setState, send)(
-											moving,
-											swimlaneId,
-											targetIndex,
-										);
-										clearPicked();
-									}}
-									theatre={
-										theatre
+							<div
+								style={{
+									padding: '20px 10px',
+									display: 'flex',
+									alignItems: 'center',
+									gap: 10,
+									...(theatre ? DIMMED_WHILE_PLAYING : {}),
+								}}
+							>
+								<Dropdown
+									testId="board-switcher"
+									label="Board:"
+									value={
+										selectedBoard
 											? {
-													flashIssueId: playback.current?.issue ?? null,
-													flashKey: playback.current?.id ?? null,
+													id: selectedBoard.id,
+													label: selectedBoard.title,
 											  }
 											: null
 									}
-									pickedIssueIds={pickedIssueIds}
-									onDragOver={setDragOverSwimlaneId}
-									onDragOverIssue={(swimlaneId, index) =>
-										setDropTarget({swimlaneId, index})
+									items={
+										state?.boards.map(board => ({
+											id: board.id,
+											label: board.title,
+										})) ?? []
 									}
-									onDragLeave={clearDragState}
+									placeholder="Loading..."
+									onSelect={selectBoard}
 								/>
-							))}
 
-							{/* Appends: `createSwimlane` ranks at the end, so the ghost sits
+								<Input
+									data-testid="text-filter"
+									type="search"
+									value={textFilter}
+									placeholder="filter by ref or title"
+									aria-label="Filter tickets by ref or title"
+									spellCheck={false}
+									onChange={event => setTextFilter(event.target.value)}
+									onKeyDown={event => {
+										if (event.key === 'Escape') {
+											setTextFilter('');
+											event.currentTarget.blur();
+										}
+									}}
+									style={{width: 220, padding: '5px 10px', fontSize: 12}}
+								/>
+							</div>
+
+							{/* Scrolling sideways is this row's job; scrolling down is each
+					    column's. Both on one element gives a page-level vertical bar
+					    alongside each column's own. */}
+							<div
+								style={{
+									display: 'flex',
+									gap: 8,
+									flex: 1,
+									minHeight: 0,
+									overflowX: 'auto',
+									overflowY: 'hidden',
+									// Lit, but not touchable: the board is what a movie is
+									// watched on, and the panel a click would open is closed for
+									// the duration anyway.
+									pointerEvents: theatre ? 'none' : undefined,
+									// The player floats over the board, and a column running
+									// under it would play its last cards behind the transport.
+									// Reserved rather than overlaid, so the whole picture stays
+									// in view.
+									paddingBottom: theatre ? THEATRE_PLAYER_CLEARANCE : 0,
+									transition: 'padding-bottom 240ms ease',
+								}}
+							>
+								{shownSwimlanes.map(swimlane => (
+									<SwimlaneColumn
+										key={swimlane.id}
+										swimlane={swimlane}
+										selected={false}
+										selectedIssueId={selectedIssue?.id ?? null}
+										commentsByIssueId={commentsByIssueId}
+										dragOver={dragOverSwimlaneId === swimlane.id}
+										dropIndex={
+											dropTarget?.swimlaneId === swimlane.id
+												? dropTarget.index
+												: null
+										}
+										onSelectIssue={selectIssue}
+										onSelectIssueComments={selectIssueComments}
+										isolatedTagId={isolatedTagId}
+										onFilterByTag={filterByTag}
+										onCreateIssue={openCreateIssueModal}
+										onRenameSwimlane={openRenameSwimlane}
+										onDeleteSwimlane={setDeleteSwimlaneId}
+										dropSide={
+											swimlaneDropEdge?.swimlaneId === swimlane.id
+												? swimlaneDropEdge.side
+												: null
+										}
+										onSwimlaneDragOver={(swimlaneId, side) =>
+											setSwimlaneDropEdge({swimlaneId, side})
+										}
+										onSwimlaneDragEnd={() => setSwimlaneDropEdge(null)}
+										onDropSwimlane={dropSwimlane}
+										onDropIssue={(issueId, swimlaneId, targetIndex) => {
+											const moving = pickedIssueIds.includes(issueId)
+												? pickedIssueIds
+												: [issueId];
+
+											moveIssue(state, setState, send)(
+												moving,
+												swimlaneId,
+												targetIndex,
+											);
+											clearPicked();
+										}}
+										theatre={
+											theatre
+												? {
+														flashIssueId: playback.current?.issue ?? null,
+														flashKey: playback.current?.id ?? null,
+												  }
+												: null
+										}
+										pickedIssueIds={pickedIssueIds}
+										onDragOver={setDragOverSwimlaneId}
+										onDragOverIssue={(swimlaneId, index) =>
+											setDropTarget({swimlaneId, index})
+										}
+										onDragLeave={clearDragState}
+									/>
+								))}
+
+								{/* Appends: `createSwimlane` ranks at the end, so the ghost sits
 							where the new column will actually appear. Hidden on a readonly
 							board, which also covers a scrubbed timeline. */}
-							{selectedBoard && !selectedBoard.readonly && !offline && (
-								<AddSwimlaneColumn onClick={() => setCreateSwimlaneTitle('')} />
-							)}
+								{selectedBoard && !selectedBoard.readonly && !offline && (
+									<AddSwimlaneColumn
+										onClick={() => setCreateSwimlaneTitle('')}
+									/>
+								)}
 
-							{/* Grows scrollWidth by exactly what closing the panel gave back
+								{/* Grows scrollWidth by exactly what closing the panel gave back
 							in clientWidth, keeping max scrollLeft identical across
 							open/closed so the board doesn't bounce back when scrolled far
 							right. Reads the panel's persisted width directly rather than
@@ -1902,17 +1924,20 @@ export const App = () => {
 							this spacer is, so the last-persisted value is always current.
 							Only for a side dock: a bottom panel takes height, not width, so
 							reserving width for it would shove the board the other way. */}
-							{asideDock === 'right' &&
-								!commitDiff &&
-								!(selectedIssue && state?.user) && (
-									<div style={{width: readStoredAsideWidth(), flexShrink: 0}} />
-								)}
+								{asideDock === 'right' &&
+									!commitDiff &&
+									!(selectedIssue && state?.user) && (
+										<div
+											style={{width: readStoredAsideWidth(), flexShrink: 0}}
+										/>
+									)}
 
-							{/* The page's right margin, scrolling with the columns. Constant,
+								{/* The page's right margin, scrolling with the columns. Constant,
 							so it cancels out of the invariant above. */}
-							<div style={{width: BOARD_GUTTER, flexShrink: 0}} />
-						</div>
-					</main>
+								<div style={{width: BOARD_GUTTER, flexShrink: 0}} />
+							</div>
+						</main>
+					</div>
 
 					{/* The side panels close for the film rather than dimming: at
 					    440px they are a third of the picture, and none of what they

--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -39,6 +39,7 @@ import {TicketRefLinksProvider} from './components/MarkdownContent';
 import {ErrorToast} from './components/ErrorToast';
 import {TimeScrubber} from './components/TimeScrubber';
 import {TheatrePlayer} from './components/TheatrePlayer';
+import {TheatreLog} from './components/TheatreLog';
 import {useAsideDock} from './lib/aside-dock';
 import {moveIssue} from './lib/gui-move-issue';
 import {reconnectDelayMs} from './lib/reconnect';
@@ -74,7 +75,13 @@ import {
 	issuePassesBoardFilter,
 	windowIssueIds,
 } from './lib/scrubber';
-import {buildTheatrePlan, TheatrePlan, useTheatrePlayback} from './lib/theatre';
+import {
+	buildTheatrePlan,
+	THEATRE_PLAYER_CLEARANCE,
+	TheatrePlan,
+	theatreLogEntries,
+	useTheatrePlayback,
+} from './lib/theatre';
 import {Input} from './components/FormPrimitives';
 import {useBoardSelection} from './lib/use-board-selection';
 import {sendSocketJson} from './lib/socket-send';
@@ -96,11 +103,6 @@ const BOARD_GUTTER = 30;
 
 // What the chrome around the board wears while a movie plays. Faded rather than
 // unmounted: the page must not reflow around the picture being watched.
-// The room the floating player takes at the foot of the page, which the board
-// gives up while one is open. Must cover the player's own height and the gap
-// it sits above.
-const THEATRE_PLAYER_CLEARANCE = 118;
-
 const DIMMED_WHILE_PLAYING: React.CSSProperties = {
 	opacity: 0.3,
 	pointerEvents: 'none',
@@ -172,6 +174,9 @@ export const App = () => {
 	// Bumped per answered time-travel request. The player's clock waits on it
 	// rather than stacking a checkout on one the server has not answered yet.
 	const [scrubAck, setScrubAck] = useState(0);
+	// The log panel is open. Owned here rather than in the player: it is a panel
+	// in the board's own row, and the board moves over for it.
+	const [theatreLogOpen, setTheatreLogOpen] = useState(false);
 	const [commitDiff, setCommitDiff] = useState<{
 		sha: string;
 		loading: boolean;
@@ -1734,6 +1739,10 @@ export const App = () => {
 						transition: 'opacity 160ms ease',
 					}}
 				>
+					{theatre && theatreLogOpen && (
+						<TheatreLog entries={theatreLogEntries(theatre, playback.cursor)} />
+					)}
+
 					{/* Vertical overflow is hidden here: the swimlanes size themselves to
 				    this box, so anything spilling out would put a second scrollbar on
 				    the page next to the columns' own. */}
@@ -2056,6 +2065,8 @@ export const App = () => {
 					<TheatrePlayer
 						plan={theatre}
 						playback={playback}
+						logOpen={theatreLogOpen}
+						onToggleLog={() => setTheatreLogOpen(open => !open)}
 						onExit={exitTheatre}
 					/>
 				)}

--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -38,6 +38,7 @@ import {GlobalScrollbarStyles} from './components/GlobalScrollbarStyles';
 import {TicketRefLinksProvider} from './components/MarkdownContent';
 import {ErrorToast} from './components/ErrorToast';
 import {TimeScrubber} from './components/TimeScrubber';
+import {TheatrePlayer} from './components/TheatrePlayer';
 import {useAsideDock} from './lib/aside-dock';
 import {moveIssue} from './lib/gui-move-issue';
 import {reconnectDelayMs} from './lib/reconnect';
@@ -73,6 +74,7 @@ import {
 	issuePassesBoardFilter,
 	windowIssueIds,
 } from './lib/scrubber';
+import {buildTheatrePlan, TheatrePlan, useTheatrePlayback} from './lib/theatre';
 import {Input} from './components/FormPrimitives';
 import {useBoardSelection} from './lib/use-board-selection';
 import {sendSocketJson} from './lib/socket-send';
@@ -91,6 +93,19 @@ const EMPTY_COMMENTS: GuiState['commentsByIssueId'] = {};
 
 // The board's page margin, matching the left padding on <main>.
 const BOARD_GUTTER = 30;
+
+// What the chrome around the board wears while a movie plays. Faded rather than
+// unmounted: the page must not reflow around the picture being watched.
+// The room the floating player takes at the foot of the page, which the board
+// gives up while one is open. Must cover the player's own height and the gap
+// it sits above.
+const THEATRE_PLAYER_CLEARANCE = 118;
+
+const DIMMED_WHILE_PLAYING: React.CSSProperties = {
+	opacity: 0.3,
+	pointerEvents: 'none',
+	transition: 'opacity 240ms ease',
+};
 
 export const DropIndicator = () => (
 	<div
@@ -150,6 +165,13 @@ export const App = () => {
 		commits: GuiCommitEntry[];
 	}>({requestId: 0, timeline: null, commits: []});
 	const [historyBuffer] = useState(() => createHistoryBuffer(setHistory));
+	// The movie on screen, or null for no player. Held rather than derived from
+	// the timeline: the window is re-fetched while the board changes underneath
+	// it, and a plan that changed halfway would be a different film.
+	const [theatre, setTheatre] = useState<TheatrePlan | null>(null);
+	// Bumped per answered time-travel request. The player's clock waits on it
+	// rather than stacking a checkout on one the server has not answered yet.
+	const [scrubAck, setScrubAck] = useState(0);
 	const [commitDiff, setCommitDiff] = useState<{
 		sha: string;
 		loading: boolean;
@@ -443,11 +465,16 @@ export const App = () => {
 			return;
 		}
 
+		// Not while a movie is playing: this re-runs on every state broadcast, and
+		// a movie is a broadcast per frame — for a panel that is not even on
+		// screen. The board's own state is what the player is showing.
+		if (theatre) return;
+
 		sendSocketJson(socketRef.current, {
 			type: 'issue:get',
 			payload: {issueId: selectedIssue.id},
 		});
-	}, [selectedIssue?.id, state]);
+	}, [selectedIssue?.id, state, theatre]);
 
 	// Separate from issue:get above, which re-runs on every state broadcast:
 	// the commit list comes from git, not the event log, so a board change is
@@ -753,12 +780,15 @@ export const App = () => {
 				}
 			}
 
-			if (
-				message.type === 'time-travel:result' &&
-				message.payload?.status === 'fail'
-			) {
-				console.log('Time travel failed', message);
-				requestState();
+			if (message.type === 'time-travel:result') {
+				// Every reply, refusals included: the player's clock is waiting on
+				// one, and a refused checkout it never heard about would stall it.
+				setScrubAck(count => count + 1);
+
+				if (message.payload?.status === 'fail') {
+					console.log('Time travel failed', message);
+					requestState();
+				}
 			}
 
 			if (message.type === 'sync-status') {
@@ -1110,6 +1140,35 @@ export const App = () => {
 	const returnToLive = () => {
 		send('time-travel:live', {});
 	};
+
+	// Plays the window the scrubber is showing. Its own timeline is the script:
+	// the same events it has drawn, in the order the clock put them in.
+	const startTheatre = () => {
+		if (!history.timeline) return;
+
+		setTheatre(buildTheatrePlan(history.timeline));
+	};
+
+	// Leaving the cinema hands the board back, live and editable, wherever the
+	// movie happened to stop.
+	const exitTheatre = () => {
+		setTheatre(null);
+		returnToLive();
+	};
+
+	const playback = useTheatrePlayback({
+		plan: theatre,
+		ack: scrubAck,
+		onSeek: scrubToTime,
+	});
+
+	// A movie is checked out one frame at a time over the socket, so a dropped
+	// one leaves the player running against nothing. It closes rather than
+	// stalling; the board is already parked wherever the last frame landed, and
+	// the reconnect brings the way back with it.
+	useEffect(() => {
+		if (!connected) setTheatre(null);
+	}, [connected]);
 
 	// Both requests carry the same id so their replies can be paired, and replies
 	// to an abandoned request discarded.
@@ -1612,21 +1671,26 @@ export const App = () => {
 					/>
 				)}
 
-				<Header
-					state={state}
-					connection={
-						connected
-							? 'connected'
-							: !offline
-							? 'connecting'
-							: reconnectExhausted
-							? 'lost'
-							: 'reconnecting'
-					}
-					onReconnect={reconnectNow}
-					scrubbing={state?.timeTravel?.mode === 'scrub'}
-					syncStatus={syncStatus}
-				/>
+				{/* Dimmed and inert with the rest of the chrome while a movie plays:
+				    the board is the picture, and everything around it is the room
+				    lights. */}
+				<div style={theatre ? DIMMED_WHILE_PLAYING : undefined}>
+					<Header
+						state={state}
+						connection={
+							connected
+								? 'connected'
+								: !offline
+								? 'connecting'
+								: reconnectExhausted
+								? 'lost'
+								: 'reconnecting'
+						}
+						onReconnect={reconnectNow}
+						scrubbing={state?.timeTravel?.mode === 'scrub'}
+						syncStatus={syncStatus}
+					/>
+				</div>
 
 				<TimeScrubber
 					timeline={history.timeline}
@@ -1641,6 +1705,8 @@ export const App = () => {
 					timeTravel={state?.timeTravel ?? {mode: 'live', asOfTime: null}}
 					onScrub={scrubToTime}
 					onReturnToLive={returnToLive}
+					onPlayTheatre={startTheatre}
+					theatreOpen={theatre !== null}
 					selection={selection}
 					onChangeSelection={changeSelection}
 					selectedIssue={
@@ -1649,7 +1715,9 @@ export const App = () => {
 							: null
 					}
 					knownIdentities={knownIdentities}
-					refreshOn={selection.windowOnly ? state : null}
+					// Not while a movie plays: the window would be re-fetched on every
+					// frame, and the plan is drawn from it.
+					refreshOn={selection.windowOnly && !theatre ? state : null}
 				/>
 
 				{/* Dimmed while offline so the board reads as inert. The topbar stays at
@@ -1686,6 +1754,7 @@ export const App = () => {
 								display: 'flex',
 								alignItems: 'center',
 								gap: 10,
+								...(theatre ? DIMMED_WHILE_PLAYING : {}),
 							}}
 						>
 							<Dropdown
@@ -1738,6 +1807,16 @@ export const App = () => {
 								minHeight: 0,
 								overflowX: 'auto',
 								overflowY: 'hidden',
+								// Lit, but not touchable: the board is what a movie is
+								// watched on, and the panel a click would open is closed for
+								// the duration anyway.
+								pointerEvents: theatre ? 'none' : undefined,
+								// The player floats over the board, and a column running
+								// under it would play its last cards behind the transport.
+								// Reserved rather than overlaid, so the whole picture stays
+								// in view.
+								paddingBottom: theatre ? THEATRE_PLAYER_CLEARANCE : 0,
+								transition: 'padding-bottom 240ms ease',
 							}}
 						>
 							{shownSwimlanes.map(swimlane => (
@@ -1782,6 +1861,14 @@ export const App = () => {
 										);
 										clearPicked();
 									}}
+									theatre={
+										theatre
+											? {
+													flashIssueId: playback.current?.issue ?? null,
+													flashKey: playback.current?.id ?? null,
+											  }
+											: null
+									}
 									pickedIssueIds={pickedIssueIds}
 									onDragOver={setDragOverSwimlaneId}
 									onDragOverIssue={(swimlaneId, index) =>
@@ -1818,7 +1905,11 @@ export const App = () => {
 						</div>
 					</main>
 
-					{commitDiff && (
+					{/* The side panels close for the film rather than dimming: at
+					    440px they are a third of the picture, and none of what they
+					    show is part of it. Closing is only visual — the ticket stays
+					    selected, and the panel is back when the player leaves. */}
+					{!theatre && commitDiff && (
 						<Aside dock={asideDock} onWidthChange={setCommitDiffPanelWidth}>
 							{({isFullscreen, toggleFullscreen}) => (
 								<DiffPanel
@@ -1841,7 +1932,7 @@ export const App = () => {
 						</Aside>
 					)}
 
-					{!commitDiff && pickedIssues.length > 1 && (
+					{!theatre && !commitDiff && pickedIssues.length > 1 && (
 						<BulkDetails
 							dock={asideDock}
 							issues={pickedIssues}
@@ -1880,7 +1971,8 @@ export const App = () => {
 						/>
 					)}
 
-					{!commitDiff &&
+					{!theatre &&
+						!commitDiff &&
 						pickedIssues.length <= 1 &&
 						selectedIssue &&
 						state?.user && (
@@ -1959,6 +2051,14 @@ export const App = () => {
 							/>
 						)}
 				</div>
+
+				{theatre && (
+					<TheatrePlayer
+						plan={theatre}
+						playback={playback}
+						onExit={exitTheatre}
+					/>
+				)}
 
 				{createIssueModal && (
 					<CreateNodeModal

--- a/source/gui/client/components/IconPlayback.tsx
+++ b/source/gui/client/components/IconPlayback.tsx
@@ -1,21 +1,39 @@
-// The player's transport glyphs. Filled rather than stroked, unlike the rest of
-// the icon set: at the size a transport button wants they read as shapes, and a
-// stroked triangle at 14px is a wireframe.
+// The transport glyphs. Stroked at the same weight as the rest of the icon set,
+// so the player reads as part of a terminal's chrome rather than as a media
+// widget dropped onto it.
 
-export const IconPlay = ({size = 16}: {size?: number}) => (
-	<svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true">
-		<path d="M8 5.5v13l11-6.5z" fill="currentColor" />
+export const IconPlay = ({size = 14}: {size?: number}) => (
+	<svg
+		width={size}
+		height={size}
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		strokeWidth="2"
+		strokeLinejoin="round"
+		aria-hidden="true"
+	>
+		<path d="M8 5.5 19 12 8 18.5Z" />
 	</svg>
 );
 
-export const IconPause = ({size = 16}: {size?: number}) => (
-	<svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true">
-		<rect x="7" y="5" width="3.5" height="14" rx="1" fill="currentColor" />
-		<rect x="13.5" y="5" width="3.5" height="14" rx="1" fill="currentColor" />
+export const IconPause = ({size = 14}: {size?: number}) => (
+	<svg
+		width={size}
+		height={size}
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		strokeWidth="2"
+		strokeLinecap="round"
+		aria-hidden="true"
+	>
+		<line x1="9" y1="5.5" x2="9" y2="18.5" />
+		<line x1="15" y1="5.5" x2="15" y2="18.5" />
 	</svg>
 );
 
-export const IconReplay = ({size = 16}: {size?: number}) => (
+export const IconReplay = ({size = 14}: {size?: number}) => (
 	<svg
 		width={size}
 		height={size}
@@ -32,7 +50,7 @@ export const IconReplay = ({size = 16}: {size?: number}) => (
 	</svg>
 );
 
-export const IconClose = ({size = 16}: {size?: number}) => (
+export const IconClose = ({size = 14}: {size?: number}) => (
 	<svg
 		width={size}
 		height={size}
@@ -45,5 +63,23 @@ export const IconClose = ({size = 16}: {size?: number}) => (
 	>
 		<line x1="6" y1="6" x2="18" y2="18" />
 		<line x1="18" y1="6" x2="6" y2="18" />
+	</svg>
+);
+
+export const IconPopOut = ({size = 12}: {size?: number}) => (
+	<svg
+		width={size}
+		height={size}
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		strokeWidth="2"
+		strokeLinecap="round"
+		strokeLinejoin="round"
+		aria-hidden="true"
+	>
+		<polyline points="14 4 20 4 20 10" />
+		<line x1="20" y1="4" x2="12" y2="12" />
+		<path d="M18 15v4a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V7a1 1 0 0 1 1-1h4" />
 	</svg>
 );

--- a/source/gui/client/components/IconPlayback.tsx
+++ b/source/gui/client/components/IconPlayback.tsx
@@ -1,0 +1,49 @@
+// The player's transport glyphs. Filled rather than stroked, unlike the rest of
+// the icon set: at the size a transport button wants they read as shapes, and a
+// stroked triangle at 14px is a wireframe.
+
+export const IconPlay = ({size = 16}: {size?: number}) => (
+	<svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true">
+		<path d="M8 5.5v13l11-6.5z" fill="currentColor" />
+	</svg>
+);
+
+export const IconPause = ({size = 16}: {size?: number}) => (
+	<svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true">
+		<rect x="7" y="5" width="3.5" height="14" rx="1" fill="currentColor" />
+		<rect x="13.5" y="5" width="3.5" height="14" rx="1" fill="currentColor" />
+	</svg>
+);
+
+export const IconReplay = ({size = 16}: {size?: number}) => (
+	<svg
+		width={size}
+		height={size}
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		strokeWidth="2"
+		strokeLinecap="round"
+		strokeLinejoin="round"
+		aria-hidden="true"
+	>
+		<path d="M20 12a8 8 0 1 1-2.6-5.9" />
+		<polyline points="20 3 20 8 15 8" />
+	</svg>
+);
+
+export const IconClose = ({size = 16}: {size?: number}) => (
+	<svg
+		width={size}
+		height={size}
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		strokeWidth="2"
+		strokeLinecap="round"
+		aria-hidden="true"
+	>
+		<line x1="6" y1="6" x2="18" y2="18" />
+		<line x1="18" y1="6" x2="6" y2="18" />
+	</svg>
+);

--- a/source/gui/client/components/ScrubberLayout.tsx
+++ b/source/gui/client/components/ScrubberLayout.tsx
@@ -129,11 +129,20 @@ export type ScrubberChart = {
 export const ScrubberLayout = ({
 	collapsed,
 	onToggleCollapsed,
+	canPlay,
+	onPlay,
+	standDown,
 	controls,
 	chart,
 }: {
 	collapsed: boolean;
 	onToggleCollapsed: () => void;
+	canPlay: boolean;
+	onPlay: () => void;
+	// The history player is up and owns the board's position. The whole bar goes
+	// quiet rather than offering a second control for the same thing — the
+	// needle keeps following, so it still says where the movie is.
+	standDown: boolean;
 	controls: React.ComponentProps<typeof ScrubberControls>;
 	chart: ScrubberChart;
 }) => {
@@ -153,6 +162,9 @@ export const ScrubberLayout = ({
 				// which would lop off the overhanging hint. Safe to disable only
 				// because this panel is square.
 				overflow: 'visible',
+				opacity: standDown ? 0.3 : 1,
+				pointerEvents: standDown ? 'none' : undefined,
+				transition: 'opacity 240ms ease',
 			}}
 		>
 			<style>{SCRUBBER_KEYFRAMES}</style>
@@ -177,6 +189,8 @@ export const ScrubberLayout = ({
 					<ScrubberHeader
 						collapsed={collapsed}
 						onToggleCollapsed={onToggleCollapsed}
+						canPlay={canPlay}
+						onPlay={onPlay}
 					/>
 
 					{collapsed ? (

--- a/source/gui/client/components/ScrubberLayout.tsx
+++ b/source/gui/client/components/ScrubberLayout.tsx
@@ -139,9 +139,10 @@ export const ScrubberLayout = ({
 	onToggleCollapsed: () => void;
 	canPlay: boolean;
 	onPlay: () => void;
-	// The history player is up and owns the board's position. The whole bar goes
-	// quiet rather than offering a second control for the same thing — the
-	// needle keeps following, so it still says where the movie is.
+	// The history player is up and owns the board's position. Nothing on the bar
+	// answers a pointer while it is, but only the controls dim for it: the charts
+	// are part of what is being watched — the needle sweeps them as the movie
+	// runs — so they stay lit.
 	standDown: boolean;
 	controls: React.ComponentProps<typeof ScrubberControls>;
 	chart: ScrubberChart;
@@ -162,9 +163,7 @@ export const ScrubberLayout = ({
 				// which would lop off the overhanging hint. Safe to disable only
 				// because this panel is square.
 				overflow: 'visible',
-				opacity: standDown ? 0.3 : 1,
 				pointerEvents: standDown ? 'none' : undefined,
-				transition: 'opacity 240ms ease',
 			}}
 		>
 			<style>{SCRUBBER_KEYFRAMES}</style>
@@ -184,6 +183,8 @@ export const ScrubberLayout = ({
 						// Holds the row's height when collapsing takes the controls out
 						// of it.
 						minHeight: 22,
+						opacity: standDown ? 0.3 : 1,
+						transition: 'opacity 240ms ease',
 					}}
 				>
 					<ScrubberHeader

--- a/source/gui/client/components/ScrubberParts.tsx
+++ b/source/gui/client/components/ScrubberParts.tsx
@@ -935,19 +935,25 @@ export const ScrubberHeader = ({
 					: 'Not enough history in this window to play'
 			}
 			aria-label="Play the board's history"
+			// Square and outlined rather than a filled key next to the chevron's
+			// panel: it is the same affordance the player's own transport is, and
+			// the two have to read as one thing in two places.
 			style={{
-				background: GUI_THEME.panel2,
-				border: `1px solid ${canPlay ? GUI_THEME.line : GUI_THEME.transparent}`,
-				borderRadius: 6,
+				background: 'transparent',
+				border: `1px solid ${canPlay ? GUI_THEME.accent : GUI_THEME.line}`,
+				borderRadius: 3,
 				color: canPlay ? GUI_THEME.accent : GUI_THEME.dim,
-				padding: '3px 7px',
+				width: 24,
+				height: 24,
+				padding: 0,
 				cursor: canPlay ? 'pointer' : 'default',
 				opacity: canPlay ? 1 : 0.4,
 				display: 'inline-flex',
 				alignItems: 'center',
+				justifyContent: 'center',
 			}}
 		>
-			<IconPlay size={14} />
+			<IconPlay size={13} />
 		</button>
 	</div>
 );

--- a/source/gui/client/components/ScrubberParts.tsx
+++ b/source/gui/client/components/ScrubberParts.tsx
@@ -44,6 +44,7 @@ import {Checkbox} from './Checkbox';
 import {IconBars} from './IconBars';
 import {IconChevronDown} from './IconChevronDown';
 import {IconChevronRight} from './IconChevronRight';
+import {IconPlay} from './IconPlayback';
 import {IconScatter} from './IconScatter';
 
 // Named once: the collapsed header puts the same box up when the rest of this
@@ -880,9 +881,14 @@ export const ScrubberControls = ({
 export const ScrubberHeader = ({
 	collapsed,
 	onToggleCollapsed,
+	canPlay,
+	onPlay,
 }: {
 	collapsed: boolean;
 	onToggleCollapsed: () => void;
+	// False where the window holds too little to play, or the socket is down.
+	canPlay: boolean;
+	onPlay: () => void;
 }) => (
 	<div
 		style={{
@@ -914,6 +920,34 @@ export const ScrubberHeader = ({
 			) : (
 				<IconChevronDown size={14} />
 			)}
+		</button>
+
+		{/* On the header rather than in the controls row, so it is still there
+		    with the scrubber shut — the movie is watched on the board, and the
+		    charts are not part of it. */}
+		<button
+			data-testid="theatre-play"
+			onClick={onPlay}
+			disabled={!canPlay}
+			title={
+				canPlay
+					? "Play this window of the board's history"
+					: 'Not enough history in this window to play'
+			}
+			aria-label="Play the board's history"
+			style={{
+				background: GUI_THEME.panel2,
+				border: `1px solid ${canPlay ? GUI_THEME.line : GUI_THEME.transparent}`,
+				borderRadius: 6,
+				color: canPlay ? GUI_THEME.accent : GUI_THEME.dim,
+				padding: '3px 7px',
+				cursor: canPlay ? 'pointer' : 'default',
+				opacity: canPlay ? 1 : 0.4,
+				display: 'inline-flex',
+				alignItems: 'center',
+			}}
+		>
+			<IconPlay size={14} />
 		</button>
 	</div>
 );

--- a/source/gui/client/components/SwimlaneColumn.tsx
+++ b/source/gui/client/components/SwimlaneColumn.tsx
@@ -41,6 +41,7 @@ export const SwimlaneColumn = ({
 	onDragOver,
 	onDragOverIssue,
 	onDragLeave,
+	theatre,
 }: {
 	swimlane: GuiSwimlane;
 	selected: boolean;
@@ -56,6 +57,10 @@ export const SwimlaneColumn = ({
 	onCreateIssue: (swimlaneId: string) => void;
 	onRenameSwimlane: (swimlaneId: string) => void;
 	onDeleteSwimlane: (swimlaneId: string) => void;
+	// Null unless the history player is up. `flashIssueId` is the ticket the
+	// event that just landed happened to, and `flashKey` that event's id, which
+	// is what restarts the flash when two of them in a row touch one ticket.
+	theatre: {flashIssueId: string | null; flashKey: string | null} | null;
 	// Which edge of this column the dragged swimlane would land on, if any.
 	dropSide: 'left' | 'right' | null;
 	onSwimlaneDragOver: (swimlaneId: string, side: 'left' | 'right') => void;
@@ -285,6 +290,12 @@ export const SwimlaneColumn = ({
 										onDropIssue(issueId, swimlane.id, targetIndex);
 										onDragLeave();
 									}}
+									theatre={theatre !== null}
+									flashKey={
+										theatre && theatre.flashIssueId === ticket.id
+											? theatre.flashKey
+											: null
+									}
 								/>
 							</React.Fragment>
 						))}

--- a/source/gui/client/components/TheatreLog.tsx
+++ b/source/gui/client/components/TheatreLog.tsx
@@ -1,0 +1,170 @@
+// The movie's log: a panel down the left of the board holding one timestamped
+// line per event as it lands, the column sliding up by a row each time and the
+// oldest lines dissolving off the top.
+//
+// A panel rather than a wash over the board — it takes its own width and the
+// board moves over for it, so neither has to be read through the other.
+//
+// The rows are a slice of the script rather than a list grown as events arrive,
+// so what is off the top is not merely invisible — it is not in the document at
+// all, and the panel costs the same at the end of a long movie as at the start.
+
+import {useEffect, useRef} from 'react';
+import {
+	formatDate,
+	formatTimeOfDay,
+	isSameDay,
+} from '../../../lib/utils/date.utils.js';
+import {GUI_THEME, TEXT} from '../lib/gui-theme';
+import {usePrefersReducedMotion} from '../lib/scrubber';
+import {
+	THEATRE_CRAWL_FRAMES,
+	THEATRE_CRAWL_TIMING,
+	THEATRE_LOG_ROW_HEIGHT,
+	THEATRE_PLAYER_CLEARANCE,
+	TheatreEvent,
+} from '../lib/theatre';
+
+const LOG_WIDTH = 380;
+
+// Dissolves the top of the column so lines leave rather than being clipped off.
+// On the column alone, not the panel: the panel keeps its edges. Both spellings,
+// since the unprefixed property is not in Safari.
+const CRAWL_MASK = 'linear-gradient(to bottom, transparent 0%, #000 34%)';
+
+// The clock alone against each line, with the day called once above the lines
+// that share it — a full date on all of them is the same ten characters twenty
+// times over.
+type LogRow =
+	| {kind: 'day'; key: string; label: string}
+	| {kind: 'event'; key: string; time: string; label: string};
+
+const toRows = (entries: TheatreEvent[]): LogRow[] => {
+	const rows: LogRow[] = [];
+	let previous: Date | null = null;
+
+	for (const entry of entries) {
+		const at = new Date(entry.t);
+
+		if (!previous || !isSameDay(previous, at)) {
+			rows.push({kind: 'day', key: `day-${entry.id}`, label: formatDate(at)});
+		}
+
+		rows.push({
+			kind: 'event',
+			key: entry.id,
+			time: formatTimeOfDay(at),
+			label: entry.label,
+		});
+
+		previous = at;
+	}
+
+	return rows;
+};
+
+export const TheatreLog = ({entries}: {entries: TheatreEvent[]}) => {
+	const animate = !usePrefersReducedMotion();
+	const columnRef = useRef<HTMLDivElement | null>(null);
+	const newestId = entries[entries.length - 1]?.id ?? null;
+
+	useEffect(() => {
+		const column = columnRef.current;
+		if (!column || !animate || newestId === null) return;
+
+		column.animate(THEATRE_CRAWL_FRAMES, THEATRE_CRAWL_TIMING);
+	}, [newestId, animate]);
+
+	return (
+		<aside
+			data-testid="theatre-log"
+			aria-live="off"
+			style={{
+				width: LOG_WIDTH,
+				flexShrink: 0,
+				minHeight: 0,
+				display: 'flex',
+				flexDirection: 'column',
+				borderRight: `1px solid ${GUI_THEME.line}`,
+				background: GUI_THEME.panel,
+			}}
+		>
+			<div
+				style={{
+					flex: 1,
+					minHeight: 0,
+					display: 'flex',
+					flexDirection: 'column',
+					// Filled from the bottom, so a new line pushes the column up and the
+					// oldest one off the top into the fade.
+					justifyContent: 'flex-end',
+					overflow: 'hidden',
+					// A row's worth past the drawer: the crawl starts each line one
+					// row low and slides it up, and at rest against the drawer that
+					// slide would run the newest line in behind it.
+					padding: `0 14px ${
+						THEATRE_PLAYER_CLEARANCE + THEATRE_LOG_ROW_HEIGHT
+					}px 30px`,
+					maskImage: CRAWL_MASK,
+					WebkitMaskImage: CRAWL_MASK,
+				}}
+			>
+				<div ref={columnRef}>
+					{toRows(entries).map(row => (
+						<div
+							key={row.key}
+							data-testid={
+								row.kind === 'day' ? 'theatre-log-day' : 'theatre-log-line'
+							}
+							style={{
+								display: 'flex',
+								gap: 10,
+								height: THEATRE_LOG_ROW_HEIGHT,
+								lineHeight: `${THEATRE_LOG_ROW_HEIGHT}px`,
+								fontSize: TEXT.meta,
+								// One clipped line each, which is what makes the crawl even:
+								// every row is the height the column slides by.
+								whiteSpace: 'nowrap',
+								animation: animate
+									? 'epiqTheatreLogLine 260ms ease-out'
+									: undefined,
+							}}
+						>
+							{row.kind === 'day' ? (
+								<span
+									style={{
+										color: GUI_THEME.dim,
+										fontVariantNumeric: 'tabular-nums',
+									}}
+								>
+									{row.label}
+								</span>
+							) : (
+								<>
+									<span
+										style={{
+											color: GUI_THEME.dim2,
+											fontVariantNumeric: 'tabular-nums',
+											flexShrink: 0,
+										}}
+									>
+										{row.time}
+									</span>
+									<span
+										style={{
+											color: GUI_THEME.secondary,
+											overflow: 'hidden',
+											textOverflow: 'ellipsis',
+										}}
+									>
+										{row.label}
+									</span>
+								</>
+							)}
+						</div>
+					))}
+				</div>
+			</div>
+		</aside>
+	);
+};

--- a/source/gui/client/components/TheatreLog.tsx
+++ b/source/gui/client/components/TheatreLog.tsx
@@ -18,7 +18,7 @@ import {
 import {GUI_THEME, TEXT} from '../lib/gui-theme';
 import {usePrefersReducedMotion} from '../lib/scrubber';
 import {
-	THEATRE_CRAWL_FRAMES,
+	crawlShiftFrames,
 	THEATRE_CRAWL_TIMING,
 	THEATRE_LOG_ROW_HEIGHT,
 	THEATRE_PLAYER_CLEARANCE,
@@ -66,13 +66,28 @@ const toRows = (entries: TheatreEvent[]): LogRow[] => {
 export const TheatreLog = ({entries}: {entries: TheatreEvent[]}) => {
 	const animate = !usePrefersReducedMotion();
 	const columnRef = useRef<HTMLDivElement | null>(null);
+	const rows = toRows(entries);
 	const newestId = entries[entries.length - 1]?.id ?? null;
+
+	// The keys on screen before this render. The column slides by however many
+	// rows joined the bottom, which is not always one: an event that crosses
+	// midnight brings a day header down with it, and a fixed shift would leave
+	// the crawl stepping at every boundary.
+	const shownKeysRef = useRef<Set<string>>(new Set());
 
 	useEffect(() => {
 		const column = columnRef.current;
-		if (!column || !animate || newestId === null) return;
+		const shown = shownKeysRef.current;
+		const appended = rows.filter(row => !shown.has(row.key)).length;
 
-		column.animate(THEATRE_CRAWL_FRAMES, THEATRE_CRAWL_TIMING);
+		shownKeysRef.current = new Set(rows.map(row => row.key));
+
+		if (!column || !animate || newestId === null || appended === 0) return;
+
+		column.animate(crawlShiftFrames(appended), THEATRE_CRAWL_TIMING);
+		// Deliberately keyed on the newest line rather than on `rows`, which is
+		// rebuilt every render: the crawl moves when the log does, not when the
+		// board above it repaints.
 	}, [newestId, animate]);
 
 	return (
@@ -110,7 +125,7 @@ export const TheatreLog = ({entries}: {entries: TheatreEvent[]}) => {
 				}}
 			>
 				<div ref={columnRef}>
-					{toRows(entries).map(row => (
+					{rows.map(row => (
 						<div
 							key={row.key}
 							data-testid={

--- a/source/gui/client/components/TheatrePlayer.tsx
+++ b/source/gui/client/components/TheatrePlayer.tsx
@@ -1,0 +1,338 @@
+// The movie player that comes up over a dimmed board while its history plays:
+// a transport, the bar that is the only control on the board's position while
+// it is up, and the moment and caption of the event that just landed.
+
+import {useEffect, useRef} from 'react';
+import {formatDateTime} from '../../../lib/utils/date.utils.js';
+import {GUI_THEME, TEXT} from '../lib/gui-theme';
+import {clamp, usePrefersReducedMotion} from '../lib/scrubber';
+import {THEATRE_KEYFRAMES, TheatrePlan, TheatrePlayback} from '../lib/theatre';
+import {IconClose, IconPause, IconPlay, IconReplay} from './IconPlayback';
+
+const PLAYER_WIDTH = 760;
+// How far an arrow key moves the bar, as a share of the whole movie.
+const SEEK_STEP = 0.02;
+const BAR_HEIGHT = 4;
+const KNOB_SIZE = 12;
+
+const transportButtonStyle = (primary: boolean): React.CSSProperties => ({
+	background: primary ? GUI_THEME.accent : 'transparent',
+	border: `1px solid ${primary ? GUI_THEME.accent : GUI_THEME.line}`,
+	color: primary ? GUI_THEME.bg : GUI_THEME.secondary,
+	borderRadius: 999,
+	width: primary ? 34 : 26,
+	height: primary ? 34 : 26,
+	display: 'inline-flex',
+	alignItems: 'center',
+	justifyContent: 'center',
+	cursor: 'pointer',
+	flexShrink: 0,
+	padding: 0,
+	transition:
+		'background 160ms ease, color 160ms ease, border-color 160ms ease',
+});
+
+export const TheatrePlayer = ({
+	plan,
+	playback,
+	onExit,
+}: {
+	plan: TheatrePlan;
+	playback: TheatrePlayback;
+	onExit: () => void;
+}) => {
+	const animate = !usePrefersReducedMotion();
+	const trackRef = useRef<HTMLDivElement | null>(null);
+	const {
+		progress,
+		playing,
+		done,
+		speed,
+		cursor,
+		current,
+		currentTime,
+		totalCount,
+		toggle,
+		cycleSpeed,
+		seekTo,
+		beginSeek,
+		endSeek,
+	} = playback;
+
+	// Space is the transport and Escape is the way out, for as long as the
+	// player is up. Bound on the document rather than the panel: nothing inside
+	// it holds focus after a click on the board behind.
+	useEffect(() => {
+		const onKeyDown = (event: KeyboardEvent) => {
+			const target = event.target as HTMLElement | null;
+
+			// A form field's own keys win. Every input on the page is standing down
+			// while the player is up, but the player can be opened with one focused.
+			if (
+				target &&
+				(target.isContentEditable ||
+					['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName))
+			) {
+				return;
+			}
+
+			if (event.key === 'Escape') {
+				event.preventDefault();
+				onExit();
+				return;
+			}
+
+			if (event.key === ' ' || event.key === 'Spacebar') {
+				event.preventDefault();
+				toggle();
+			}
+		};
+
+		document.addEventListener('keydown', onKeyDown);
+		return () => document.removeEventListener('keydown', onKeyDown);
+	}, [onExit, toggle]);
+
+	const fractionFromEvent = (event: React.PointerEvent<HTMLDivElement>) => {
+		const rect = event.currentTarget.getBoundingClientRect();
+
+		return clamp((event.clientX - rect.left) / Math.max(1, rect.width), 0, 1);
+	};
+
+	return (
+		<>
+			<style>{THEATRE_KEYFRAMES}</style>
+
+			{/* Darkens the edges so the board reads as the lit thing on the screen.
+			    Over everything but the player itself, and never in the way of a
+			    pointer — what it covers is already standing down. */}
+			<div
+				data-testid="theatre-vignette"
+				style={{
+					position: 'fixed',
+					inset: 0,
+					pointerEvents: 'none',
+					zIndex: 40,
+					background:
+						'radial-gradient(120% 90% at 50% 45%, rgba(6,7,10,0) 35%, rgba(6,7,10,0.72) 100%)',
+					animation: animate ? 'epiqTheatreFade 320ms ease-out' : undefined,
+				}}
+			/>
+
+			<div
+				data-testid="theatre-player"
+				role="group"
+				aria-label="History player"
+				style={{
+					position: 'fixed',
+					left: '50%',
+					bottom: 26,
+					transform: 'translateX(-50%)',
+					width: `min(${PLAYER_WIDTH}px, calc(100vw - 60px))`,
+					zIndex: 50,
+					display: 'flex',
+					flexDirection: 'column',
+					gap: 10,
+					padding: '14px 18px 16px',
+					borderRadius: 14,
+					border: `1px solid ${GUI_THEME.edge}`,
+					background: 'rgba(17, 20, 27, 0.92)',
+					backdropFilter: 'blur(14px)',
+					WebkitBackdropFilter: 'blur(14px)',
+					boxShadow: '0 24px 60px rgba(0, 0, 0, 0.6)',
+					animation: animate ? 'epiqTheatreRise 260ms ease-out' : undefined,
+				}}
+			>
+				<div style={{display: 'flex', alignItems: 'center', gap: 14}}>
+					<button
+						type="button"
+						data-testid="theatre-toggle"
+						onClick={toggle}
+						title={done ? 'Play again' : playing ? 'Pause' : 'Play'}
+						aria-label={done ? 'Play again' : playing ? 'Pause' : 'Play'}
+						style={transportButtonStyle(true)}
+					>
+						{done ? (
+							<IconReplay size={15} />
+						) : playing ? (
+							<IconPause size={16} />
+						) : (
+							<IconPlay size={16} />
+						)}
+					</button>
+
+					{/* The board's position while the player is up. The scrubber stands
+					    down for exactly this reason: two controls for one position
+					    would fight over it. */}
+					<div
+						data-testid="theatre-progress"
+						role="slider"
+						aria-label="Playback position"
+						aria-valuemin={0}
+						aria-valuemax={100}
+						aria-valuenow={Math.round(progress * 100)}
+						tabIndex={0}
+						ref={trackRef}
+						onPointerDown={event => {
+							event.currentTarget.setPointerCapture(event.pointerId);
+							beginSeek();
+							seekTo(fractionFromEvent(event));
+						}}
+						onPointerMove={event => {
+							if (!event.currentTarget.hasPointerCapture(event.pointerId)) {
+								return;
+							}
+
+							seekTo(fractionFromEvent(event));
+						}}
+						onPointerUp={event => {
+							event.currentTarget.releasePointerCapture(event.pointerId);
+							endSeek();
+						}}
+						onPointerCancel={endSeek}
+						onKeyDown={event => {
+							const step =
+								event.key === 'ArrowLeft'
+									? -SEEK_STEP
+									: event.key === 'ArrowRight'
+									? SEEK_STEP
+									: null;
+
+							if (step === null) return;
+
+							event.preventDefault();
+							seekTo(progress + step);
+						}}
+						style={{
+							position: 'relative',
+							flex: 1,
+							height: 18,
+							display: 'flex',
+							alignItems: 'center',
+							cursor: 'pointer',
+							touchAction: 'none',
+						}}
+					>
+						<div
+							style={{
+								position: 'absolute',
+								left: 0,
+								right: 0,
+								height: BAR_HEIGHT,
+								borderRadius: 999,
+								background: 'rgba(122, 157, 214, 0.22)',
+							}}
+						/>
+						<div
+							style={{
+								position: 'absolute',
+								left: 0,
+								width: `${progress * 100}%`,
+								height: BAR_HEIGHT,
+								borderRadius: 999,
+								background: `linear-gradient(90deg, #b3a5ff, ${GUI_THEME.accent})`,
+								boxShadow: `0 0 10px rgba(118, 212, 255, 0.45)`,
+							}}
+						/>
+						<div
+							style={{
+								position: 'absolute',
+								left: `${progress * 100}%`,
+								width: KNOB_SIZE,
+								height: KNOB_SIZE,
+								marginLeft: -KNOB_SIZE / 2,
+								borderRadius: '50%',
+								background: GUI_THEME.accent,
+								boxShadow: '0 0 12px rgba(118, 212, 255, 0.7)',
+							}}
+						/>
+					</div>
+
+					<button
+						type="button"
+						data-testid="theatre-speed"
+						onClick={cycleSpeed}
+						title="Playback speed"
+						style={{
+							...transportButtonStyle(false),
+							width: 38,
+							borderRadius: 8,
+							fontFamily: 'inherit',
+							fontSize: TEXT.label,
+							color: GUI_THEME.accent,
+						}}
+					>
+						{speed}×
+					</button>
+
+					<button
+						type="button"
+						data-testid="theatre-exit"
+						onClick={onExit}
+						title="Leave the player and follow the board again"
+						aria-label="Close the history player"
+						style={transportButtonStyle(false)}
+					>
+						<IconClose size={13} />
+					</button>
+				</div>
+
+				<div
+					style={{
+						display: 'flex',
+						alignItems: 'baseline',
+						gap: 12,
+						fontSize: TEXT.meta,
+						// Holds the row's height across a caption that comes and goes, so
+						// the panel never breathes as the movie runs.
+						minHeight: 16,
+					}}
+				>
+					<span
+						data-testid="theatre-time"
+						style={{
+							color: GUI_THEME.accent,
+							fontVariantNumeric: 'tabular-nums',
+							flexShrink: 0,
+						}}
+					>
+						{formatDateTime(new Date(currentTime))}
+					</span>
+
+					<span
+						data-testid="theatre-count"
+						style={{
+							color: GUI_THEME.dim2,
+							fontVariantNumeric: 'tabular-nums',
+							flexShrink: 0,
+						}}
+					>
+						{cursor + 1}/{totalCount} edits
+					</span>
+
+					{/* Keyed on the event so each caption is its own element, and the
+					    entrance runs again for the next one rather than the text
+					    swapping underneath a finished animation. */}
+					<span
+						key={current?.id ?? 'start'}
+						data-testid="theatre-caption"
+						style={{
+							color: GUI_THEME.secondary,
+							overflow: 'hidden',
+							textOverflow: 'ellipsis',
+							whiteSpace: 'nowrap',
+							animation: animate
+								? 'epiqTheatreCaption 220ms ease-out'
+								: undefined,
+						}}
+					>
+						{current
+							? current.label
+							: `Opening on the board before ${formatDateTime(
+									new Date(plan.events[0]!.t),
+							  )}`}
+					</span>
+				</div>
+			</div>
+		</>
+	);
+};

--- a/source/gui/client/components/TheatrePlayer.tsx
+++ b/source/gui/client/components/TheatrePlayer.tsx
@@ -74,6 +74,15 @@ export const TheatrePlayer = ({
 		endSeek,
 	} = playback;
 
+	// Held in refs so the listener below is bound once for the life of the
+	// player. Both are re-created on every render of the board above, and the
+	// board renders on every frame of the movie — listing them would add and
+	// drop a document listener sixty times a second.
+	const onExitRef = useRef(onExit);
+	onExitRef.current = onExit;
+	const toggleRef = useRef(toggle);
+	toggleRef.current = toggle;
+
 	// Space is the transport and Escape is the way out, for as long as the
 	// player is up. Bound on the document rather than the panel: nothing inside
 	// it holds focus after a click on the board behind.
@@ -81,31 +90,33 @@ export const TheatrePlayer = ({
 		const onKeyDown = (event: KeyboardEvent) => {
 			const target = event.target as HTMLElement | null;
 
-			// A form field's own keys win. Every input on the page is standing down
-			// while the player is up, but the player can be opened with one focused.
+			// Anything that answers a key itself keeps it. Form fields because the
+			// player can be opened with one focused, and buttons because Space is
+			// how a focused one is pressed — swallowing it here would leave the
+			// player's own controls unreachable from the keyboard.
 			if (
 				target &&
 				(target.isContentEditable ||
-					['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName))
+					['INPUT', 'TEXTAREA', 'SELECT', 'BUTTON'].includes(target.tagName))
 			) {
 				return;
 			}
 
 			if (event.key === 'Escape') {
 				event.preventDefault();
-				onExit();
+				onExitRef.current();
 				return;
 			}
 
 			if (event.key === ' ' || event.key === 'Spacebar') {
 				event.preventDefault();
-				toggle();
+				toggleRef.current();
 			}
 		};
 
 		document.addEventListener('keydown', onKeyDown);
 		return () => document.removeEventListener('keydown', onKeyDown);
-	}, [onExit, toggle]);
+	}, []);
 
 	const fractionFromEvent = (event: React.PointerEvent<HTMLDivElement>) => {
 		const rect = event.currentTarget.getBoundingClientRect();

--- a/source/gui/client/components/TheatrePlayer.tsx
+++ b/source/gui/client/components/TheatrePlayer.tsx
@@ -7,38 +7,53 @@ import {formatDateTime} from '../../../lib/utils/date.utils.js';
 import {GUI_THEME, TEXT} from '../lib/gui-theme';
 import {clamp, usePrefersReducedMotion} from '../lib/scrubber';
 import {THEATRE_KEYFRAMES, TheatrePlan, TheatrePlayback} from '../lib/theatre';
-import {IconClose, IconPause, IconPlay, IconReplay} from './IconPlayback';
+import {
+	IconClose,
+	IconPause,
+	IconPlay,
+	IconPopOut,
+	IconReplay,
+} from './IconPlayback';
 
-const PLAYER_WIDTH = 760;
 // How far an arrow key moves the bar, as a share of the whole movie.
 const SEEK_STEP = 0.02;
-const BAR_HEIGHT = 4;
-const KNOB_SIZE = 12;
+const BAR_HEIGHT = 2;
+const KNOB_SIZE = 9;
+
+// Square and outlined at one size, the transport included: a filled accent
+// disc is a media widget, and this sits in a terminal. The transport is set
+// apart by colour alone, which is all it needs to be the one to reach for.
+const TRANSPORT_SIZE = 24;
 
 const transportButtonStyle = (primary: boolean): React.CSSProperties => ({
-	background: primary ? GUI_THEME.accent : 'transparent',
+	background: 'transparent',
 	border: `1px solid ${primary ? GUI_THEME.accent : GUI_THEME.line}`,
-	color: primary ? GUI_THEME.bg : GUI_THEME.secondary,
-	borderRadius: 999,
-	width: primary ? 34 : 26,
-	height: primary ? 34 : 26,
+	color: primary ? GUI_THEME.accent : GUI_THEME.secondary,
+	borderRadius: 3,
+	width: TRANSPORT_SIZE,
+	height: TRANSPORT_SIZE,
 	display: 'inline-flex',
 	alignItems: 'center',
 	justifyContent: 'center',
 	cursor: 'pointer',
 	flexShrink: 0,
 	padding: 0,
-	transition:
-		'background 160ms ease, color 160ms ease, border-color 160ms ease',
+	transition: 'color 160ms ease, border-color 160ms ease',
 });
 
 export const TheatrePlayer = ({
 	plan,
 	playback,
+	logOpen,
+	onToggleLog,
 	onExit,
 }: {
 	plan: TheatrePlan;
 	playback: TheatrePlayback;
+	// Owned above: the log is a panel in the board's own row, so the layout has
+	// to know about it, not just the drawer that opens it.
+	logOpen: boolean;
+	onToggleLog: () => void;
 	onExit: () => void;
 }) => {
 	const animate = !usePrefersReducedMotion();
@@ -122,23 +137,25 @@ export const TheatrePlayer = ({
 				data-testid="theatre-player"
 				role="group"
 				aria-label="History player"
+				// A drawer risen from the foot of the window rather than a card
+				// floating over it: attached edge to edge, square, and held apart
+				// from the board by one hairline the way a dev tool's panel is. The
+				// board's own 30px gutter carries through, so the transport lines up
+				// with the first column.
 				style={{
 					position: 'fixed',
-					left: '50%',
-					bottom: 26,
-					transform: 'translateX(-50%)',
-					width: `min(${PLAYER_WIDTH}px, calc(100vw - 60px))`,
+					left: 0,
+					right: 0,
+					bottom: 0,
 					zIndex: 50,
 					display: 'flex',
 					flexDirection: 'column',
-					gap: 10,
-					padding: '14px 18px 16px',
-					borderRadius: 14,
-					border: `1px solid ${GUI_THEME.edge}`,
-					background: 'rgba(17, 20, 27, 0.92)',
+					gap: 9,
+					padding: '11px 30px 13px',
+					borderTop: `1px solid ${GUI_THEME.line}`,
+					background: 'rgba(13, 16, 22, 0.94)',
 					backdropFilter: 'blur(14px)',
 					WebkitBackdropFilter: 'blur(14px)',
-					boxShadow: '0 24px 60px rgba(0, 0, 0, 0.6)',
 					animation: animate ? 'epiqTheatreRise 260ms ease-out' : undefined,
 				}}
 			>
@@ -152,11 +169,11 @@ export const TheatrePlayer = ({
 						style={transportButtonStyle(true)}
 					>
 						{done ? (
-							<IconReplay size={15} />
+							<IconReplay size={13} />
 						) : playing ? (
-							<IconPause size={16} />
+							<IconPause size={13} />
 						) : (
-							<IconPlay size={16} />
+							<IconPlay size={13} />
 						)}
 					</button>
 
@@ -230,7 +247,6 @@ export const TheatrePlayer = ({
 								height: BAR_HEIGHT,
 								borderRadius: 999,
 								background: `linear-gradient(90deg, #b3a5ff, ${GUI_THEME.accent})`,
-								boxShadow: `0 0 10px rgba(118, 212, 255, 0.45)`,
 							}}
 						/>
 						<div
@@ -242,7 +258,7 @@ export const TheatrePlayer = ({
 								marginLeft: -KNOB_SIZE / 2,
 								borderRadius: '50%',
 								background: GUI_THEME.accent,
-								boxShadow: '0 0 12px rgba(118, 212, 255, 0.7)',
+								boxShadow: '0 0 5px rgba(118, 212, 255, 0.35)',
 							}}
 						/>
 					</div>
@@ -254,8 +270,7 @@ export const TheatrePlayer = ({
 						title="Playback speed"
 						style={{
 							...transportButtonStyle(false),
-							width: 38,
-							borderRadius: 8,
+							width: 34,
 							fontFamily: 'inherit',
 							fontSize: TEXT.label,
 							color: GUI_THEME.accent,
@@ -272,7 +287,7 @@ export const TheatrePlayer = ({
 						aria-label="Close the history player"
 						style={transportButtonStyle(false)}
 					>
-						<IconClose size={13} />
+						<IconClose size={12} />
 					</button>
 				</div>
 
@@ -331,6 +346,35 @@ export const TheatrePlayer = ({
 									new Date(plan.events[0]!.t),
 							  )}`}
 					</span>
+
+					{/* Beside the line it expands: the caption is the last of the log,
+					    and this is the rest of it. */}
+					<button
+						type="button"
+						data-testid="theatre-log-toggle"
+						aria-pressed={logOpen}
+						onClick={onToggleLog}
+						title={
+							logOpen
+								? 'Hide the log'
+								: 'Show every event as it plays, over the board'
+						}
+						aria-label="Show the log over the board"
+						style={{
+							background: 'transparent',
+							border: 'none',
+							padding: 0,
+							marginLeft: 'auto',
+							color: logOpen ? GUI_THEME.accent : GUI_THEME.dim,
+							cursor: 'pointer',
+							display: 'inline-flex',
+							alignItems: 'center',
+							flexShrink: 0,
+							transition: 'color 160ms ease',
+						}}
+					>
+						<IconPopOut size={12} />
+					</button>
 				</div>
 			</div>
 		</>

--- a/source/gui/client/components/TicketCard.tsx
+++ b/source/gui/client/components/TicketCard.tsx
@@ -1,6 +1,11 @@
 import {useEffect, useRef} from 'react';
 import {GuiComment, GuiIssue} from '../lib/gui-state.model';
 import {GUI_THEME} from '../lib/gui-theme';
+import {
+	THEATRE_CARD_IN_ANIMATION,
+	THEATRE_FLASH_FRAMES,
+	THEATRE_FLASH_TIMING,
+} from '../lib/theatre';
 import {isSwimlaneDrag} from '../lib/gui-move-swimlane';
 import {CopyRef} from './CopyRef';
 import {IconComment} from './IconComment';
@@ -18,6 +23,8 @@ export const TicketCard = ({
 	onFilterByTag,
 	onDragOverIssue,
 	onDropIssueAt,
+	theatre,
+	flashKey,
 }: {
 	ticket: GuiIssue;
 	index: number;
@@ -33,6 +40,13 @@ export const TicketCard = ({
 	onFilterByTag: (tagId: string) => void;
 	onDragOverIssue: (targetIndex: number) => void;
 	onDropIssueAt: (issueId: string, targetIndex: number) => void;
+	// The history player is up, so a card arriving on the board is one the movie
+	// just produced and is worth an entrance.
+	theatre: boolean;
+	// The id of the event that just landed on this ticket, or null. Its identity
+	// is what matters, not its content: two events in a row on one ticket have
+	// to flash twice.
+	flashKey: string | null;
 }) => {
 	const cardRef = useRef<HTMLDivElement | null>(null);
 
@@ -47,6 +61,25 @@ export const TicketCard = ({
 			inline: 'nearest',
 		});
 	}, [isSelected]);
+
+	// Run off the element rather than through a CSS animation on the style prop:
+	// the card's entrance already owns that property, and the board re-renders
+	// on every frame of the movie, which would put the entrance back and cut a
+	// running flash short. A web animation overrides the inline styles for its
+	// own duration and reverts, and starts fresh on every call — which is what
+	// makes two events in a row on one ticket flash twice.
+	//
+	// Deliberately not cancelled on the way out: events land closer together
+	// than the flash is long, so cancelling as the spotlight moves to the next
+	// ticket would cut every one of them short. A later flash on this same card
+	// simply wins, and a finished one drops off on its own.
+	useEffect(() => {
+		const card = cardRef.current;
+		if (!card || flashKey === null) return;
+		if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+		card.animate(THEATRE_FLASH_FRAMES, THEATRE_FLASH_TIMING);
+	}, [flashKey]);
 
 	const getVisualTargetIndex = (isAfterMiddle: boolean) =>
 		index + (isAfterMiddle ? 1 : 0);
@@ -115,6 +148,10 @@ export const TicketCard = ({
 				border: `1px solid ${
 					isSelected || isPicked ? GUI_THEME.accent : 'transparent'
 				}`,
+				// The flash is applied to the node directly (see above), so it must
+				// not be set here too or React would put it back on every render and
+				// cut the running one short.
+				animation: theatre ? THEATRE_CARD_IN_ANIMATION : undefined,
 			}}
 		>
 			<div

--- a/source/gui/client/components/TimeScrubber.tsx
+++ b/source/gui/client/components/TimeScrubber.tsx
@@ -47,6 +47,7 @@ import {
 	usePrefersReducedMotion,
 	windowNamesIssues,
 } from '../lib/scrubber';
+import {canPlayTimeline} from '../lib/theatre';
 import {HintContent, ScrubberLayout} from './ScrubberLayout';
 import {ScatterLayer, ScatterPoint} from './ScrubberParts';
 import {GUI_THEME} from '../lib/gui-theme';
@@ -83,6 +84,8 @@ export const TimeScrubber = ({
 	selectedIssue,
 	knownIdentities,
 	refreshOn,
+	onPlayTheatre,
+	theatreOpen,
 }: {
 	timeline: GuiEventTimeline | null;
 	commits: GuiCommitEntry[];
@@ -127,6 +130,11 @@ export const TimeScrubber = ({
 	// shows, a ticket filed since the last fetch is missing from it, and would
 	// be hidden from the board it has just joined.
 	refreshOn: unknown;
+	// Opens the history player over this window.
+	onPlayTheatre: () => void;
+	// The player is up. It owns the board's position for as long as it is, so
+	// the whole bar stands down rather than competing for the same thing.
+	theatreOpen: boolean;
 }) => {
 	const {
 		scope,
@@ -559,6 +567,11 @@ export const TimeScrubber = ({
 		// with the rest of the controls when there is nothing to ask.
 		if (!connected) return;
 
+		// The player is driving the board's position. Pointer events cannot reach
+		// the chart while it is up, but a drag begun before it opened still ends
+		// somewhere.
+		if (theatreOpen) return;
+
 		const target = axis.fractionToTime(fraction);
 
 		// A click dispatches on both press and release; answering the second
@@ -762,6 +775,9 @@ export const TimeScrubber = ({
 		<ScrubberLayout
 			collapsed={collapsed}
 			onToggleCollapsed={() => setCollapsed(!collapsed)}
+			canPlay={connected && !theatreOpen && canPlayTimeline(timeline)}
+			onPlay={onPlayTheatre}
+			standDown={theatreOpen}
 			controls={{
 				connected,
 				scope,

--- a/source/gui/client/lib/theatre.test.ts
+++ b/source/gui/client/lib/theatre.test.ts
@@ -9,7 +9,9 @@ import {
 	playbackPosition,
 	seekTimeFor,
 	THEATRE_LEAD_IN,
+	THEATRE_LOG_LINES,
 	theatreDurationMs,
+	theatreLogEntries,
 } from './theatre';
 
 const entry = (
@@ -156,6 +158,48 @@ describe('seekTimeFor', () => {
 	it('asks for the moment just past the event, so its own change is in', () => {
 		expect(seekTimeFor(plan, 0)).toBe(101);
 		expect(seekTimeFor(plan, 1)).toBe(201);
+	});
+});
+
+describe('theatreLogEntries', () => {
+	const plan = buildTheatrePlan(
+		timeline(
+			Array.from({length: THEATRE_LOG_LINES + 10}, (_, index) =>
+				entry(`e${index}`, 1000 + index),
+			),
+		),
+	)!;
+
+	it('is empty until the first event has played', () => {
+		expect(theatreLogEntries(plan, -1)).toEqual([]);
+	});
+
+	it('reads oldest first, ending on the event that just landed', () => {
+		const entries = theatreLogEntries(plan, 3);
+
+		expect(entries.map(event => event.id)).toEqual(['e0', 'e1', 'e2', 'e3']);
+	});
+
+	// The cap is on the document as much as on the reading: rows above it have
+	// scrolled out of the fade, and keeping them would grow the overlay by a
+	// node per event for the length of the movie.
+	it('never holds more lines than the overlay can show', () => {
+		const entries = theatreLogEntries(plan, plan.events.length - 1);
+
+		expect(entries).toHaveLength(THEATRE_LOG_LINES);
+		expect(entries[entries.length - 1]!.id).toBe(
+			plan.events[plan.events.length - 1]!.id,
+		);
+	});
+
+	// Sliced off the plan rather than accumulated as events land, which is what
+	// lets it follow the bar backwards as well as forwards.
+	it('goes back with a seek backwards', () => {
+		expect(theatreLogEntries(plan, 2).map(event => event.id)).toEqual([
+			'e0',
+			'e1',
+			'e2',
+		]);
 	});
 });
 

--- a/source/gui/client/lib/theatre.test.ts
+++ b/source/gui/client/lib/theatre.test.ts
@@ -1,0 +1,180 @@
+import {describe, expect, it} from 'vitest';
+import {buildPlaybackFractions} from '../../../lib/utils/playback-pacing.js';
+import {GuiEventTimeline, GuiEventTimelineEntry} from './gui-state.model';
+import {
+	buildTheatrePlan,
+	canPlayTimeline,
+	cursorAt,
+	nextSpeed,
+	playbackPosition,
+	seekTimeFor,
+	THEATRE_LEAD_IN,
+	theatreDurationMs,
+} from './theatre';
+
+const entry = (
+	id: string,
+	t: number,
+	issue: string | null = null,
+): GuiEventTimelineEntry => ({
+	id,
+	t,
+	action: 'issue:create',
+	label: `event ${id}`,
+	actor: null,
+	tag: null,
+	assignee: null,
+	issue,
+});
+
+const timeline = (events: GuiEventTimelineEntry[]): GuiEventTimeline => ({
+	bucketMs: 1000,
+	buckets: [],
+	events,
+	earliest: 0,
+	latest: 10_000,
+});
+
+describe('buildTheatrePlan', () => {
+	it('plays the window in clock order, whatever order the log listed it in', () => {
+		const plan = buildTheatrePlan(
+			timeline([entry('b', 300), entry('a', 100), entry('c', 200)]),
+		);
+
+		expect(plan?.events.map(event => event.id)).toEqual(['a', 'c', 'b']);
+	});
+
+	it('opens a tick before the first event and closes on the last', () => {
+		const plan = buildTheatrePlan(timeline([entry('a', 100), entry('b', 900)]));
+
+		expect(plan?.startTime).toBe(99);
+		expect(plan?.endTime).toBe(900);
+	});
+
+	it('carries the ticket each event happened to, for the board to flash', () => {
+		const plan = buildTheatrePlan(
+			timeline([entry('a', 100, 'issue-1'), entry('b', 200, null)]),
+		);
+
+		expect(plan?.events.map(event => event.issue)).toEqual(['issue-1', null]);
+	});
+
+	it('refuses a window too thin to be a movie', () => {
+		expect(buildTheatrePlan(timeline([entry('a', 100)]))).toBeNull();
+		expect(buildTheatrePlan(timeline([]))).toBeNull();
+	});
+});
+
+describe('canPlayTimeline', () => {
+	it('is false with no timeline, and for a window the server sent as buckets alone', () => {
+		expect(canPlayTimeline(null)).toBe(false);
+		expect(canPlayTimeline(timeline([]))).toBe(false);
+	});
+
+	it('is true once the window holds a stretch to play', () => {
+		expect(canPlayTimeline(timeline([entry('a', 1), entry('b', 2)]))).toBe(
+			true,
+		);
+	});
+});
+
+describe('buildPlaybackFractions', () => {
+	it('runs from the first event to a full bar on the last', () => {
+		const fractions = buildPlaybackFractions([0, 1000, 2000]);
+
+		expect(fractions[0]).toBe(0);
+		expect(fractions[2]).toBe(1);
+	});
+
+	// The point of the weighting, in the terms the util itself puts it: one
+	// month-long gap costs far less playback time than thirty day-long ones. A
+	// quiet stretch fast-forwards; a busy one keeps its spacing.
+	it('gives a busy month far more of the movie than a silent one of equal length', () => {
+		const dayMs = 24 * 60 * 60 * 1000;
+
+		// A month of one event a day, then a month of silence, then one event.
+		// The two months are the same length of wall clock.
+		const times = Array.from({length: 31}, (_, index) => index * dayMs).concat(
+			60 * dayMs,
+		);
+		const fractions = buildPlaybackFractions(times);
+
+		const busyShare = fractions[30]! - fractions[0]!;
+		const silentShare = fractions[31]! - fractions[30]!;
+
+		expect(busyShare).toBeGreaterThan(silentShare * 4);
+	});
+
+	it('spaces events evenly when every timestamp is identical', () => {
+		expect(buildPlaybackFractions([5, 5, 5, 5])).toEqual([0.25, 0.5, 0.75, 1]);
+	});
+});
+
+describe('cursorAt', () => {
+	const fractions = [0, 0.5, 1];
+
+	it('is -1 before the first event has landed', () => {
+		expect(cursorAt(fractions, -0.1)).toBe(-1);
+	});
+
+	it('lands an event exactly on its own position', () => {
+		expect(cursorAt(fractions, 0)).toBe(0);
+		expect(cursorAt(fractions, 0.5)).toBe(1);
+		expect(cursorAt(fractions, 1)).toBe(2);
+	});
+
+	it('holds the last event it passed between two positions', () => {
+		expect(cursorAt(fractions, 0.49)).toBe(0);
+		expect(cursorAt(fractions, 0.99)).toBe(1);
+	});
+});
+
+describe('playbackPosition', () => {
+	// The first event sits at fraction 0, so without the opening beat it would
+	// land on the clock's own frame zero and the movie would start one edit in.
+	it('is before the first event for as long as the opening beat runs', () => {
+		expect(playbackPosition(0)).toBeLessThan(0);
+		expect(playbackPosition(THEATRE_LEAD_IN / 2)).toBeLessThan(0);
+		expect(cursorAt([0, 0.5, 1], playbackPosition(0))).toBe(-1);
+	});
+
+	it('reaches the first event as the beat ends, and the last at the end', () => {
+		expect(playbackPosition(THEATRE_LEAD_IN)).toBeCloseTo(0);
+		expect(playbackPosition(1)).toBeCloseTo(1);
+	});
+});
+
+describe('seekTimeFor', () => {
+	const plan = buildTheatrePlan(timeline([entry('a', 100), entry('b', 200)]))!;
+
+	it('opens on the board before any of it happened', () => {
+		expect(seekTimeFor(plan, -1)).toBe(99);
+	});
+
+	// The checkout cut is exclusive, so the moment asked for has to be past the
+	// event or the state it produced is the one left out.
+	it('asks for the moment just past the event, so its own change is in', () => {
+		expect(seekTimeFor(plan, 0)).toBe(101);
+		expect(seekTimeFor(plan, 1)).toBe(201);
+	});
+});
+
+describe('theatreDurationMs', () => {
+	it('does not pad a handful of events out, nor let a long history run away', () => {
+		expect(theatreDurationMs(1)).toBe(6_000);
+		expect(theatreDurationMs(100_000)).toBe(45_000);
+	});
+
+	it('scales with the number of events in between', () => {
+		expect(theatreDurationMs(50)).toBeGreaterThan(theatreDurationMs(20));
+	});
+});
+
+describe('nextSpeed', () => {
+	it('cycles and wraps', () => {
+		expect(nextSpeed(0.5)).toBe(1);
+		expect(nextSpeed(1)).toBe(2);
+		expect(nextSpeed(2)).toBe(4);
+		expect(nextSpeed(4)).toBe(0.5);
+	});
+});

--- a/source/gui/client/lib/theatre.ts
+++ b/source/gui/client/lib/theatre.ts
@@ -1,0 +1,355 @@
+// The board's history played as a movie: what gets played, when each event
+// lands, and the clock that walks it. TheatrePlayer draws against this.
+//
+// Nothing new is asked of the server. The clock walks the timeline the scrubber
+// already holds, and each event it reaches checks the board out at that moment
+// with the same `time-travel:scrub` a needle drag sends.
+
+import {useCallback, useEffect, useRef, useState} from 'react';
+import {buildPlaybackFractions} from '../../../lib/utils/playback-pacing.js';
+import {GuiEventTimeline} from './gui-state.model';
+import {clamp} from './scrubber';
+
+// One frame of the movie, cut down to what playback, the caption and the
+// board's spotlight need.
+export type TheatreEvent = {
+	id: string;
+	t: number;
+	label: string;
+	// The ticket the event happened to, or null for a board- or swimlane-level
+	// one. What the board flashes as the event lands.
+	issue: string | null;
+};
+
+export type TheatrePlan = {
+	events: TheatreEvent[];
+	// Ascending, in [0..1]: entry i is where events[i] lands in the movie.
+	fractions: number[];
+	// The moment the board opens on, before any of it has happened.
+	startTime: number;
+	endTime: number;
+};
+
+// Two events is the shortest thing that is a movie rather than a still.
+export const MIN_THEATRE_EVENTS = 2;
+
+// False where the window is too thin to play, and where the server capped it
+// and sent buckets alone — counts name no moments to walk.
+export const canPlayTimeline = (timeline: GuiEventTimeline | null): boolean =>
+	(timeline?.events.length ?? 0) >= MIN_THEATRE_EVENTS;
+
+export const buildTheatrePlan = (
+	timeline: GuiEventTimeline,
+): TheatrePlan | null => {
+	// Sorted here rather than trusted: the log is ordered causally, which is not
+	// the same as by the clock, and a movie is watched in clock order.
+	const events: TheatreEvent[] = [...timeline.events]
+		.sort((left, right) => left.t - right.t)
+		.map(entry => ({
+			id: entry.id,
+			t: entry.t,
+			label: entry.label,
+			issue: entry.issue,
+		}));
+
+	if (events.length < MIN_THEATRE_EVENTS) return null;
+
+	const times = events.map(event => event.t);
+
+	return {
+		events,
+		fractions: buildPlaybackFractions(times),
+		// A tick before the first event, not the window's own start: the movie
+		// opens on the board as it was just before any of this happened, with no
+		// dead air in front of it.
+		startTime: times[0]! - 1,
+		endTime: times[times.length - 1]!,
+	};
+};
+
+// How long the movie runs at 1x. Scaled by the number of events so a handful is
+// not padded out to the same length as a year of history, and bounded at both
+// ends so neither becomes unwatchable.
+const MS_PER_EVENT = 350;
+const MIN_DURATION_MS = 6_000;
+const MAX_DURATION_MS = 45_000;
+
+// The most playback time one animation frame may advance. See the frame loop.
+const MAX_FRAME_MS = 100;
+
+export const theatreDurationMs = (eventCount: number): number =>
+	clamp(eventCount * MS_PER_EVENT, MIN_DURATION_MS, MAX_DURATION_MS);
+
+export const THEATRE_SPEEDS = [0.5, 1, 2, 4] as const;
+
+export type TheatreSpeed = (typeof THEATRE_SPEEDS)[number];
+
+export const nextSpeed = (speed: TheatreSpeed): TheatreSpeed =>
+	THEATRE_SPEEDS[(THEATRE_SPEEDS.indexOf(speed) + 1) % THEATRE_SPEEDS.length]!;
+
+// The index of the last event whose scheduled position `progress` has reached,
+// or -1 before the first one lands. A binary search rather than a walk on from
+// the last answer, because dragging the player's bar seeks backwards as readily
+// as forwards.
+export const cursorAt = (fractions: number[], progress: number): number => {
+	let low = 0;
+	let high = fractions.length - 1;
+	let found = -1;
+
+	while (low <= high) {
+		const mid = (low + high) >> 1;
+
+		if (fractions[mid]! <= progress) {
+			found = mid;
+			low = mid + 1;
+		} else {
+			high = mid - 1;
+		}
+	}
+
+	return found;
+};
+
+// The opening beat, as a share of the movie: the board as it was before any of
+// this happened, held long enough to be read as a starting point. Without it
+// the first event lands on frame zero, since it is what the clock is measured
+// from, and the movie opens one edit in.
+export const THEATRE_LEAD_IN = 0.06;
+
+// Where the clock's [0..1] sits in the events themselves, once the opening beat
+// is taken off the front. Negative for as long as that beat is running, which
+// is the position of a board no event has reached yet.
+export const playbackPosition = (progress: number): number =>
+	(progress - THEATRE_LEAD_IN) / (1 - THEATRE_LEAD_IN);
+
+// The moment to check the board out at for a cursor. The cut is exclusive,
+// hence the +1: what the movie shows is the state the event produced.
+export const seekTimeFor = (plan: TheatrePlan, cursor: number): number =>
+	cursor < 0 ? plan.startTime : plan.events[cursor]!.t + 1;
+
+export type TheatrePlayback = {
+	// [0..1], off the local clock rather than the events applied, so the bar
+	// glides through quiet stretches instead of waiting on the next round trip.
+	progress: number;
+	cursor: number;
+	playing: boolean;
+	done: boolean;
+	speed: TheatreSpeed;
+	// The event that landed last, or null before the first.
+	current: TheatreEvent | null;
+	currentTime: number;
+	totalCount: number;
+	toggle: () => void;
+	restart: () => void;
+	cycleSpeed: () => void;
+	seekTo: (fraction: number) => void;
+	beginSeek: () => void;
+	endSeek: () => void;
+};
+
+// `plan` null is a player that is not up; every hook still runs, and the
+// playback it hands back is inert.
+export const useTheatrePlayback = ({
+	plan,
+	ack,
+	onSeek,
+}: {
+	plan: TheatrePlan | null;
+	// Bumped once per answered time-travel request. What lets the clock hold a
+	// seek back rather than stacking another on one the server has not answered.
+	ack: number;
+	onSeek: (time: number) => void;
+}): TheatrePlayback => {
+	const [speed, setSpeed] = useState<TheatreSpeed>(1);
+	const [playing, setPlaying] = useState(false);
+	const [progress, setProgress] = useState(0);
+	// A bar being dragged owns the position, so the clock stands aside for it.
+	const [seeking, setSeeking] = useState(false);
+
+	// Where the clock actually is. The frame loop advances this and mirrors it
+	// into state for rendering; everything that moves the position by hand
+	// writes both. Deliberately not re-assigned from `progress` on render: a
+	// movie renders on every state broadcast, and one landing between a frame's
+	// write and its commit would drag the clock back a frame each time.
+	const progressRef = useRef(0);
+
+	const frameRef = useRef<number | null>(null);
+
+	// The cursor last asked for — null when nothing has been, which is not the
+	// same as -1, the cursor of the board before the first event.
+	const sentCursorRef = useRef<number | null>(null);
+	const inflightRef = useRef(false);
+
+	// Held in a ref so the dispatch below turns on the cursor moving and nothing
+	// else. The caller re-creates its sender every render, and an effect that
+	// listed it would run on each one.
+	const onSeekRef = useRef(onSeek);
+	onSeekRef.current = onSeek;
+
+	const durationMs = theatreDurationMs(plan?.events.length ?? 0);
+	const cursor = plan
+		? cursorAt(plan.fractions, playbackPosition(progress))
+		: -1;
+	const done = plan !== null && progress >= 1;
+
+	// Opens on the first frame and rewinds anything a previous movie left behind.
+	useEffect(() => {
+		setProgress(0);
+		progressRef.current = 0;
+		sentCursorRef.current = null;
+		inflightRef.current = false;
+		setPlaying(plan !== null);
+	}, [plan]);
+
+	// Before the dispatch below, so the ack that clears the flag and the render
+	// that acts on it are the same one.
+	useEffect(() => {
+		inflightRef.current = false;
+	}, [ack]);
+
+	useEffect(() => {
+		if (!plan) return;
+		// One request at a time. Events the clock passes meanwhile are not lost —
+		// the cursor read on the next attempt covers all of them at once.
+		if (inflightRef.current) return;
+		if (sentCursorRef.current === cursor) return;
+
+		sentCursorRef.current = cursor;
+		inflightRef.current = true;
+		onSeekRef.current(seekTimeFor(plan, cursor));
+	}, [plan, cursor, ack]);
+
+	useEffect(() => {
+		if (!plan || !playing || seeking) return;
+
+		let last = performance.now();
+
+		const step = (now: number) => {
+			// Frames stop arriving while the tab is in the background, and the first
+			// one back carries the whole gap. Capped, so a movie left in another tab
+			// carries on from where it was being watched instead of fast-forwarding
+			// to the end — and firing a checkout per event on the way.
+			const delta = Math.min(now - last, MAX_FRAME_MS);
+			last = now;
+
+			const next = Math.min(
+				1,
+				progressRef.current + (delta * speed) / durationMs,
+			);
+
+			progressRef.current = next;
+			setProgress(next);
+
+			if (next >= 1) {
+				setPlaying(false);
+				return;
+			}
+
+			frameRef.current = requestAnimationFrame(step);
+		};
+
+		frameRef.current = requestAnimationFrame(step);
+
+		return () => {
+			if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);
+			frameRef.current = null;
+		};
+	}, [plan, playing, seeking, speed, durationMs]);
+
+	const restart = useCallback(() => {
+		setProgress(0);
+		progressRef.current = 0;
+		setPlaying(true);
+	}, []);
+
+	const toggle = useCallback(() => {
+		// At the end there is nothing to resume, so the transport plays it again.
+		if (progressRef.current >= 1) {
+			restart();
+			return;
+		}
+
+		setPlaying(current => !current);
+	}, [restart]);
+
+	const cycleSpeed = useCallback(() => setSpeed(nextSpeed), []);
+
+	const seekTo = useCallback((fraction: number) => {
+		const next = clamp(fraction, 0, 1);
+		progressRef.current = next;
+		setProgress(next);
+
+		// Dropped here rather than left to the next frame: the clock stops at the
+		// end wherever the end is reached from, and a seek to it while a hidden
+		// tab is withholding frames would otherwise still read as playing.
+		if (next >= 1) setPlaying(false);
+	}, []);
+
+	return {
+		progress,
+		cursor,
+		playing,
+		done,
+		speed,
+		current: plan && cursor >= 0 ? plan.events[cursor]! : null,
+		currentTime: plan
+			? cursor >= 0
+				? plan.events[cursor]!.t
+				: plan.startTime
+			: 0,
+		totalCount: plan?.events.length ?? 0,
+		toggle,
+		restart,
+		cycleSpeed,
+		seekTo,
+		beginSeek: useCallback(() => setSeeking(true), []),
+		endSeek: useCallback(() => setSeeking(false), []),
+	};
+};
+
+// Mounted with the player, so the board's cards can use them for as long as one
+// is up. The flash is what marks the ticket an event just landed on.
+export const THEATRE_KEYFRAMES = `
+@keyframes epiqTheatreRise {
+	from { opacity: 0; transform: translate(-50%, 18px); }
+	to { opacity: 1; transform: translate(-50%, 0); }
+}
+@keyframes epiqTheatreFade {
+	from { opacity: 0; }
+	to { opacity: 1; }
+}
+@keyframes epiqTheatreCaption {
+	from { opacity: 0; transform: translateY(4px); }
+	to { opacity: 1; transform: translateY(0); }
+}
+@keyframes epiqTheatreCardIn {
+	from { opacity: 0; transform: scale(0.96); }
+	to { opacity: 1; transform: scale(1); }
+}
+@media (prefers-reduced-motion: reduce) {
+	@keyframes epiqTheatreRise { from { opacity: 1; transform: translate(-50%, 0); } to { opacity: 1; transform: translate(-50%, 0); } }
+	@keyframes epiqTheatreCardIn { from { opacity: 1; } to { opacity: 1; } }
+	@keyframes epiqTheatreCaption { from { opacity: 1; } to { opacity: 1; } }
+}
+`;
+
+export const THEATRE_CARD_IN_ANIMATION = 'epiqTheatreCardIn 260ms ease-out';
+
+// The spotlight on the ticket an event just landed on. Web-animation frames
+// rather than a keyframes rule: the card's own entrance owns its `animation`
+// property, and this has to be able to run twice in a row on one card.
+export const THEATRE_FLASH_FRAMES: Keyframe[] = [
+	{
+		boxShadow: '0 0 0 0 rgba(118, 212, 255, 0.6)',
+		background: 'rgba(118, 212, 255, 0.24)',
+	},
+	{
+		boxShadow: '0 0 0 12px rgba(118, 212, 255, 0)',
+		background: 'rgba(118, 212, 255, 0)',
+	},
+];
+
+export const THEATRE_FLASH_TIMING: KeyframeAnimationOptions = {
+	duration: 900,
+	easing: 'ease-out',
+};

--- a/source/gui/client/lib/theatre.ts
+++ b/source/gui/client/lib/theatre.ts
@@ -389,11 +389,21 @@ export const THEATRE_PLAYER_CLEARANCE = 80;
 // shift is the same every time and the crawl stays even.
 export const THEATRE_LOG_ROW_HEIGHT = 18;
 
-// The column slides up by a row as each line lands, rather than the stack
-// jumping. Run off the element for the same reason the card flash is: lines
-// arrive faster than the animation is long, and a restart has to be a restart.
-export const THEATRE_CRAWL_FRAMES: Keyframe[] = [
-	{transform: `translateY(${THEATRE_LOG_ROW_HEIGHT}px)`},
+// A seek can replace the whole column at once. Sliding that far would be a
+// swipe rather than a crawl, so the shift is capped at what an ordinary step
+// can be — one line, or a line and the day header it brought with it.
+const MAX_CRAWL_ROWS = 2;
+
+// The column slides up by however many rows joined the bottom, rather than the
+// stack jumping. Run off the element for the same reason the card flash is:
+// lines arrive faster than the animation is long, and a restart has to be a
+// restart.
+export const crawlShiftFrames = (rows: number): Keyframe[] => [
+	{
+		transform: `translateY(${
+			Math.min(rows, MAX_CRAWL_ROWS) * THEATRE_LOG_ROW_HEIGHT
+		}px)`,
+	},
 	{transform: 'translateY(0)'},
 ];
 

--- a/source/gui/client/lib/theatre.ts
+++ b/source/gui/client/lib/theatre.ts
@@ -127,6 +127,26 @@ export const playbackPosition = (progress: number): number =>
 export const seekTimeFor = (plan: TheatrePlan, cursor: number): number =>
 	cursor < 0 ? plan.startTime : plan.events[cursor]!.t + 1;
 
+// How many played events the log holds. It is a cap on the DOM as much as on
+// the reading: rows above this have scrolled up out of the fade, and keeping
+// them mounted would grow the overlay by one node per event for the length of
+// the movie.
+export const THEATRE_LOG_LINES = 24;
+
+// The tail of what has played, oldest first. Sliced off the plan rather than
+// accumulated as events land: a seek has to take the log with it, backwards as
+// readily as forwards, and a slice of the script is already exactly that.
+export const theatreLogEntries = (
+	plan: TheatrePlan,
+	cursor: number,
+): TheatreEvent[] =>
+	cursor < 0
+		? []
+		: plan.events.slice(
+				Math.max(0, cursor - THEATRE_LOG_LINES + 1),
+				cursor + 1,
+		  );
+
 export type TheatrePlayback = {
 	// [0..1], off the local clock rather than the events applied, so the bar
 	// glides through quiet stretches instead of waiting on the next round trip.
@@ -311,8 +331,8 @@ export const useTheatrePlayback = ({
 // is up. The flash is what marks the ticket an event just landed on.
 export const THEATRE_KEYFRAMES = `
 @keyframes epiqTheatreRise {
-	from { opacity: 0; transform: translate(-50%, 18px); }
-	to { opacity: 1; transform: translate(-50%, 0); }
+	from { opacity: 0; transform: translateY(100%); }
+	to { opacity: 1; transform: translateY(0); }
 }
 @keyframes epiqTheatreFade {
 	from { opacity: 0; }
@@ -326,10 +346,15 @@ export const THEATRE_KEYFRAMES = `
 	from { opacity: 0; transform: scale(0.96); }
 	to { opacity: 1; transform: scale(1); }
 }
+@keyframes epiqTheatreLogLine {
+	from { opacity: 0; }
+	to { opacity: 1; }
+}
 @media (prefers-reduced-motion: reduce) {
-	@keyframes epiqTheatreRise { from { opacity: 1; transform: translate(-50%, 0); } to { opacity: 1; transform: translate(-50%, 0); } }
+	@keyframes epiqTheatreRise { from { opacity: 1; transform: none; } to { opacity: 1; transform: none; } }
 	@keyframes epiqTheatreCardIn { from { opacity: 1; } to { opacity: 1; } }
 	@keyframes epiqTheatreCaption { from { opacity: 1; } to { opacity: 1; } }
+	@keyframes epiqTheatreLogLine { from { opacity: 1; } to { opacity: 1; } }
 }
 `;
 
@@ -351,5 +376,28 @@ export const THEATRE_FLASH_FRAMES: Keyframe[] = [
 
 export const THEATRE_FLASH_TIMING: KeyframeAnimationOptions = {
 	duration: 900,
+	easing: 'ease-out',
+};
+
+// The height of the player's drawer. The board and the log panel both give it
+// up rather than running underneath and playing their last rows behind the
+// transport, so the two have to read it from one place.
+export const THEATRE_PLAYER_CLEARANCE = 80;
+
+// One row of the log, which is what the whole column shifts by as a line
+// arrives. Fixed rather than measured: every row is one clipped line, so the
+// shift is the same every time and the crawl stays even.
+export const THEATRE_LOG_ROW_HEIGHT = 18;
+
+// The column slides up by a row as each line lands, rather than the stack
+// jumping. Run off the element for the same reason the card flash is: lines
+// arrive faster than the animation is long, and a restart has to be a restart.
+export const THEATRE_CRAWL_FRAMES: Keyframe[] = [
+	{transform: `translateY(${THEATRE_LOG_ROW_HEIGHT}px)`},
+	{transform: 'translateY(0)'},
+];
+
+export const THEATRE_CRAWL_TIMING: KeyframeAnimationOptions = {
+	duration: 220,
 	easing: 'ease-out',
 };

--- a/source/lib/command-line/commands/replay-engine.ts
+++ b/source/lib/command-line/commands/replay-engine.ts
@@ -8,6 +8,7 @@ import {
 } from '../../event/event-materialize.js';
 import {Mode} from '../../model/action-map.model.js';
 import {isFail} from '../../model/result-types.js';
+import {buildPlaybackFractions} from '../../utils/playback-pacing.js';
 import {getState, patchState} from '../../state/state.js';
 
 // Target frame rate for the movie.
@@ -61,28 +62,6 @@ const finishReplay = (): void => {
 		// handed control back (replay starts with nothing selected).
 		selectedIndex: 0,
 	});
-};
-
-// Build the normalized [0..1] position at which each event should have played.
-// Inter-event gaps are weighted by their square root so long idle stretches
-// compress (a month-long gap costs far less than 30 day-long ones) while bursts
-// of rapid edits keep their relative spacing — quiet periods fast-forward,
-// crunch weeks burst. Falls back to even spacing when timestamps are identical.
-const buildPlaybackFractions = (times: number[]): number[] => {
-	const cumulative: number[] = [];
-	let acc = 0;
-
-	for (let i = 0; i < times.length; i++) {
-		const gap = i === 0 ? 0 : Math.max(0, times[i]! - times[i - 1]!);
-		acc += Math.sqrt(gap);
-		cumulative[i] = acc;
-	}
-
-	const total = acc;
-
-	return cumulative.map((value, i) =>
-		total > 0 ? value / total : (i + 1) / times.length,
-	);
 };
 
 // Drive the forward replay. `events` are the (causally ordered) events that

--- a/source/lib/utils/date.utils.ts
+++ b/source/lib/utils/date.utils.ts
@@ -31,6 +31,11 @@ export const formatDateTime = (date: Date): string =>
 	`${pad(date.getHours())}:` +
 	`${pad(date.getMinutes())}`;
 
+// Only the day, for a list that marks where one ends and prints the clock alone
+// against every line inside it.
+export const formatDate = (date: Date): string =>
+	`${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+
 // Only the clock, for the second half of an interval that stays inside one day.
 export const formatTimeOfDay = (date: Date): string =>
 	`${pad(date.getHours())}:${pad(date.getMinutes())}`;

--- a/source/lib/utils/playback-pacing.ts
+++ b/source/lib/utils/playback-pacing.ts
@@ -1,0 +1,25 @@
+// How a stretch of history is paced when it is played back as a movie. Shared
+// by the TUI's replay engine and the GUI's theatre player so a board's history
+// runs at the same tempo whichever one is watching it.
+
+// Build the normalized [0..1] position at which each event should have played.
+// Inter-event gaps are weighted by their square root so long idle stretches
+// compress (a month-long gap costs far less than 30 day-long ones) while bursts
+// of rapid edits keep their relative spacing — quiet periods fast-forward,
+// crunch weeks burst. Falls back to even spacing when timestamps are identical.
+export const buildPlaybackFractions = (times: number[]): number[] => {
+	const cumulative: number[] = [];
+	let acc = 0;
+
+	for (let i = 0; i < times.length; i++) {
+		const gap = i === 0 ? 0 : Math.max(0, times[i]! - times[i - 1]!);
+		acc += Math.sqrt(gap);
+		cumulative[i] = acc;
+	}
+
+	const total = acc;
+
+	return cumulative.map((value, i) =>
+		total > 0 ? value / total : (i + 1) / times.length,
+	);
+};

--- a/source/test/e2e-gui/theatre.pw.ts
+++ b/source/test/e2e-gui/theatre.pw.ts
@@ -176,6 +176,53 @@ test('the transport pauses and resumes, and the movie ends on a full bar', async
 	expect(pageErrors).toEqual([]);
 });
 
+// The crawl is a slice of the script, not a list grown as events land, which
+// is what keeps a long movie from adding a node per event to the overlay.
+test('the pop-out puts the log over the board, capped at what it can show', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await openBoard(page, appUrl);
+	await page.getByTestId('theatre-play').click();
+
+	const log = page.getByTestId('theatre-log');
+	await expect(log).toHaveCount(0);
+
+	const toggle = page.getByTestId('theatre-log-toggle');
+	await toggle.click();
+	await expect(log).toBeVisible();
+	await expect(toggle).toHaveAttribute('aria-pressed', 'true');
+
+	// Lines arrive as the movie plays. That they stay capped however long it
+	// runs is theatre.test.ts's job — this only holds that the cap is a real
+	// bound on the document rather than on the reading alone.
+	const lines = page.getByTestId('theatre-log-line');
+	await expect.poll(async () => await lines.count()).toBeGreaterThan(1);
+	expect(await lines.count()).toBeLessThanOrEqual(30);
+
+	// The day each run of lines belongs to is called once above them, rather
+	// than repeated on every line.
+	await expect(page.getByTestId('theatre-log-day').first()).toBeVisible();
+
+	// A panel, not a wash over the board: it takes its own width and the first
+	// swimlane starts to the right of where it ends.
+	const logBox = (await log.boundingBox())!;
+	const lane = (await page
+		.getByTestId('swimlane-handle')
+		.first()
+		.boundingBox())!;
+
+	expect(logBox.width).toBeGreaterThan(100);
+	expect(lane.x).toBeGreaterThanOrEqual(logBox.x + logBox.width);
+
+	await toggle.click();
+	await expect(log).toHaveCount(0);
+
+	await returnToLive(page);
+	expect(pageErrors).toEqual([]);
+});
+
 test('closing the player hands the board back, live and editable', async ({
 	page,
 	appUrl,

--- a/source/test/e2e-gui/theatre.pw.ts
+++ b/source/test/e2e-gui/theatre.pw.ts
@@ -1,0 +1,217 @@
+import type {Page} from '@playwright/test';
+import {expect, test} from './fixtures.js';
+
+// The suite shares one server, and a board left parked in the past never
+// finishes loading for the next test.
+const returnToLive = async (page: Page) => {
+	const exit = page.getByTestId('theatre-exit');
+	// The one button reads "Resume" while the board is in the past and "Now"
+	// once it is back, so the label is what says where it got to.
+	const now = page.getByRole('button', {name: 'Now', exact: true});
+	const resume = page.getByRole('button', {name: 'Resume', exact: true});
+
+	if ((await exit.count()) > 0) await exit.click();
+
+	// Pressed until it takes, rather than asked once: a request for live is a
+	// message like any other and a socket replaced under it drops it silently,
+	// which would leave the board parked in the past for the rest of the file.
+	await expect(async () => {
+		if (await now.isVisible()) return;
+		// Bounded: the button relabels itself to "Now" the moment live lands, and
+		// an unbounded click on the old label would sit out the whole retry
+		// budget waiting for an element that has already become the answer.
+		if (await resume.isVisible()) await resume.click({timeout: 1_000});
+
+		await expect(now).toBeVisible({timeout: 2_000});
+	}).toPass({timeout: 20_000});
+};
+
+const openBoard = async (page: Page, appUrl: string) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+};
+
+test('the play button opens a player over a dimmed board', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await openBoard(page, appUrl);
+
+	const play = page.getByTestId('theatre-play');
+	await expect(play).toBeEnabled();
+	await play.click();
+
+	const player = page.getByTestId('theatre-player');
+	await expect(player).toBeVisible();
+	await expect(page.getByTestId('theatre-vignette')).toBeVisible();
+
+	// The transport opens playing, so the first thing it offers is a pause.
+	await expect(page.getByTestId('theatre-toggle')).toHaveAttribute(
+		'aria-label',
+		'Pause',
+	);
+
+	await returnToLive(page);
+	expect(pageErrors).toEqual([]);
+});
+
+// The whole point of standing it down: two controls for one position fight
+// over it, and the one the movie is not driving wins the last word.
+test('the scrubber stands down while the player is up', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await openBoard(page, appUrl);
+
+	const track = page.getByTestId('scrubber-track');
+	const box = await track.boundingBox();
+	if (!box) throw new Error('scrubber track is not on screen');
+
+	await page.getByTestId('theatre-play').click();
+	await expect(page.getByTestId('theatre-player')).toBeVisible();
+
+	// The bar is faded and takes no pointer at all, so a click aimed at the
+	// track lands on nothing rather than checking the board out somewhere else.
+	await expect(track).toHaveCSS('pointer-events', 'none');
+	await expect(page.getByRole('button', {name: 'Week', exact: true})).toHaveCSS(
+		'pointer-events',
+		'none',
+	);
+
+	await returnToLive(page);
+	expect(pageErrors).toEqual([]);
+});
+
+// The movie is a checkout per event. If the clock did not wait on the server's
+// answer, a long history would put hundreds of unanswered ones on the socket.
+test('never asks for a second checkout before the first is answered', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	let inFlight = 0;
+	let overlapped = false;
+
+	await page.routeWebSocket(/\/ws/, ws => {
+		const server = ws.connectToServer();
+
+		ws.onMessage(message => {
+			if (
+				typeof message === 'string' &&
+				message.includes('"type":"time-travel:scrub"')
+			) {
+				inFlight += 1;
+				if (inFlight > 1) overlapped = true;
+			}
+
+			server.send(message);
+		});
+
+		server.onMessage(message => {
+			if (
+				typeof message === 'string' &&
+				message.includes('"type":"time-travel:result"')
+			) {
+				inFlight = Math.max(0, inFlight - 1);
+			}
+
+			ws.send(message);
+		});
+	});
+
+	await openBoard(page, appUrl);
+	await page.getByTestId('theatre-play').click();
+	await expect(page.getByTestId('theatre-player')).toBeVisible();
+
+	// Long enough for a short seeded history to play most of the way through.
+	await page.waitForTimeout(6000);
+
+	expect(overlapped).toBe(false);
+
+	await returnToLive(page);
+	expect(pageErrors).toEqual([]);
+});
+
+test('the transport pauses and resumes, and the movie ends on a full bar', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await openBoard(page, appUrl);
+	await page.getByTestId('theatre-play').click();
+
+	const toggle = page.getByTestId('theatre-toggle');
+	const bar = page.getByTestId('theatre-progress');
+
+	await toggle.click();
+	await expect(toggle).toHaveAttribute('aria-label', 'Play');
+
+	const paused = await bar.getAttribute('aria-valuenow');
+	await page.waitForTimeout(600);
+	expect(await bar.getAttribute('aria-valuenow')).toBe(paused);
+
+	await toggle.click();
+	await expect(toggle).toHaveAttribute('aria-label', 'Pause');
+	await expect
+		.poll(async () => Number(await bar.getAttribute('aria-valuenow')))
+		.toBeGreaterThan(Number(paused));
+
+	// Dragged to the end rather than waited out: how long the movie runs is a
+	// property of the seeded window, and the end is what this is about. The
+	// transport says so by offering to play it again.
+	const box = await bar.boundingBox();
+	if (!box) throw new Error('the player bar is not on screen');
+
+	await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+	await page.mouse.down();
+	await page.mouse.move(box.x + box.width + 40, box.y + box.height / 2);
+	await page.mouse.up();
+
+	await expect(bar).toHaveAttribute('aria-valuenow', '100');
+	await expect(toggle).toHaveAttribute('aria-label', 'Play again');
+
+	await returnToLive(page);
+	expect(pageErrors).toEqual([]);
+});
+
+test('closing the player hands the board back, live and editable', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await openBoard(page, appUrl);
+	await page.getByTestId('theatre-play').click();
+	await expect(page.getByTestId('theatre-player')).toBeVisible();
+
+	await page.getByTestId('theatre-exit').click();
+
+	await expect(page.getByTestId('theatre-player')).toHaveCount(0);
+	await expect(page.getByTestId('theatre-vignette')).toHaveCount(0);
+	await expect(
+		page.getByRole('button', {name: 'Now', exact: true}),
+	).toBeVisible();
+	await expect(page.getByTestId('scrubber-track')).not.toHaveCSS(
+		'pointer-events',
+		'none',
+	);
+
+	expect(pageErrors).toEqual([]);
+});
+
+test('escape leaves the player', async ({page, appUrl, pageErrors}) => {
+	await openBoard(page, appUrl);
+	await page.getByTestId('theatre-play').click();
+	await expect(page.getByTestId('theatre-player')).toBeVisible();
+
+	await page.keyboard.press('Escape');
+
+	// Escape is the way out, and the way out hands the board back.
+	await expect(page.getByTestId('theatre-player')).toHaveCount(0);
+	await expect(
+		page.getByRole('button', {name: 'Now', exact: true}),
+	).toBeVisible();
+
+	expect(pageErrors).toEqual([]);
+});


### PR DESCRIPTION
Theatre mode for the GUI: press play and the board's history runs as a movie.

The room lights go down — topbar, scrubber controls, board toolbar and detail panel dim and stand down — and a drawer rises from the foot of the window with a transport, a seekable bar, the moment being played, an edit counter and the caption of the event that just landed. The board is the picture: cards arrive with an entrance and the ticket each event touched flashes. A pop-out on the caption opens the log as a panel down the left, one timestamped line per event, crawling up and dissolving off the top.

## How it works

No new server path and no new message type. The scrubber already holds the window's events, so a local clock walks them and each one it reaches checks the board out with the same `time-travel:scrub` a needle drag sends — back-pressured on `time-travel:result`, so exactly one checkout is ever in flight and events passed meanwhile coalesce into the next. Progress runs off the local clock, so the bar is smooth regardless of round-trip time.

The √gap pacing moved out of the TUI's `replay-engine.ts` into `source/lib/utils/playback-pacing.ts`, which both engines now import — a quiet month fast-forwards and a busy week keeps its spacing, identically in the terminal and the browser.

The scrubber is disabled while the player is up: two controls for one position compete. Its charts stay lit and its needle keeps following, so the timeline still shows where the movie is.

## Worth a reviewer's eye

- The single-flight protocol in `useTheatrePlayback` — effect declaration order is load-bearing, so the ack that clears the in-flight flag and the dispatch that acts on it land in the same commit.
- The clock lives in a ref, never re-read from state on render: the board re-renders on every frame of the movie, and a render landing between a frame's write and its commit would drag the clock back each time.
- Animation frames are capped at 100ms of playback each, so a movie left in a background tab resumes where it was rather than fast-forwarding to the end and firing a checkout per event on the way.
- The log's rows are a slice of the plan taken against the playhead, not a list grown as events arrive: it follows a seek backwards, and nothing above the fade is in the document.

## Verified

1085 unit tests, 118 GUI e2e — on the rebased tree, not the pre-rebase one. 23 new unit tests (`source/gui/client/lib/theatre.test.ts`) and 7 new browser tests (`source/test/e2e-gui/theatre.pw.ts`).

A `/code-review high` pass found four issues, all fixed here: the log stacking above the board instead of beside it for anyone with the detail panel docked to the bottom; the crawl stepping at every day boundary because a day header makes the column grow by two rows, not one; a document keydown listener rebound sixty times a second; and Space being swallowed from the player's own buttons, leaving them unreachable by keyboard.
