### PR TITLE
J44D2XS DXGX61V The event log becomes the board's own, and carries the commits

### DIFF
--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -39,7 +39,7 @@ import {TicketRefLinksProvider} from './components/MarkdownContent';
 import {ErrorToast} from './components/ErrorToast';
 import {TimeScrubber} from './components/TimeScrubber';
 import {TheatrePlayer} from './components/TheatrePlayer';
-import {TheatreLog} from './components/TheatreLog';
+import {EventLog} from './components/EventLog';
 import {useAsideDock} from './lib/aside-dock';
 import {moveIssue} from './lib/gui-move-issue';
 import {reconnectDelayMs} from './lib/reconnect';
@@ -65,6 +65,7 @@ import {
 	GuiRefCommitEntry,
 	GuiContributor,
 	GuiEventTimeline,
+	GuiEventTimelineEntry,
 	GuiState,
 	GuiSwimlane,
 	GuiUser,
@@ -73,15 +74,16 @@ import {
 	buildBoardFilter,
 	isPeriodWindow,
 	issuePassesBoardFilter,
+	usePersistedFlag,
 	windowIssueIds,
 } from './lib/scrubber';
 import {
 	buildTheatrePlan,
 	THEATRE_PLAYER_CLEARANCE,
 	TheatrePlan,
-	theatreLogEntries,
 	useTheatrePlayback,
 } from './lib/theatre';
+import {logEntriesUpTo} from './lib/event-log';
 import {Input} from './components/FormPrimitives';
 import {useBoardSelection} from './lib/use-board-selection';
 import {sendSocketJson} from './lib/socket-send';
@@ -98,8 +100,16 @@ type IssueDetailsTab = 'overview' | 'comments' | 'history' | 'code';
 // on every render.
 const EMPTY_COMMENTS: GuiState['commentsByIssueId'] = {};
 
+// Module scope for the same reason: a shut log must not hand the memo below a
+// new array on every render.
+const EMPTY_LOG_EVENTS: GuiEventTimelineEntry[] = [];
+
 // The board's page margin, matching the left padding on <main>.
 const BOARD_GUTTER = 30;
+
+// Remembered beside the scrubber's own view flags, which is what its checkbox
+// sits among.
+const LOG_STORAGE_KEY = 'epiq.timeScrubber.showLog';
 
 // What the chrome around the board wears while a movie plays. Faded rather than
 // unmounted: the page must not reflow around the picture being watched.
@@ -174,9 +184,10 @@ export const App = () => {
 	// Bumped per answered time-travel request. The player's clock waits on it
 	// rather than stacking a checkout on one the server has not answered yet.
 	const [scrubAck, setScrubAck] = useState(0);
-	// The log panel is open. Owned here rather than in the player: it is a panel
-	// in the board's own row, and the board moves over for it.
-	const [theatreLogOpen, setTheatreLogOpen] = useState(false);
+	// The log panel is open. Owned here rather than in the scrubber or the
+	// player: it is a panel in the board's own row, the board moves over for it,
+	// and its checkbox and the player's pop-out are two controls over one flag.
+	const [logOpen, setLogOpen] = usePersistedFlag(LOG_STORAGE_KEY, false);
 	const [commitDiff, setCommitDiff] = useState<{
 		sha: string;
 		loading: boolean;
@@ -1167,6 +1178,26 @@ export const App = () => {
 		onSeek: scrubToTime,
 	});
 
+	// The window in clock order, which is not the order the log stores it in.
+	// Sorted once per window rather than per render, and not at all while the
+	// panel is shut.
+	const logEvents = useMemo(() => {
+		if (!logOpen) return EMPTY_LOG_EVENTS;
+
+		return [...(history.timeline?.events ?? [])].sort(
+			(left, right) => left.t - right.t,
+		);
+	}, [logOpen, history.timeline]);
+
+	// Where the board is standing, which is the only thing the three cases
+	// differ by: the playhead while a movie runs, the checkout while the needle
+	// is parked, and the present while live.
+	const logMoment = theatre
+		? playback.current?.t ?? -Infinity
+		: state?.timeTravel?.mode === 'scrub' && state.timeTravel.asOfTime !== null
+		? state.timeTravel.asOfTime
+		: Infinity;
+
 	// A movie is checked out one frame at a time over the socket, so a dropped
 	// one leaves the player running against nothing. It closes rather than
 	// stalling; the board is already parked wherever the last frame landed, and
@@ -1712,6 +1743,8 @@ export const App = () => {
 					onReturnToLive={returnToLive}
 					onPlayTheatre={startTheatre}
 					theatreOpen={theatre !== null}
+					logOpen={logOpen}
+					onChangeLogOpen={setLogOpen}
 					selection={selection}
 					onChangeSelection={changeSelection}
 					selectedIssue={
@@ -1754,9 +1787,10 @@ export const App = () => {
 							overflow: 'hidden',
 						}}
 					>
-						{theatre && theatreLogOpen && (
-							<TheatreLog
-								entries={theatreLogEntries(theatre, playback.cursor)}
+						{logOpen && (
+							<EventLog
+								entries={logEntriesUpTo(logEvents, logMoment)}
+								bottomClearance={theatre ? THEATRE_PLAYER_CLEARANCE : 0}
 							/>
 						)}
 
@@ -2090,8 +2124,8 @@ export const App = () => {
 					<TheatrePlayer
 						plan={theatre}
 						playback={playback}
-						logOpen={theatreLogOpen}
-						onToggleLog={() => setTheatreLogOpen(open => !open)}
+						logOpen={logOpen}
+						onToggleLog={() => setLogOpen(!logOpen)}
 						onExit={exitTheatre}
 					/>
 				)}

--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -1753,9 +1753,15 @@ export const App = () => {
 							: null
 					}
 					knownIdentities={knownIdentities}
-					// Not while a movie plays: the window would be re-fetched on every
-					// frame, and the plan is drawn from it.
-					refreshOn={selection.windowOnly && !theatre ? state : null}
+					// The log reads the window, so a swimlane or ticket made while it
+					// is open has to reach it — the board's own broadcast is what says
+					// there is something new to fetch.
+					//
+					// Not while a movie plays: the state changes on every frame of one,
+					// and the window it is drawn from must not move underneath it.
+					refreshOn={
+						(selection.windowOnly || logOpen) && !theatre ? state : null
+					}
 				/>
 
 				{/* Dimmed while offline so the board reads as inert. The topbar stays at

--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -1957,10 +1957,14 @@ export const App = () => {
 							tracking it live: the panel — and any drag — isn't mounted while
 							this spacer is, so the last-persisted value is always current.
 							Only for a side dock: a bottom panel takes height, not width, so
-							reserving width for it would shove the board the other way. */}
+							reserving width for it would shove the board the other way.
+
+							A film closes every one of those panels, so the width has to be
+							reserved for that too — or pressing play over a board scrolled
+							hard right bounces it back by the panel's width. */}
 								{asideDock === 'right' &&
-									!commitDiff &&
-									!(selectedIssue && state?.user) && (
+									(theatre ||
+										(!commitDiff && !(selectedIssue && state?.user))) && (
 										<div
 											style={{width: readStoredAsideWidth(), flexShrink: 0}}
 										/>

--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -65,7 +65,6 @@ import {
 	GuiRefCommitEntry,
 	GuiContributor,
 	GuiEventTimeline,
-	GuiEventTimelineEntry,
 	GuiState,
 	GuiSwimlane,
 	GuiUser,
@@ -83,7 +82,7 @@ import {
 	TheatrePlan,
 	useTheatrePlayback,
 } from './lib/theatre';
-import {logEntriesUpTo} from './lib/event-log';
+import {buildLogEntries, LogEntry, logEntriesUpTo} from './lib/event-log';
 import {Input} from './components/FormPrimitives';
 import {useBoardSelection} from './lib/use-board-selection';
 import {sendSocketJson} from './lib/socket-send';
@@ -102,7 +101,7 @@ const EMPTY_COMMENTS: GuiState['commentsByIssueId'] = {};
 
 // Module scope for the same reason: a shut log must not hand the memo below a
 // new array on every render.
-const EMPTY_LOG_EVENTS: GuiEventTimelineEntry[] = [];
+const EMPTY_LOG_ROWS: LogEntry[] = [];
 
 // The board's page margin, matching the left padding on <main>.
 const BOARD_GUTTER = 30;
@@ -1178,16 +1177,14 @@ export const App = () => {
 		onSeek: scrubToTime,
 	});
 
-	// The window in clock order, which is not the order the log stores it in.
-	// Sorted once per window rather than per render, and not at all while the
-	// panel is shut.
-	const logEvents = useMemo(() => {
-		if (!logOpen) return EMPTY_LOG_EVENTS;
+	// Both series of the window in one column, in clock order — which is not the
+	// order the log stores either of them in. Built once per window rather than
+	// per render, and not at all while the panel is shut.
+	const logRows = useMemo(() => {
+		if (!logOpen) return EMPTY_LOG_ROWS;
 
-		return [...(history.timeline?.events ?? [])].sort(
-			(left, right) => left.t - right.t,
-		);
-	}, [logOpen, history.timeline]);
+		return buildLogEntries(history.timeline?.events ?? [], history.commits);
+	}, [logOpen, history.timeline, history.commits]);
 
 	// Where the board is standing, which is the only thing the three cases
 	// differ by: the playhead while a movie runs, the checkout while the needle
@@ -1795,7 +1792,7 @@ export const App = () => {
 					>
 						{logOpen && (
 							<EventLog
-								entries={logEntriesUpTo(logEvents, logMoment)}
+								entries={logEntriesUpTo(logRows, logMoment)}
 								bottomClearance={theatre ? THEATRE_PLAYER_CLEARANCE : 0}
 							/>
 						)}

--- a/source/gui/client/components/EventLog.tsx
+++ b/source/gui/client/components/EventLog.tsx
@@ -12,14 +12,16 @@
 
 import {useEffect, useRef} from 'react';
 import {
-	formatDate,
+	formatDayLabel,
 	formatTimeOfDay,
+	formatWeekday,
 	isSameDay,
 } from '../../../lib/utils/date.utils.js';
 import {
 	crawlShiftFrames,
 	CRAWL_TIMING,
 	EVENT_LOG_KEYFRAMES,
+	LogEntry,
 	LOG_ROW_HEIGHT,
 } from '../lib/event-log';
 import {GUI_THEME, TEXT} from '../lib/gui-theme';
@@ -38,18 +40,25 @@ const CRAWL_MASK = `linear-gradient(to bottom, transparent 0, #000 ${
 	FADE_ROWS * LOG_ROW_HEIGHT
 }px)`;
 
-// What the panel needs of an event. Structural, so both the timeline's own rows
-// and a movie's cut-down ones satisfy it without either being converted.
-export type EventLogRow = {id: string; t: number; label: string};
+// A few pixels across, and no more: it marks a line's kind without becoming
+// the thing the eye lands on.
+const DOT_SIZE = 5;
+
+const dividerRuleStyle: React.CSSProperties = {
+	flex: 1,
+	height: 1,
+	alignSelf: 'center',
+	background: GUI_THEME.line,
+};
 
 // The clock alone against each line, with the day called once above the lines
 // that share it — a full date on all of them is the same ten characters twenty
 // times over.
 type Row =
 	| {kind: 'day'; key: string; label: string}
-	| {kind: 'event'; key: string; time: string; label: string};
+	| {kind: 'event'; key: string; time: string; label: string; color: string};
 
-const toRows = (entries: readonly EventLogRow[]): Row[] => {
+const toRows = (entries: readonly LogEntry[]): Row[] => {
 	const rows: Row[] = [];
 	let previous: Date | null = null;
 
@@ -57,14 +66,22 @@ const toRows = (entries: readonly EventLogRow[]): Row[] => {
 		const at = new Date(entry.t);
 
 		if (!previous || !isSameDay(previous, at)) {
-			rows.push({kind: 'day', key: `day-${entry.id}`, label: formatDate(at)});
+			rows.push({
+				kind: 'day',
+				key: `day-${entry.id}`,
+				label: formatDayLabel(at),
+			});
 		}
 
 		rows.push({
 			kind: 'event',
 			key: entry.id,
-			time: formatTimeOfDay(at),
+			// The weekday against every line, not only against the day it opens:
+			// the header scrolls off the top long before the lines under it do,
+			// and a bare clock says nothing about which day it belongs to.
+			time: `${formatWeekday(at)} ${formatTimeOfDay(at)}`,
 			label: entry.label,
+			color: entry.color,
 		});
 
 		previous = at;
@@ -77,7 +94,7 @@ export const EventLog = ({
 	entries,
 	bottomClearance,
 }: {
-	entries: readonly EventLogRow[];
+	entries: readonly LogEntry[];
 	// Room to leave at the foot of the column for whatever is floating over it —
 	// the history player's drawer, when one is up. A row past it, because the
 	// crawl starts each line one row low and slides it up.
@@ -168,14 +185,21 @@ export const EventLog = ({
 							}}
 						>
 							{row.kind === 'day' ? (
-								<span
-									style={{
-										color: GUI_THEME.dim,
-										fontVariantNumeric: 'tabular-nums',
-									}}
-								>
-									{row.label}
-								</span>
+								// A rule either side of the day, so it reads as a divider
+								// between one day's lines and the next rather than as another
+								// line of the log.
+								<>
+									<span aria-hidden style={dividerRuleStyle} />
+									<span
+										style={{
+											color: GUI_THEME.dim,
+											flexShrink: 0,
+										}}
+									>
+										{row.label}
+									</span>
+									<span aria-hidden style={dividerRuleStyle} />
+								</>
 							) : (
 								<>
 									<span
@@ -187,6 +211,20 @@ export const EventLog = ({
 									>
 										{row.time}
 									</span>
+									{/* Between the clock and the line, so a run of them makes a
+									    column of its own down the panel. */}
+									<span
+										data-testid="log-dot"
+										aria-hidden
+										style={{
+											width: DOT_SIZE,
+											height: DOT_SIZE,
+											borderRadius: '50%',
+											background: row.color,
+											flexShrink: 0,
+											alignSelf: 'center',
+										}}
+									/>
 									<span
 										style={{
 											color: GUI_THEME.secondary,

--- a/source/gui/client/components/EventLog.tsx
+++ b/source/gui/client/components/EventLog.tsx
@@ -20,7 +20,6 @@ import {
 	crawlShiftFrames,
 	CRAWL_TIMING,
 	EVENT_LOG_KEYFRAMES,
-	LOG_LINES,
 	LOG_ROW_HEIGHT,
 } from '../lib/event-log';
 import {GUI_THEME, TEXT} from '../lib/gui-theme';
@@ -33,17 +32,7 @@ const LOG_WIDTH = 380;
 // the panel happens to have.
 const FADE_ROWS = 3;
 
-// The box the lines live in, bottom-anchored inside the panel and no taller
-// than a full log. Sized in rows rather than left to fill the panel: the mask
-// below is positioned against this box, so its top edge has to be where the
-// topmost line is and not where the panel begins — or the fade is spent on the
-// empty space above the lines and only bites the first of them.
-//
-// Two rows over the cap, for the day headers a run of lines can carry. Anything
-// past that clips into the fade, which is where it should go anyway.
-const BOX_ROWS = LOG_LINES + 2;
-
-// Dissolves the top of the box so lines leave rather than being cut off. Both
+// Dissolves the top of the pane so lines leave rather than being cut off. Both
 // spellings, since the unprefixed property is not in Safari.
 const CRAWL_MASK = `linear-gradient(to bottom, transparent 0, #000 ${
 	FADE_ROWS * LOG_ROW_HEIGHT
@@ -141,9 +130,12 @@ export const EventLog = ({
 
 			<div
 				style={{
-					height: BOX_ROWS * LOG_ROW_HEIGHT,
-					// Never past the panel, however tall a full log would be.
-					maxHeight: '100%',
+					// The lines run the whole height of the panel and are cut off at
+					// its top, where the fade is. Bounded to the pane rather than to a
+					// row count, so the log reaches the top of whatever height it is
+					// given instead of stopping short in a box of its own.
+					flex: 1,
+					minHeight: 0,
 					display: 'flex',
 					flexDirection: 'column',
 					// Filled from the bottom, so a new line pushes the column up and the

--- a/source/gui/client/components/EventLog.tsx
+++ b/source/gui/client/components/EventLog.tsx
@@ -14,7 +14,6 @@ import {useEffect, useRef} from 'react';
 import {
 	formatDayLabel,
 	formatTimeOfDay,
-	formatWeekday,
 	isSameDay,
 } from '../../../lib/utils/date.utils.js';
 import {
@@ -76,10 +75,10 @@ const toRows = (entries: readonly LogEntry[]): Row[] => {
 		rows.push({
 			kind: 'event',
 			key: entry.id,
-			// The weekday against every line, not only against the day it opens:
-			// the header scrolls off the top long before the lines under it do,
-			// and a bare clock says nothing about which day it belongs to.
-			time: `${formatWeekday(at)} ${formatTimeOfDay(at)}`,
+			// The clock alone: the divider above a run of lines already names the
+			// day they belong to, and repeating it against each of them says the
+			// same thing twenty times.
+			time: formatTimeOfDay(at),
 			label: entry.label,
 			color: entry.color,
 		});

--- a/source/gui/client/components/EventLog.tsx
+++ b/source/gui/client/components/EventLog.tsx
@@ -1,13 +1,14 @@
-// The movie's log: a panel down the left of the board holding one timestamped
-// line per event as it lands, the column sliding up by a row each time and the
-// oldest lines dissolving off the top.
+// The board's event log: a panel down the left holding one timestamped line
+// per event, the column sliding up by a row as each lands and the oldest lines
+// dissolving off the top.
 //
 // A panel rather than a wash over the board — it takes its own width and the
 // board moves over for it, so neither has to be read through the other.
 //
-// The rows are a slice of the script rather than a list grown as events arrive,
-// so what is off the top is not merely invisible — it is not in the document at
-// all, and the panel costs the same at the end of a long movie as at the start.
+// The rows it is handed are a slice taken against the moment the board is
+// standing at, never a list grown as events arrive, so what is off the top is
+// not merely invisible — it is not in the document at all, and the panel costs
+// the same on a year of history as on an hour.
 
 import {useEffect, useRef} from 'react';
 import {
@@ -15,32 +16,52 @@ import {
 	formatTimeOfDay,
 	isSameDay,
 } from '../../../lib/utils/date.utils.js';
-import {GUI_THEME, TEXT} from '../lib/gui-theme';
-import {usePrefersReducedMotion} from '../lib/scrubber';
 import {
 	crawlShiftFrames,
-	THEATRE_CRAWL_TIMING,
-	THEATRE_LOG_ROW_HEIGHT,
-	THEATRE_PLAYER_CLEARANCE,
-	TheatreEvent,
-} from '../lib/theatre';
+	CRAWL_TIMING,
+	EVENT_LOG_KEYFRAMES,
+	LOG_LINES,
+	LOG_ROW_HEIGHT,
+} from '../lib/event-log';
+import {GUI_THEME, TEXT} from '../lib/gui-theme';
+import {usePrefersReducedMotion} from '../lib/scrubber';
 
 const LOG_WIDTH = 380;
 
-// Dissolves the top of the column so lines leave rather than being clipped off.
-// On the column alone, not the panel: the panel keeps its edges. Both spellings,
-// since the unprefixed property is not in Safari.
-const CRAWL_MASK = 'linear-gradient(to bottom, transparent 0%, #000 34%)';
+// How many rows the top of the log dissolves over. Measured in rows rather
+// than as a share of anything, so the fade is the same depth whatever height
+// the panel happens to have.
+const FADE_ROWS = 3;
+
+// The box the lines live in, bottom-anchored inside the panel and no taller
+// than a full log. Sized in rows rather than left to fill the panel: the mask
+// below is positioned against this box, so its top edge has to be where the
+// topmost line is and not where the panel begins — or the fade is spent on the
+// empty space above the lines and only bites the first of them.
+//
+// Two rows over the cap, for the day headers a run of lines can carry. Anything
+// past that clips into the fade, which is where it should go anyway.
+const BOX_ROWS = LOG_LINES + 2;
+
+// Dissolves the top of the box so lines leave rather than being cut off. Both
+// spellings, since the unprefixed property is not in Safari.
+const CRAWL_MASK = `linear-gradient(to bottom, transparent 0, #000 ${
+	FADE_ROWS * LOG_ROW_HEIGHT
+}px)`;
+
+// What the panel needs of an event. Structural, so both the timeline's own rows
+// and a movie's cut-down ones satisfy it without either being converted.
+export type EventLogRow = {id: string; t: number; label: string};
 
 // The clock alone against each line, with the day called once above the lines
 // that share it — a full date on all of them is the same ten characters twenty
 // times over.
-type LogRow =
+type Row =
 	| {kind: 'day'; key: string; label: string}
 	| {kind: 'event'; key: string; time: string; label: string};
 
-const toRows = (entries: TheatreEvent[]): LogRow[] => {
-	const rows: LogRow[] = [];
+const toRows = (entries: readonly EventLogRow[]): Row[] => {
+	const rows: Row[] = [];
 	let previous: Date | null = null;
 
 	for (const entry of entries) {
@@ -63,7 +84,16 @@ const toRows = (entries: TheatreEvent[]): LogRow[] => {
 	return rows;
 };
 
-export const TheatreLog = ({entries}: {entries: TheatreEvent[]}) => {
+export const EventLog = ({
+	entries,
+	bottomClearance,
+}: {
+	entries: readonly EventLogRow[];
+	// Room to leave at the foot of the column for whatever is floating over it —
+	// the history player's drawer, when one is up. A row past it, because the
+	// crawl starts each line one row low and slides it up.
+	bottomClearance: number;
+}) => {
 	const animate = !usePrefersReducedMotion();
 	const columnRef = useRef<HTMLDivElement | null>(null);
 	const rows = toRows(entries);
@@ -84,15 +114,15 @@ export const TheatreLog = ({entries}: {entries: TheatreEvent[]}) => {
 
 		if (!column || !animate || newestId === null || appended === 0) return;
 
-		column.animate(crawlShiftFrames(appended), THEATRE_CRAWL_TIMING);
+		column.animate(crawlShiftFrames(appended), CRAWL_TIMING);
 		// Deliberately keyed on the newest line rather than on `rows`, which is
 		// rebuilt every render: the crawl moves when the log does, not when the
-		// board above it repaints.
+		// board beside it repaints.
 	}, [newestId, animate]);
 
 	return (
 		<aside
-			data-testid="theatre-log"
+			data-testid="event-log"
 			aria-live="off"
 			style={{
 				width: LOG_WIDTH,
@@ -100,26 +130,30 @@ export const TheatreLog = ({entries}: {entries: TheatreEvent[]}) => {
 				minHeight: 0,
 				display: 'flex',
 				flexDirection: 'column',
+				// The lines sit at the foot of the panel, so the newest is always in
+				// the same place however few of them there are.
+				justifyContent: 'flex-end',
 				borderRight: `1px solid ${GUI_THEME.line}`,
 				background: GUI_THEME.panel,
 			}}
 		>
+			<style>{EVENT_LOG_KEYFRAMES}</style>
+
 			<div
 				style={{
-					flex: 1,
-					minHeight: 0,
+					height: BOX_ROWS * LOG_ROW_HEIGHT,
+					// Never past the panel, however tall a full log would be.
+					maxHeight: '100%',
 					display: 'flex',
 					flexDirection: 'column',
 					// Filled from the bottom, so a new line pushes the column up and the
 					// oldest one off the top into the fade.
 					justifyContent: 'flex-end',
 					overflow: 'hidden',
-					// A row's worth past the drawer: the crawl starts each line one
-					// row low and slides it up, and at rest against the drawer that
-					// slide would run the newest line in behind it.
-					padding: `0 14px ${
-						THEATRE_PLAYER_CLEARANCE + THEATRE_LOG_ROW_HEIGHT
-					}px 30px`,
+					// The clearance keeps the lines off whatever floats over the foot of
+					// the board; the two rows past it are what the crawl slides through
+					// on its way up, which would otherwise be clipped as it went.
+					padding: `0 14px ${bottomClearance + LOG_ROW_HEIGHT * 2}px 30px`,
 					maskImage: CRAWL_MASK,
 					WebkitMaskImage: CRAWL_MASK,
 				}}
@@ -128,21 +162,17 @@ export const TheatreLog = ({entries}: {entries: TheatreEvent[]}) => {
 					{rows.map(row => (
 						<div
 							key={row.key}
-							data-testid={
-								row.kind === 'day' ? 'theatre-log-day' : 'theatre-log-line'
-							}
+							data-testid={row.kind === 'day' ? 'log-day' : 'log-line'}
 							style={{
 								display: 'flex',
 								gap: 10,
-								height: THEATRE_LOG_ROW_HEIGHT,
-								lineHeight: `${THEATRE_LOG_ROW_HEIGHT}px`,
+								height: LOG_ROW_HEIGHT,
+								lineHeight: `${LOG_ROW_HEIGHT}px`,
 								fontSize: TEXT.meta,
 								// One clipped line each, which is what makes the crawl even:
 								// every row is the height the column slides by.
 								whiteSpace: 'nowrap',
-								animation: animate
-									? 'epiqTheatreLogLine 260ms ease-out'
-									: undefined,
+								animation: animate ? 'epiqLogLine 260ms ease-out' : undefined,
 							}}
 						>
 							{row.kind === 'day' ? (

--- a/source/gui/client/components/ScrubberLayout.tsx
+++ b/source/gui/client/components/ScrubberLayout.tsx
@@ -130,7 +130,10 @@ export const ScrubberLayout = ({
 	collapsed,
 	onToggleCollapsed,
 	canPlay,
+	playTitle,
 	onPlay,
+	logOpen,
+	onChangeLogOpen,
 	standDown,
 	controls,
 	chart,
@@ -138,7 +141,11 @@ export const ScrubberLayout = ({
 	collapsed: boolean;
 	onToggleCollapsed: () => void;
 	canPlay: boolean;
+	playTitle: string;
 	onPlay: () => void;
+	// The event log panel, switched here and from the player's own pop-out.
+	logOpen: boolean;
+	onChangeLogOpen: (next: boolean) => void;
 	// The history player is up and owns the board's position. Nothing on the bar
 	// answers a pointer while it is, but only the controls dim for it: the charts
 	// are part of what is being watched — the needle sweeps them as the movie
@@ -191,7 +198,10 @@ export const ScrubberLayout = ({
 						collapsed={collapsed}
 						onToggleCollapsed={onToggleCollapsed}
 						canPlay={canPlay}
+						playTitle={playTitle}
 						onPlay={onPlay}
+						logOpen={logOpen}
+						onChangeLogOpen={onChangeLogOpen}
 					/>
 
 					{collapsed ? (

--- a/source/gui/client/components/ScrubberParts.tsx
+++ b/source/gui/client/components/ScrubberParts.tsx
@@ -522,7 +522,6 @@ export const ScrubberControls = ({
 	atLatest,
 	windowOnly,
 	windowFilterable,
-	logOpen,
 	ticketOnly,
 	ticketSelected,
 	ticketFocus,
@@ -541,7 +540,6 @@ export const ScrubberControls = ({
 	onChangeScope,
 	onChangeOffset,
 	onChangeWindowOnly,
-	onChangeLogOpen,
 	onChangeTicketOnly,
 	onChangeLayoutMode,
 	onChangeShowIssues,
@@ -567,8 +565,6 @@ export const ScrubberControls = ({
 	atLatest: boolean;
 	// The board is narrowed to the tickets this window has an event for.
 	windowOnly: boolean;
-	// The event log panel is on the board.
-	logOpen: boolean;
 	// False where the window came back as counts alone, naming no tickets to
 	// narrow to.
 	windowFilterable: boolean;
@@ -595,7 +591,6 @@ export const ScrubberControls = ({
 	onChangeScope: (scope: Scope) => void;
 	onChangeOffset: (offset: number) => void;
 	onChangeWindowOnly: (next: boolean) => void;
-	onChangeLogOpen: (next: boolean) => void;
 	onChangeTicketOnly: (next: boolean) => void;
 	onChangeLayoutMode: (mode: LayoutMode) => void;
 	onChangeShowIssues: (next: boolean) => void;
@@ -755,19 +750,6 @@ export const ScrubberControls = ({
 			</div>
 
 			<div style={{display: 'flex', gap: 12, alignItems: 'center'}}>
-				{/* First in the row, ahead of the narrowings further along it: this
-			    one hides no ticket and changes no window. It puts a panel on the
-			    board, which is a different kind of thing from everything else
-			    here, so it stands at the head rather than among them.
-
-			    It asks the socket for nothing — the window it lists is already on
-			    screen — so it stays usable offline, as the narrowings do. */}
-				<Checkbox
-					label={LOG_LABEL}
-					title="Show the event log down the left of the board"
-					checked={logOpen}
-					onChange={onChangeLogOpen}
-				/>
 				<Checkbox
 					label="Code"
 					checked={showCommits}
@@ -901,13 +883,22 @@ export const ScrubberHeader = ({
 	collapsed,
 	onToggleCollapsed,
 	canPlay,
+	playTitle,
 	onPlay,
+	logOpen,
+	onChangeLogOpen,
 }: {
 	collapsed: boolean;
 	onToggleCollapsed: () => void;
-	// False where the window holds too little to play, or the socket is down.
+	// False where the window holds nothing to play, or the socket is down.
 	canPlay: boolean;
+	// Why, when it cannot be pressed — a window can be unplayable for opposite
+	// reasons, and a button nobody can press has to say which.
+	playTitle: string;
 	onPlay: () => void;
+	// The event log panel is on the board.
+	logOpen: boolean;
+	onChangeLogOpen: (next: boolean) => void;
 }) => (
 	<div
 		style={{
@@ -948,11 +939,7 @@ export const ScrubberHeader = ({
 			data-testid="theatre-play"
 			onClick={onPlay}
 			disabled={!canPlay}
-			title={
-				canPlay
-					? "Play this window of the board's history"
-					: 'Not enough history in this window to play'
-			}
+			title={playTitle}
 			aria-label="Play the board's history"
 			// Square and outlined rather than a filled key next to the chevron's
 			// panel: it is the same affordance the player's own transport is, and
@@ -974,6 +961,21 @@ export const ScrubberHeader = ({
 		>
 			<IconPlay size={13} />
 		</button>
+
+		{/* Beside the play button rather than among the checkboxes at the far end
+		    of the bar: those all narrow what is drawn, and this puts a panel on
+		    the board — the same kind of thing as starting a movie. Here it is also
+		    still on screen with the scrubber collapsed, which the controls row is
+		    not.
+
+		    It asks the socket for nothing, the window it lists being already on
+		    screen, so it stays usable offline. */}
+		<Checkbox
+			label={LOG_LABEL}
+			title="Show the event log down the left of the board"
+			checked={logOpen}
+			onChange={onChangeLogOpen}
+		/>
 	</div>
 );
 

--- a/source/gui/client/components/ScrubberParts.tsx
+++ b/source/gui/client/components/ScrubberParts.tsx
@@ -50,6 +50,7 @@ import {IconScatter} from './IconScatter';
 // Named once: the collapsed header puts the same box up when the rest of this
 // row is not on screen.
 export const SCOPE_ONLY_LABEL = 'Scope only';
+export const LOG_LABEL = 'Log';
 export const TICKET_ONLY_LABEL = 'Ticket only';
 
 const toggleButtonStyle = (active: boolean): React.CSSProperties => ({
@@ -521,6 +522,7 @@ export const ScrubberControls = ({
 	atLatest,
 	windowOnly,
 	windowFilterable,
+	logOpen,
 	ticketOnly,
 	ticketSelected,
 	ticketFocus,
@@ -539,6 +541,7 @@ export const ScrubberControls = ({
 	onChangeScope,
 	onChangeOffset,
 	onChangeWindowOnly,
+	onChangeLogOpen,
 	onChangeTicketOnly,
 	onChangeLayoutMode,
 	onChangeShowIssues,
@@ -564,6 +567,8 @@ export const ScrubberControls = ({
 	atLatest: boolean;
 	// The board is narrowed to the tickets this window has an event for.
 	windowOnly: boolean;
+	// The event log panel is on the board.
+	logOpen: boolean;
 	// False where the window came back as counts alone, naming no tickets to
 	// narrow to.
 	windowFilterable: boolean;
@@ -590,6 +595,7 @@ export const ScrubberControls = ({
 	onChangeScope: (scope: Scope) => void;
 	onChangeOffset: (offset: number) => void;
 	onChangeWindowOnly: (next: boolean) => void;
+	onChangeLogOpen: (next: boolean) => void;
 	onChangeTicketOnly: (next: boolean) => void;
 	onChangeLayoutMode: (mode: LayoutMode) => void;
 	onChangeShowIssues: (next: boolean) => void;
@@ -749,6 +755,19 @@ export const ScrubberControls = ({
 			</div>
 
 			<div style={{display: 'flex', gap: 12, alignItems: 'center'}}>
+				{/* First in the row, ahead of the narrowings further along it: this
+			    one hides no ticket and changes no window. It puts a panel on the
+			    board, which is a different kind of thing from everything else
+			    here, so it stands at the head rather than among them.
+
+			    It asks the socket for nothing — the window it lists is already on
+			    screen — so it stays usable offline, as the narrowings do. */}
+				<Checkbox
+					label={LOG_LABEL}
+					title="Show the event log down the left of the board"
+					checked={logOpen}
+					onChange={onChangeLogOpen}
+				/>
 				<Checkbox
 					label="Code"
 					checked={showCommits}

--- a/source/gui/client/components/TheatrePlayer.tsx
+++ b/source/gui/client/components/TheatrePlayer.tsx
@@ -89,24 +89,31 @@ export const TheatrePlayer = ({
 	useEffect(() => {
 		const onKeyDown = (event: KeyboardEvent) => {
 			const target = event.target as HTMLElement | null;
+			const tag = target?.tagName ?? '';
 
-			// Anything that answers a key itself keeps it. Form fields because the
-			// player can be opened with one focused, and buttons because Space is
-			// how a focused one is pressed — swallowing it here would leave the
-			// player's own controls unreachable from the keyboard.
+			// A form field keeps every key: the player can be opened with one
+			// focused.
 			if (
 				target &&
 				(target.isContentEditable ||
-					['INPUT', 'TEXTAREA', 'SELECT', 'BUTTON'].includes(target.tagName))
+					['INPUT', 'TEXTAREA', 'SELECT'].includes(tag))
 			) {
 				return;
 			}
 
+			// Ahead of the button check below, and deliberately: Escape is the way
+			// out from wherever focus happens to be, and after a click on any of
+			// the player's own controls that is one of its buttons.
 			if (event.key === 'Escape') {
 				event.preventDefault();
 				onExitRef.current();
 				return;
 			}
+
+			// Space is how a focused button is pressed, so it belongs to the
+			// button — taking it here would leave the player's own controls
+			// unreachable from the keyboard.
+			if (tag === 'BUTTON') return;
 
 			if (event.key === ' ' || event.key === 'Spacebar') {
 				event.preventDefault();
@@ -370,7 +377,7 @@ export const TheatrePlayer = ({
 								? 'Hide the log'
 								: 'Show every event as it plays, over the board'
 						}
-						aria-label="Show the log over the board"
+						aria-label={logOpen ? 'Hide the log' : 'Show the log'}
 						style={{
 							background: 'transparent',
 							border: 'none',

--- a/source/gui/client/components/TimeScrubber.tsx
+++ b/source/gui/client/components/TimeScrubber.tsx
@@ -784,12 +784,26 @@ export const TimeScrubber = ({
 		fraction: (rangeDrag.from + rangeDrag.to) / 2,
 	};
 
+	// A window can be unplayable for opposite reasons: too little in it, or so
+	// much that the server sent counts alone and named no moments to walk. The
+	// same disabled button stands for both, so the title has to separate them.
+	const playTitle = !connected
+		? 'Not while the connection is down'
+		: canPlayTimeline(timeline)
+		? "Play this window of the board's history"
+		: timeline && timeline.buckets.length > 0
+		? 'Too many events in this window to play it — narrow the window'
+		: 'Not enough history in this window to play';
+
 	return (
 		<ScrubberLayout
 			collapsed={collapsed}
 			onToggleCollapsed={() => setCollapsed(!collapsed)}
 			canPlay={connected && !theatreOpen && canPlayTimeline(timeline)}
+			playTitle={playTitle}
 			onPlay={onPlayTheatre}
+			logOpen={logOpen}
+			onChangeLogOpen={onChangeLogOpen}
 			standDown={theatreOpen}
 			controls={{
 				connected,
@@ -800,8 +814,6 @@ export const TimeScrubber = ({
 				atLatest,
 				windowOnly,
 				windowFilterable: windowNamesIssues(timeline),
-				logOpen,
-				onChangeLogOpen,
 				ticketOnly,
 				ticketSelected: selectedIssue !== null,
 				ticketFocus,

--- a/source/gui/client/components/TimeScrubber.tsx
+++ b/source/gui/client/components/TimeScrubber.tsx
@@ -86,6 +86,8 @@ export const TimeScrubber = ({
 	refreshOn,
 	onPlayTheatre,
 	theatreOpen,
+	logOpen,
+	onChangeLogOpen,
 }: {
 	timeline: GuiEventTimeline | null;
 	commits: GuiCommitEntry[];
@@ -132,6 +134,10 @@ export const TimeScrubber = ({
 	refreshOn: unknown;
 	// Opens the history player over this window.
 	onPlayTheatre: () => void;
+	// The event log panel, which the player's own pop-out also switches. Owned
+	// above because the panel is in the board's row, not in this bar.
+	logOpen: boolean;
+	onChangeLogOpen: (next: boolean) => void;
 	// The player is up. It owns the board's position for as long as it is, so
 	// the whole bar stands down rather than competing for the same thing.
 	theatreOpen: boolean;
@@ -794,6 +800,8 @@ export const TimeScrubber = ({
 				atLatest,
 				windowOnly,
 				windowFilterable: windowNamesIssues(timeline),
+				logOpen,
+				onChangeLogOpen,
 				ticketOnly,
 				ticketSelected: selectedIssue !== null,
 				ticketFocus,

--- a/source/gui/client/components/TimeScrubber.tsx
+++ b/source/gui/client/components/TimeScrubber.tsx
@@ -128,9 +128,11 @@ export const TimeScrubber = ({
 	knownIdentities: Record<'actor' | 'tag' | 'assignee', GuiEventIdentity[]>;
 	// Anything whose identity changing means the window has to be asked for
 	// again. The window is otherwise fetched only when it moves, which is fine
-	// while it is just a picture — but once it decides which tickets the board
-	// shows, a ticket filed since the last fetch is missing from it, and would
-	// be hidden from the board it has just joined.
+	// while it is just a picture — but two things read it as live data. Once it
+	// decides which tickets the board shows, a ticket filed since the last fetch
+	// is missing from it and would be hidden from the board it has just joined;
+	// and once the log is drawn from it, an event made since the last fetch
+	// never reaches the panel that is supposed to be listing it.
 	refreshOn: unknown;
 	// Opens the history player over this window.
 	onPlayTheatre: () => void;

--- a/source/gui/client/lib/event-log.test.ts
+++ b/source/gui/client/lib/event-log.test.ts
@@ -5,23 +5,37 @@ const at = (id: string, t: number) => ({id, t, label: `event ${id}`});
 
 describe('lastIndexAtOrBefore', () => {
 	const values = [10, 20, 30];
+	const self = (value: number) => value;
 
 	it('is -1 when nothing is at or before the limit', () => {
-		expect(lastIndexAtOrBefore(values, 9)).toBe(-1);
-		expect(lastIndexAtOrBefore([], 100)).toBe(-1);
+		expect(lastIndexAtOrBefore(values, 9, self)).toBe(-1);
+		expect(lastIndexAtOrBefore([], 100, self)).toBe(-1);
 	});
 
 	it('includes the value that sits exactly on the limit', () => {
-		expect(lastIndexAtOrBefore(values, 10)).toBe(0);
-		expect(lastIndexAtOrBefore(values, 30)).toBe(2);
+		expect(lastIndexAtOrBefore(values, 10, self)).toBe(0);
+		expect(lastIndexAtOrBefore(values, 30, self)).toBe(2);
 	});
 
 	it('holds the last one passed between two values', () => {
-		expect(lastIndexAtOrBefore(values, 29)).toBe(1);
+		expect(lastIndexAtOrBefore(values, 29, self)).toBe(1);
 	});
 
 	it('takes everything for a limit past the end', () => {
-		expect(lastIndexAtOrBefore(values, Infinity)).toBe(2);
+		expect(lastIndexAtOrBefore(values, Infinity, self)).toBe(2);
+	});
+
+	// The reason it reads through an accessor: this runs in a render that
+	// repeats every animation frame, and projecting the values into an array
+	// first would put an O(n) walk in front of the search.
+	it('reads only the items the search visits', () => {
+		const seen: number[] = [];
+		lastIndexAtOrBefore(values, 25, value => {
+			seen.push(value);
+			return value;
+		});
+
+		expect(seen.length).toBeLessThan(values.length);
 	});
 });
 

--- a/source/gui/client/lib/event-log.test.ts
+++ b/source/gui/client/lib/event-log.test.ts
@@ -1,5 +1,12 @@
 import {describe, expect, it} from 'vitest';
-import {lastIndexAtOrBefore, LOG_LINES, logEntriesUpTo} from './event-log';
+import {
+	buildLogEntries,
+	lastIndexAtOrBefore,
+	LOG_LINES,
+	logEntriesUpTo,
+} from './event-log';
+import {GuiCommitEntry, GuiEventTimelineEntry} from './gui-state.model';
+import {EVENT_CATEGORY_COLORS, GUI_THEME} from './gui-theme';
 
 const at = (id: string, t: number) => ({id, t, label: `event ${id}`});
 
@@ -83,5 +90,80 @@ describe('logEntriesUpTo', () => {
 		const parked = logEntriesUpTo(events, events[events.length - 1]!.t);
 
 		expect(live).toEqual(parked);
+	});
+});
+
+const event = (
+	id: string,
+	t: number,
+	action: string,
+): GuiEventTimelineEntry => ({
+	id,
+	t,
+	action,
+	label: `event ${id}`,
+	actor: null,
+	tag: null,
+	assignee: null,
+	issue: null,
+});
+
+const commit = (sha: string, time: number): GuiCommitEntry => ({
+	sha,
+	time,
+	author: 'jo',
+	subject: `commit ${sha}`,
+	linesChanged: 3,
+	insertions: 2,
+	deletions: 1,
+});
+
+describe('buildLogEntries', () => {
+	it('interleaves commits with events by the clock', () => {
+		const rows = buildLogEntries(
+			[event('a', 100, 'create.issue'), event('b', 300, 'create.issue')],
+			[commit('sha1', 200)],
+		);
+
+		expect(rows.map(row => row.id)).toEqual(['a', 'commit-sha1', 'b']);
+	});
+
+	// A sha and a ULID share no namespace, and both end up as React keys in one
+	// column.
+	it('keeps commit ids from colliding with event ids', () => {
+		const rows = buildLogEntries(
+			[event('sha1', 1, 'create.issue')],
+			[commit('sha1', 2)],
+		);
+
+		expect(new Set(rows.map(row => row.id)).size).toBe(2);
+	});
+
+	it('marks a commit with the green its dots already have on the chart', () => {
+		const rows = buildLogEntries([], [commit('sha1', 1)]);
+
+		expect(rows[0]!.color).toBe(GUI_THEME.green);
+		expect(rows[0]!.label).toBe('commit sha1');
+	});
+
+	// The same colour the scatter gives the kind, so a line reads the same in
+	// both places.
+	it('marks a board event with its category colour', () => {
+		const rows = buildLogEntries(
+			[
+				event('a', 1, 'add.issue.comment'),
+				event('b', 2, 'add.issue.tag'),
+				event('c', 3, 'add.issue.assignee'),
+				event('d', 4, 'create.issue'),
+			],
+			[],
+		);
+
+		expect(rows.map(row => row.color)).toEqual([
+			EVENT_CATEGORY_COLORS.comments,
+			EVENT_CATEGORY_COLORS.tagging,
+			EVENT_CATEGORY_COLORS.assigning,
+			EVENT_CATEGORY_COLORS.tickets,
+		]);
 	});
 });

--- a/source/gui/client/lib/event-log.test.ts
+++ b/source/gui/client/lib/event-log.test.ts
@@ -1,0 +1,73 @@
+import {describe, expect, it} from 'vitest';
+import {lastIndexAtOrBefore, LOG_LINES, logEntriesUpTo} from './event-log';
+
+const at = (id: string, t: number) => ({id, t, label: `event ${id}`});
+
+describe('lastIndexAtOrBefore', () => {
+	const values = [10, 20, 30];
+
+	it('is -1 when nothing is at or before the limit', () => {
+		expect(lastIndexAtOrBefore(values, 9)).toBe(-1);
+		expect(lastIndexAtOrBefore([], 100)).toBe(-1);
+	});
+
+	it('includes the value that sits exactly on the limit', () => {
+		expect(lastIndexAtOrBefore(values, 10)).toBe(0);
+		expect(lastIndexAtOrBefore(values, 30)).toBe(2);
+	});
+
+	it('holds the last one passed between two values', () => {
+		expect(lastIndexAtOrBefore(values, 29)).toBe(1);
+	});
+
+	it('takes everything for a limit past the end', () => {
+		expect(lastIndexAtOrBefore(values, Infinity)).toBe(2);
+	});
+});
+
+describe('logEntriesUpTo', () => {
+	const events = Array.from({length: LOG_LINES + 10}, (_, index) =>
+		at(`e${index}`, 1000 + index),
+	);
+
+	it('is empty before the first event has happened', () => {
+		expect(logEntriesUpTo(events, 999)).toEqual([]);
+	});
+
+	it('reads oldest first, ending on the event at the moment asked for', () => {
+		expect(logEntriesUpTo(events, 1003).map(event => event.id)).toEqual([
+			'e0',
+			'e1',
+			'e2',
+			'e3',
+		]);
+	});
+
+	// The cap is on the document as much as on the reading: rows above it have
+	// scrolled out of the fade, and keeping them would grow the panel by a node
+	// per event for as long as it is open.
+	it('never holds more lines than the panel can show', () => {
+		const entries = logEntriesUpTo(events, Infinity);
+
+		expect(entries).toHaveLength(LOG_LINES);
+		expect(entries[entries.length - 1]!.id).toBe(events[events.length - 1]!.id);
+	});
+
+	// One rule for all three of live, scrubbed and playing — only the moment
+	// handed to it differs, so moving that moment backwards has to take the log
+	// back with it.
+	it('follows the moment backwards as readily as forwards', () => {
+		expect(logEntriesUpTo(events, 1002).map(event => event.id)).toEqual([
+			'e0',
+			'e1',
+			'e2',
+		]);
+	});
+
+	it('takes the whole tail of the window for a moment past its end', () => {
+		const live = logEntriesUpTo(events, Infinity);
+		const parked = logEntriesUpTo(events, events[events.length - 1]!.t);
+
+		expect(live).toEqual(parked);
+	});
+});

--- a/source/gui/client/lib/event-log.ts
+++ b/source/gui/client/lib/event-log.ts
@@ -1,0 +1,99 @@
+// The log panel's own logic: which lines it holds, and how the column moves as
+// they arrive. Not theatre's, though a movie is one of the three things that
+// can drive it — the panel is on the board whenever its box is ticked.
+//
+// One rule throughout: the last few events at or before the moment the board is
+// standing at. What supplies that moment differs — the playhead while a movie
+// runs, the checkout while the needle is parked, the present while live — but
+// the slice does not.
+
+// How many lines the panel holds. A cap on the document as much as on the
+// reading: rows above this have scrolled up out of the fade, and keeping them
+// mounted would grow the panel by a node per event for as long as it is open.
+export const LOG_LINES = 24;
+
+// The height of one line, which is what the column shifts by as a line lands.
+// Fixed rather than measured: every row is one clipped line, so the shift is
+// the same every time and the crawl stays even.
+export const LOG_ROW_HEIGHT = 18;
+
+// The index of the last entry whose value is at or before `limit`, or -1 when
+// none is. A binary search rather than a walk on from the last answer, because
+// the moment can move backwards — a seek, or a needle dragged left — as
+// readily as forwards.
+export const lastIndexAtOrBefore = (
+	values: readonly number[],
+	limit: number,
+): number => {
+	let low = 0;
+	let high = values.length - 1;
+	let found = -1;
+
+	while (low <= high) {
+		const mid = (low + high) >> 1;
+
+		if (values[mid]! <= limit) {
+			found = mid;
+			low = mid + 1;
+		} else {
+			high = mid - 1;
+		}
+	}
+
+	return found;
+};
+
+// The tail of `events` at or before `upTo`, oldest first, capped at what the
+// panel can show. `events` must be in clock order — the log is read in the
+// order things happened, which is not the order the log stores them in.
+//
+// Generic over the entry so the timeline's own rows and a movie's cut-down ones
+// both go through it unchanged.
+export const logEntriesUpTo = <T extends {t: number}>(
+	events: readonly T[],
+	upTo: number,
+): T[] => {
+	const last = lastIndexAtOrBefore(
+		events.map(event => event.t),
+		upTo,
+	);
+
+	if (last < 0) return [];
+
+	return events.slice(Math.max(0, last - LOG_LINES + 1), last + 1);
+};
+
+// A seek can replace the whole column at once. Sliding that far would be a
+// swipe rather than a crawl, so the shift is capped at what an ordinary step
+// can be — one line, or a line and the day header it brought with it.
+const MAX_CRAWL_ROWS = 2;
+
+// The column slides up by however many rows joined the bottom, rather than the
+// stack jumping. Run off the element rather than through a CSS animation: lines
+// can arrive faster than the animation is long, and a restart has to be a
+// restart.
+export const crawlShiftFrames = (rows: number): Keyframe[] => [
+	{
+		transform: `translateY(${
+			Math.min(rows, MAX_CRAWL_ROWS) * LOG_ROW_HEIGHT
+		}px)`,
+	},
+	{transform: 'translateY(0)'},
+];
+
+export const CRAWL_TIMING: KeyframeAnimationOptions = {
+	duration: 220,
+	easing: 'ease-out',
+};
+
+// Mounted with the panel, so it carries its own entrance rather than depending
+// on a player being up to define it.
+export const EVENT_LOG_KEYFRAMES = `
+@keyframes epiqLogLine {
+	from { opacity: 0; }
+	to { opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+	@keyframes epiqLogLine { from { opacity: 1; } to { opacity: 1; } }
+}
+`;

--- a/source/gui/client/lib/event-log.ts
+++ b/source/gui/client/lib/event-log.ts
@@ -7,32 +7,44 @@
 // runs, the checkout while the needle is parked, the present while live — but
 // the slice does not.
 
-// How many lines the panel holds. A cap on the document as much as on the
-// reading: rows above this have scrolled up out of the fade, and keeping them
-// mounted would grow the panel by a node per event for as long as it is open.
-export const LOG_LINES = 24;
+// How many lines the panel is handed. Enough to fill a tall pane to its top —
+// the panel is a column of the board's full height, and a log that stopped
+// short of it would read as a box parked at the bottom rather than as the
+// board's log.
+//
+// Still a hard cap on the document, which is the point: what the pane cannot
+// show is clipped into the fade, and the panel costs these rows on a year of
+// history exactly as on an hour. Rows past the pane's height are the only
+// waste, and eighty of them is nothing next to a board of cards.
+export const LOG_LINES = 80;
 
 // The height of one line, which is what the column shifts by as a line lands.
 // Fixed rather than measured: every row is one clipped line, so the shift is
 // the same every time and the crawl stays even.
 export const LOG_ROW_HEIGHT = 18;
 
-// The index of the last entry whose value is at or before `limit`, or -1 when
+// The index of the last item whose value is at or before `limit`, or -1 when
 // none is. A binary search rather than a walk on from the last answer, because
 // the moment can move backwards — a seek, or a needle dragged left — as
 // readily as forwards.
-export const lastIndexAtOrBefore = (
-	values: readonly number[],
+//
+// Reads the value through `valueOf` rather than taking an array of numbers:
+// this runs in a render that repeats every animation frame of a movie, and
+// projecting twenty thousand timestamps into a fresh array first would be an
+// O(n) walk in front of the O(log n) search that follows it.
+export const lastIndexAtOrBefore = <T>(
+	items: readonly T[],
 	limit: number,
+	valueOf: (item: T) => number,
 ): number => {
 	let low = 0;
-	let high = values.length - 1;
+	let high = items.length - 1;
 	let found = -1;
 
 	while (low <= high) {
 		const mid = (low + high) >> 1;
 
-		if (values[mid]! <= limit) {
+		if (valueOf(items[mid]!) <= limit) {
 			found = mid;
 			low = mid + 1;
 		} else {
@@ -53,10 +65,7 @@ export const logEntriesUpTo = <T extends {t: number}>(
 	events: readonly T[],
 	upTo: number,
 ): T[] => {
-	const last = lastIndexAtOrBefore(
-		events.map(event => event.t),
-		upTo,
-	);
+	const last = lastIndexAtOrBefore(events, upTo, event => event.t);
 
 	if (last < 0) return [];
 

--- a/source/gui/client/lib/event-log.ts
+++ b/source/gui/client/lib/event-log.ts
@@ -7,6 +7,46 @@
 // runs, the checkout while the needle is parked, the present while live — but
 // the slice does not.
 
+import {GuiCommitEntry, GuiEventTimelineEntry} from './gui-state.model';
+import {EVENT_CATEGORY_COLORS, GUI_THEME} from './gui-theme';
+import {categoryOf} from './scrubber';
+
+// One line of the log. `color` is the dot it is marked with, which is the whole
+// of what says a line is a commit rather than a board event — so it is resolved
+// once here rather than being decided again wherever a row is drawn.
+export type LogEntry = {
+	id: string;
+	t: number;
+	label: string;
+	color: string;
+};
+
+// Both series in one column, in clock order. Commits are lines and nothing
+// more: they change no board state, so they never drive a checkout and never
+// become a frame of a movie — the playhead is still walked by events alone.
+export const buildLogEntries = (
+	events: readonly GuiEventTimelineEntry[],
+	commits: readonly GuiCommitEntry[],
+): LogEntry[] =>
+	[
+		...events.map(event => ({
+			id: event.id,
+			t: event.t,
+			label: event.label,
+			// The colour its dot already has on the scatter, so a kind reads the
+			// same in both places.
+			color: EVENT_CATEGORY_COLORS[categoryOf(event.action)],
+		})),
+		// Prefixed, because a sha and a ULID share no namespace and both end up
+		// as React keys in the same column.
+		...commits.map(commit => ({
+			id: `commit-${commit.sha}`,
+			t: commit.time,
+			label: commit.subject,
+			color: GUI_THEME.green,
+		})),
+	].sort((left, right) => left.t - right.t);
+
 // How many lines the panel is handed. Enough to fill a tall pane to its top —
 // the panel is a column of the board's full height, and a log that stopped
 // short of it would read as a box parked at the bottom rather than as the

--- a/source/gui/client/lib/scrubber.ts
+++ b/source/gui/client/lib/scrubber.ts
@@ -4,7 +4,9 @@
 import {useEffect, useMemo, useRef, useState} from 'react';
 import {
 	formatDateTime,
+	formatMonth,
 	formatTimeOfDay,
+	formatWeekday,
 	isSameDay,
 } from '../../../lib/utils/date.utils.js';
 import {maxOf, minOf} from '../../../lib/utils/minmax.js';
@@ -497,22 +499,6 @@ export const chooseSegmentUnit = (spanMs: number): SegmentUnit => {
 	return SEGMENT_UNIT_ORDER[Math.max(0, index - 1)]!;
 };
 
-const WEEKDAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-const MONTH_LABELS = [
-	'Jan',
-	'Feb',
-	'Mar',
-	'Apr',
-	'May',
-	'Jun',
-	'Jul',
-	'Aug',
-	'Sep',
-	'Oct',
-	'Nov',
-	'Dec',
-];
-
 const advanceByUnit = (date: Date, unit: SegmentUnit): void => {
 	if (unit === 'minute') date.setMinutes(date.getMinutes() + 1);
 	else if (unit === 'hour') date.setHours(date.getHours() + 1);
@@ -559,24 +545,20 @@ export const segmentAt = (time: number, unit: SegmentUnit): Segment => {
 		unit === 'minute'
 			? clock(start)
 			: unit === 'hour'
-			? `${WEEKDAY_LABELS[start.getDay()]} ${String(start.getHours()).padStart(
+			? `${formatWeekday(start)} ${String(start.getHours()).padStart(
 					2,
 					'0',
 			  )}:00`
 			: unit === 'day'
-			? `${WEEKDAY_LABELS[start.getDay()]} ${start.getDate()} ${
-					MONTH_LABELS[start.getMonth()]
-			  }`
+			? `${formatWeekday(start)} ${start.getDate()} ${formatMonth(start)}`
 			: unit === 'week'
 			? start.getMonth() === lastDay.getMonth()
-				? `${start.getDate()}–${lastDay.getDate()} ${
-						MONTH_LABELS[start.getMonth()]
-				  }`
-				: `${start.getDate()} ${
-						MONTH_LABELS[start.getMonth()]
-				  } – ${lastDay.getDate()} ${MONTH_LABELS[lastDay.getMonth()]}`
+				? `${start.getDate()}–${lastDay.getDate()} ${formatMonth(start)}`
+				: `${start.getDate()} ${formatMonth(
+						start,
+				  )} – ${lastDay.getDate()} ${formatMonth(lastDay)}`
 			: unit === 'month'
-			? `${MONTH_LABELS[start.getMonth()]} ${start.getFullYear()}`
+			? `${formatMonth(start)} ${start.getFullYear()}`
 			: `${start.getFullYear()}`;
 
 	return {start: start.getTime(), end: end.getTime(), label};

--- a/source/gui/client/lib/theatre.test.ts
+++ b/source/gui/client/lib/theatre.test.ts
@@ -9,9 +9,7 @@ import {
 	playbackPosition,
 	seekTimeFor,
 	THEATRE_LEAD_IN,
-	THEATRE_LOG_LINES,
 	theatreDurationMs,
-	theatreLogEntries,
 } from './theatre';
 
 const entry = (
@@ -158,48 +156,6 @@ describe('seekTimeFor', () => {
 	it('asks for the moment just past the event, so its own change is in', () => {
 		expect(seekTimeFor(plan, 0)).toBe(101);
 		expect(seekTimeFor(plan, 1)).toBe(201);
-	});
-});
-
-describe('theatreLogEntries', () => {
-	const plan = buildTheatrePlan(
-		timeline(
-			Array.from({length: THEATRE_LOG_LINES + 10}, (_, index) =>
-				entry(`e${index}`, 1000 + index),
-			),
-		),
-	)!;
-
-	it('is empty until the first event has played', () => {
-		expect(theatreLogEntries(plan, -1)).toEqual([]);
-	});
-
-	it('reads oldest first, ending on the event that just landed', () => {
-		const entries = theatreLogEntries(plan, 3);
-
-		expect(entries.map(event => event.id)).toEqual(['e0', 'e1', 'e2', 'e3']);
-	});
-
-	// The cap is on the document as much as on the reading: rows above it have
-	// scrolled out of the fade, and keeping them would grow the overlay by a
-	// node per event for the length of the movie.
-	it('never holds more lines than the overlay can show', () => {
-		const entries = theatreLogEntries(plan, plan.events.length - 1);
-
-		expect(entries).toHaveLength(THEATRE_LOG_LINES);
-		expect(entries[entries.length - 1]!.id).toBe(
-			plan.events[plan.events.length - 1]!.id,
-		);
-	});
-
-	// Sliced off the plan rather than accumulated as events land, which is what
-	// lets it follow the bar backwards as well as forwards.
-	it('goes back with a seek backwards', () => {
-		expect(theatreLogEntries(plan, 2).map(event => event.id)).toEqual([
-			'e0',
-			'e1',
-			'e2',
-		]);
 	});
 });
 

--- a/source/gui/client/lib/theatre.ts
+++ b/source/gui/client/lib/theatre.ts
@@ -7,6 +7,7 @@
 
 import {useCallback, useEffect, useRef, useState} from 'react';
 import {buildPlaybackFractions} from '../../../lib/utils/playback-pacing.js';
+import {lastIndexAtOrBefore} from './event-log';
 import {GuiEventTimeline} from './gui-state.model';
 import {clamp} from './scrubber';
 
@@ -88,27 +89,10 @@ export const nextSpeed = (speed: TheatreSpeed): TheatreSpeed =>
 	THEATRE_SPEEDS[(THEATRE_SPEEDS.indexOf(speed) + 1) % THEATRE_SPEEDS.length]!;
 
 // The index of the last event whose scheduled position `progress` has reached,
-// or -1 before the first one lands. A binary search rather than a walk on from
-// the last answer, because dragging the player's bar seeks backwards as readily
-// as forwards.
-export const cursorAt = (fractions: number[], progress: number): number => {
-	let low = 0;
-	let high = fractions.length - 1;
-	let found = -1;
-
-	while (low <= high) {
-		const mid = (low + high) >> 1;
-
-		if (fractions[mid]! <= progress) {
-			found = mid;
-			low = mid + 1;
-		} else {
-			high = mid - 1;
-		}
-	}
-
-	return found;
-};
+// or -1 before the first one lands. The same search the log takes its tail
+// with, over positions rather than moments.
+export const cursorAt = (fractions: number[], progress: number): number =>
+	lastIndexAtOrBefore(fractions, progress);
 
 // The opening beat, as a share of the movie: the board as it was before any of
 // this happened, held long enough to be read as a starting point. Without it
@@ -126,26 +110,6 @@ export const playbackPosition = (progress: number): number =>
 // hence the +1: what the movie shows is the state the event produced.
 export const seekTimeFor = (plan: TheatrePlan, cursor: number): number =>
 	cursor < 0 ? plan.startTime : plan.events[cursor]!.t + 1;
-
-// How many played events the log holds. It is a cap on the DOM as much as on
-// the reading: rows above this have scrolled up out of the fade, and keeping
-// them mounted would grow the overlay by one node per event for the length of
-// the movie.
-export const THEATRE_LOG_LINES = 24;
-
-// The tail of what has played, oldest first. Sliced off the plan rather than
-// accumulated as events land: a seek has to take the log with it, backwards as
-// readily as forwards, and a slice of the script is already exactly that.
-export const theatreLogEntries = (
-	plan: TheatrePlan,
-	cursor: number,
-): TheatreEvent[] =>
-	cursor < 0
-		? []
-		: plan.events.slice(
-				Math.max(0, cursor - THEATRE_LOG_LINES + 1),
-				cursor + 1,
-		  );
 
 export type TheatrePlayback = {
 	// [0..1], off the local clock rather than the events applied, so the bar
@@ -346,15 +310,10 @@ export const THEATRE_KEYFRAMES = `
 	from { opacity: 0; transform: scale(0.96); }
 	to { opacity: 1; transform: scale(1); }
 }
-@keyframes epiqTheatreLogLine {
-	from { opacity: 0; }
-	to { opacity: 1; }
-}
 @media (prefers-reduced-motion: reduce) {
 	@keyframes epiqTheatreRise { from { opacity: 1; transform: none; } to { opacity: 1; transform: none; } }
 	@keyframes epiqTheatreCardIn { from { opacity: 1; } to { opacity: 1; } }
 	@keyframes epiqTheatreCaption { from { opacity: 1; } to { opacity: 1; } }
-	@keyframes epiqTheatreLogLine { from { opacity: 1; } to { opacity: 1; } }
 }
 `;
 
@@ -383,31 +342,3 @@ export const THEATRE_FLASH_TIMING: KeyframeAnimationOptions = {
 // up rather than running underneath and playing their last rows behind the
 // transport, so the two have to read it from one place.
 export const THEATRE_PLAYER_CLEARANCE = 80;
-
-// One row of the log, which is what the whole column shifts by as a line
-// arrives. Fixed rather than measured: every row is one clipped line, so the
-// shift is the same every time and the crawl stays even.
-export const THEATRE_LOG_ROW_HEIGHT = 18;
-
-// A seek can replace the whole column at once. Sliding that far would be a
-// swipe rather than a crawl, so the shift is capped at what an ordinary step
-// can be — one line, or a line and the day header it brought with it.
-const MAX_CRAWL_ROWS = 2;
-
-// The column slides up by however many rows joined the bottom, rather than the
-// stack jumping. Run off the element for the same reason the card flash is:
-// lines arrive faster than the animation is long, and a restart has to be a
-// restart.
-export const crawlShiftFrames = (rows: number): Keyframe[] => [
-	{
-		transform: `translateY(${
-			Math.min(rows, MAX_CRAWL_ROWS) * THEATRE_LOG_ROW_HEIGHT
-		}px)`,
-	},
-	{transform: 'translateY(0)'},
-];
-
-export const THEATRE_CRAWL_TIMING: KeyframeAnimationOptions = {
-	duration: 220,
-	easing: 'ease-out',
-};

--- a/source/gui/client/lib/theatre.ts
+++ b/source/gui/client/lib/theatre.ts
@@ -92,7 +92,7 @@ export const nextSpeed = (speed: TheatreSpeed): TheatreSpeed =>
 // or -1 before the first one lands. The same search the log takes its tail
 // with, over positions rather than moments.
 export const cursorAt = (fractions: number[], progress: number): number =>
-	lastIndexAtOrBefore(fractions, progress);
+	lastIndexAtOrBefore(fractions, progress, fraction => fraction);
 
 // The opening beat, as a share of the movie: the board as it was before any of
 // this happened, held long enough to be read as a starting point. Without it

--- a/source/lib/utils/date.utils.ts
+++ b/source/lib/utils/date.utils.ts
@@ -31,10 +31,37 @@ export const formatDateTime = (date: Date): string =>
 	`${pad(date.getHours())}:` +
 	`${pad(date.getMinutes())}`;
 
-// Only the day, for a list that marks where one ends and prints the clock alone
-// against every line inside it.
-export const formatDate = (date: Date): string =>
-	`${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+const WEEKDAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+// The day of the week, which tells a reader what a date on its own does not:
+// whether a stretch of work was a Tuesday or a Sunday.
+export const formatWeekday = (date: Date): string =>
+	WEEKDAY_LABELS[date.getDay()]!;
+
+const MONTH_LABELS = [
+	'Jan',
+	'Feb',
+	'Mar',
+	'Apr',
+	'May',
+	'Jun',
+	'Jul',
+	'Aug',
+	'Sep',
+	'Oct',
+	'Nov',
+	'Dec',
+];
+
+export const formatMonth = (date: Date): string =>
+	MONTH_LABELS[date.getMonth()]!;
+
+// "Tue, Oct 7" — a day written to be read rather than parsed, for the divider
+// a list puts between one day's entries and the next. No year: a divider says
+// which day the lines under it belong to, and the lines themselves are already
+// in order.
+export const formatDayLabel = (date: Date): string =>
+	`${formatWeekday(date)}, ${formatMonth(date)} ${date.getDate()}`;
 
 // Only the clock, for the second half of an interval that stays inside one day.
 export const formatTimeOfDay = (date: Date): string =>

--- a/source/test/e2e-gui/theatre.pw.ts
+++ b/source/test/e2e-gui/theatre.pw.ts
@@ -178,7 +178,7 @@ test('the transport pauses and resumes, and the movie ends on a full bar', async
 
 // The crawl is a slice of the script, not a list grown as events land, which
 // is what keeps a long movie from adding a node per event to the overlay.
-test('the pop-out puts the log over the board, capped at what it can show', async ({
+test('the pop-out puts the log beside the board', async ({
 	page,
 	appUrl,
 	pageErrors,
@@ -194,12 +194,11 @@ test('the pop-out puts the log over the board, capped at what it can show', asyn
 	await expect(log).toBeVisible();
 	await expect(toggle).toHaveAttribute('aria-pressed', 'true');
 
-	// Lines arrive as the movie plays. That they stay capped however long it
-	// runs is theatre.test.ts's job — this only holds that the cap is a real
-	// bound on the document rather than on the reading alone.
+	// Lines arrive as the movie plays. How many the panel holds at most is
+	// event-log.test.ts's job — a bound asserted here would only be a bound on
+	// the seeded window, which is smaller than the cap and so proves nothing.
 	const lines = page.getByTestId('log-line');
 	await expect.poll(async () => await lines.count()).toBeGreaterThan(1);
-	expect(await lines.count()).toBeLessThanOrEqual(30);
 
 	// The day each run of lines belongs to is called once above them, rather
 	// than repeated on every line.

--- a/source/test/e2e-gui/theatre.pw.ts
+++ b/source/test/e2e-gui/theatre.pw.ts
@@ -204,6 +204,10 @@ test('the pop-out puts the log beside the board', async ({
 	// than repeated on every line.
 	await expect(page.getByTestId('log-day').first()).toBeVisible();
 
+	// Every line is marked with its kind, commits included — the dot is the
+	// whole of what separates one from a board event.
+	expect(await page.getByTestId('log-dot').count()).toBe(await lines.count());
+
 	// A panel, not a wash over the board: it takes its own width and the first
 	// swimlane starts to the right of where it ends.
 	const logBox = (await log.boundingBox())!;
@@ -276,7 +280,6 @@ test('the log picks up what happens on the board while it is open', async ({
 
 	const lines = page.getByTestId('log-line');
 	await expect.poll(async () => await lines.count()).toBeGreaterThan(0);
-	const before = await lines.count();
 
 	// A swimlane, because it writes an event without needing a ticket first.
 	const name = `log-live-${Date.now()}`;
@@ -286,8 +289,10 @@ test('the log picks up what happens on the board while it is open', async ({
 
 	await expect(page.getByText(name, {exact: true}).first()).toBeVisible();
 
-	// The line for it arrives without the window being touched.
-	await expect.poll(async () => await lines.count()).toBeGreaterThan(before);
+	// Its line arrives without the window being touched. Asserted by what the
+	// line says rather than by the count going up: the log is capped, and on a
+	// board that has already filled it a new line pushes the oldest off the top
+	// instead of adding to the tally.
 	await expect(page.getByTestId('event-log')).toContainText(name);
 
 	await box.click();

--- a/source/test/e2e-gui/theatre.pw.ts
+++ b/source/test/e2e-gui/theatre.pw.ts
@@ -260,6 +260,41 @@ test('the log stays on the board after the player leaves', async ({
 	expect(pageErrors).toEqual([]);
 });
 
+// The log is drawn from the scrubber's window, which is fetched when the window
+// moves — not when the board changes. Without the log asking for it too, a
+// swimlane made while the panel is open never reaches the panel listing it.
+test('the log picks up what happens on the board while it is open', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await openBoard(page, appUrl);
+
+	const box = page.getByRole('checkbox', {name: 'Log', exact: true});
+	await box.click();
+	await expect(page.getByTestId('event-log')).toBeVisible();
+
+	const lines = page.getByTestId('log-line');
+	await expect.poll(async () => await lines.count()).toBeGreaterThan(0);
+	const before = await lines.count();
+
+	// A swimlane, because it writes an event without needing a ticket first.
+	const name = `log-live-${Date.now()}`;
+	await page.getByTestId('add-swimlane').click();
+	await page.getByPlaceholder('swimlane name').fill(name);
+	await page.getByPlaceholder('swimlane name').press('Enter');
+
+	await expect(page.getByText(name, {exact: true}).first()).toBeVisible();
+
+	// The line for it arrives without the window being touched.
+	await expect.poll(async () => await lines.count()).toBeGreaterThan(before);
+	await expect(page.getByTestId('event-log')).toContainText(name);
+
+	await box.click();
+	await expect(page.getByTestId('event-log')).toHaveCount(0);
+	expect(pageErrors).toEqual([]);
+});
+
 test('closing the player hands the board back, live and editable', async ({
 	page,
 	appUrl,

--- a/source/test/e2e-gui/theatre.pw.ts
+++ b/source/test/e2e-gui/theatre.pw.ts
@@ -186,7 +186,7 @@ test('the pop-out puts the log over the board, capped at what it can show', asyn
 	await openBoard(page, appUrl);
 	await page.getByTestId('theatre-play').click();
 
-	const log = page.getByTestId('theatre-log');
+	const log = page.getByTestId('event-log');
 	await expect(log).toHaveCount(0);
 
 	const toggle = page.getByTestId('theatre-log-toggle');
@@ -197,13 +197,13 @@ test('the pop-out puts the log over the board, capped at what it can show', asyn
 	// Lines arrive as the movie plays. That they stay capped however long it
 	// runs is theatre.test.ts's job — this only holds that the cap is a real
 	// bound on the document rather than on the reading alone.
-	const lines = page.getByTestId('theatre-log-line');
+	const lines = page.getByTestId('log-line');
 	await expect.poll(async () => await lines.count()).toBeGreaterThan(1);
 	expect(await lines.count()).toBeLessThanOrEqual(30);
 
 	// The day each run of lines belongs to is called once above them, rather
 	// than repeated on every line.
-	await expect(page.getByTestId('theatre-log-day').first()).toBeVisible();
+	await expect(page.getByTestId('log-day').first()).toBeVisible();
 
 	// A panel, not a wash over the board: it takes its own width and the first
 	// swimlane starts to the right of where it ends.
@@ -217,6 +217,44 @@ test('the pop-out puts the log over the board, capped at what it can show', asyn
 	expect(lane.x).toBeGreaterThanOrEqual(logBox.x + logBox.width);
 
 	await toggle.click();
+	await expect(log).toHaveCount(0);
+
+	await returnToLive(page);
+	expect(pageErrors).toEqual([]);
+});
+
+// The panel is the board's, not the movie's: the pop-out and the Log box are
+// two controls over one flag, and leaving the player does not take it away.
+test('the log stays on the board after the player leaves', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await openBoard(page, appUrl);
+
+	const log = page.getByTestId('event-log');
+	const box = page.getByRole('checkbox', {name: 'Log', exact: true});
+
+	await expect(log).toHaveCount(0);
+	await box.click();
+	await expect(log).toBeVisible();
+
+	// Live, with no movie anywhere near it: the tail of the window.
+	await expect
+		.poll(async () => await page.getByTestId('log-line').count())
+		.toBeGreaterThan(0);
+
+	await page.getByTestId('theatre-play').click();
+	await expect(page.getByTestId('theatre-player')).toBeVisible();
+	await expect(log).toBeVisible();
+
+	await page.getByTestId('theatre-exit').click();
+	await expect(page.getByTestId('theatre-player')).toHaveCount(0);
+
+	// Still there, and still the same panel.
+	await expect(log).toBeVisible();
+
+	await box.click();
 	await expect(log).toHaveCount(0);
 
 	await returnToLive(page);


### PR DESCRIPTION
Two tickets over the event log the theatre player introduced.

## J44D2XS — the log becomes a panel of the board's own

It was something only a playing movie could put up. Now a `Log` checkbox beside the play button switches it, and the player's pop-out switches the same flag — one panel, two controls, not two states. The box sits in the scrubber's header rather than among the checkboxes at the far end of the bar: those all narrow what is drawn, this puts a panel on the board, and the header stays on screen with the scrubber collapsed.

One rule for what it shows — the last N events at or before wherever the board is standing — with three sources for that moment: the playhead while a movie runs, `asOfTime` while the needle is parked, the present while live. `theatreLogEntries(plan, cursor)` is gone in favour of `logEntriesUpTo(events, moment)`, so the log follows the needle now, not just the playhead.

It stopped being theatre's: `event-log.ts` holds the slice, the row height and the crawl; `TheatreLog.tsx` became `EventLog.tsx`. `cursorAt` defers to the same search the log takes its tail with, so the second copy of that binary search is gone.

**Two bugs found by using it.** The log did not update when the board changed — it reads the scrubber's window, and that window is only re-fetched when the window moves. It is wired into the existing `refreshOn` now, the same mechanism the "Scope only" narrowing uses for the same reason; the regression test was verified red without the fix. And the fade was measured against the pane rather than the lines, so it was spent on empty space above them and only clipped the first one hard.

## DXGX61V — commits in the log, and a dot per line

Every line is now `[time] [dot] [message]`. Commits are interleaved by the clock and marked in the green their dots already have on the chart; board events take their category colour from the same table the scatter uses, so a kind reads identically in both places. Commits are lines and nothing more — they change no board state, so they never drive a checkout and never become a frame of a movie. The playhead is still walked by events alone.

The day divider is a centred, readable label between two rules — `──── Tue, Sep 1 ────` — which made the weekday on every line redundant, so it went.

Along the way `scrubber.ts` gave up its private copies of the weekday and month tables; both now come from `date.utils.ts`.

## Verified

1095 unit tests, 121 GUI e2e. Nine browser tests over the player and the log, including that the log survives the player leaving and that it picks up an edit made while it is open.

A `/code-review high` pass over the first ticket found five issues, all fixed here: the board bounced left when the player opened over a right-docked panel, because the spacer reserving that width did not know about theatre; Escape stopped working after clicking any player control — a regression from an earlier review fix, where excluding `BUTTON` to give Space back to the buttons also swallowed Escape; `logEntriesUpTo` built an array of every timestamp per call, an O(n) walk in front of its own O(log n) search, in a render that repeats every animation frame; the disabled play button told a window of more than 20,000 events it had "not enough history"; and the pop-out's `aria-label` never flipped.
