### PR TITLE
6V949JX 78E8683 Fold the log by day, let it scroll, and light the text filter

### DIFF
--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -106,6 +106,12 @@ const EMPTY_LOG_ROWS: LogEntry[] = [];
 // The board's page margin, matching the left padding on <main>.
 const BOARD_GUTTER = 30;
 
+// How long the board has to be quiet before an open log asks for the window
+// again. A state broadcast is not a rare thing — a needle drag makes one every
+// 120ms and a bulk action one per ticket — and each refetch is a full replay of
+// the event log plus a `git log`, so a burst has to cost one ask, not one each.
+const LOG_REFRESH_QUIET_MS = 400;
+
 // The ring around the text filter while it holds one. The accent at low alpha,
 // so the field reads as lit rather than as selected.
 const FILTER_ON_RING = 'rgba(118, 212, 255, 0.18)';
@@ -1181,6 +1187,33 @@ export const App = () => {
 		onSeek: scrubToTime,
 	});
 
+	// Bumped when the board has changed in a way that means the scrubber's window
+	// has to be asked for again. A number rather than the state itself, because
+	// the scrubber re-fetches on this value *changing*: handing it null while a
+	// movie plays would itself be a change, and would fetch a window anchored to
+	// now — later than the one the movie was planned from, so the log would lose
+	// the very lines the playhead is narrating.
+	const [historyTick, setHistoryTick] = useState(0);
+
+	useEffect(() => {
+		// The plan is drawn from the window, so nothing may move it mid-movie.
+		if (theatre) return;
+
+		const bump = () => setHistoryTick(tick => tick + 1);
+
+		// The narrowing hides tickets, so it cannot wait: a ticket filed a moment
+		// ago would be missing from the board it has just joined.
+		if (selection.windowOnly) {
+			bump();
+			return;
+		}
+
+		if (!logOpen) return;
+
+		const timer = window.setTimeout(bump, LOG_REFRESH_QUIET_MS);
+		return () => window.clearTimeout(timer);
+	}, [state, theatre, selection.windowOnly, logOpen]);
+
 	// Both series of the window in one column, in clock order — which is not the
 	// order the log stores either of them in. Built once per window rather than
 	// per render, and not at all while the panel is shut.
@@ -1762,15 +1795,7 @@ export const App = () => {
 							: null
 					}
 					knownIdentities={knownIdentities}
-					// The log reads the window, so a swimlane or ticket made while it
-					// is open has to reach it — the board's own broadcast is what says
-					// there is something new to fetch.
-					//
-					// Not while a movie plays: the state changes on every frame of one,
-					// and the window it is drawn from must not move underneath it.
-					refreshOn={
-						(selection.windowOnly || logOpen) && !theatre ? state : null
-					}
+					refreshOn={historyTick}
 				/>
 
 				{/* Dimmed while offline so the board reads as inert. The topbar stays at

--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -1195,6 +1195,14 @@ export const App = () => {
 		? state.timeTravel.asOfTime
 		: Infinity;
 
+	// Sliced when the moment moves rather than on every render: a movie renders
+	// the board on every animation frame but reaches a new event a few times a
+	// second, and the panel below only wants a new list for the latter.
+	const logEntries = useMemo(
+		() => logEntriesUpTo(logRows, logMoment),
+		[logRows, logMoment],
+	);
+
 	// A movie is checked out one frame at a time over the socket, so a dropped
 	// one leaves the player running against nothing. It closes rather than
 	// stalling; the board is already parked wherever the last frame landed, and
@@ -1792,7 +1800,7 @@ export const App = () => {
 					>
 						{logOpen && (
 							<EventLog
-								entries={logEntriesUpTo(logRows, logMoment)}
+								entries={logEntries}
 								bottomClearance={theatre ? THEATRE_PLAYER_CLEARANCE : 0}
 							/>
 						)}

--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -106,6 +106,10 @@ const EMPTY_LOG_ROWS: LogEntry[] = [];
 // The board's page margin, matching the left padding on <main>.
 const BOARD_GUTTER = 30;
 
+// The ring around the text filter while it holds one. The accent at low alpha,
+// so the field reads as lit rather than as selected.
+const FILTER_ON_RING = 'rgba(118, 212, 255, 0.18)';
+
 // Remembered beside the scrubber's own view flags, which is what its checkbox
 // sits among.
 const LOG_STORAGE_KEY = 'epiq.timeScrubber.showLog';
@@ -1866,7 +1870,20 @@ export const App = () => {
 											event.currentTarget.blur();
 										}
 									}}
-									style={{width: 220, padding: '5px 10px', fontSize: 12}}
+									style={{
+										width: 220,
+										padding: '5px 10px',
+										fontSize: 12,
+										// Lit while it holds one: it is the only one of the board's
+										// narrowings with nothing else to say it is on, so a word
+										// typed a while ago reads as a board missing its tickets.
+										border: `1px solid ${
+											textFilter.trim() ? GUI_THEME.accent : GUI_THEME.line
+										}`,
+										boxShadow: textFilter.trim()
+											? `0 0 0 2px ${FILTER_ON_RING}`
+											: undefined,
+									}}
 								/>
 							</div>
 

--- a/source/gui/client/components/EventLog.tsx
+++ b/source/gui/client/components/EventLog.tsx
@@ -24,6 +24,8 @@ import {formatTimeOfDay} from '../../../lib/utils/date.utils.js';
 import {
 	crawlShiftFrames,
 	CRAWL_TIMING,
+	DEFAULT_OPEN_DAYS,
+	daysToOpen,
 	EVENT_LOG_STYLES,
 	groupByDay,
 	isDayOpen,
@@ -155,6 +157,18 @@ const EventLogPanel = ({
 	const days = useMemo(() => groupByDay(entries), [entries]);
 	const newestId = entries[entries.length - 1]?.id ?? null;
 
+	// How many rows the pane has room for, so the days opened by default fill it
+	// rather than leaving it mostly empty. Null until it has been measured.
+	const [paneRows, setPaneRows] = useState<number | null>(null);
+
+	const openCount = useMemo(
+		() =>
+			paneRows === null
+				? Math.min(DEFAULT_OPEN_DAYS, days.length)
+				: daysToOpen(days, paneRows),
+		[days, paneRows],
+	);
+
 	// Whether the pane was at the foot before this render's rows landed, which is
 	// what decides whether it follows them down.
 	const pinnedRef = useRef(true);
@@ -167,6 +181,28 @@ const EventLogPanel = ({
 			pane.scrollHeight - pane.scrollTop - pane.clientHeight <= PINNED_SLACK_PX;
 	};
 
+	// Measured off the pane's own height, which does not depend on what is in it
+	// — so opening days to fill the pane cannot feed back into how many fit.
+	// Before paint, so the first frame is already filled rather than showing one
+	// day and then growing.
+	useLayoutEffect(() => {
+		const pane = scrollRef.current;
+		if (!pane) return;
+
+		const measure = () => {
+			const usable = pane.clientHeight - bottomClearance - LOG_ROW_HEIGHT * 2;
+
+			setPaneRows(Math.max(1, Math.floor(usable / LOG_ROW_HEIGHT)));
+		};
+
+		measure();
+
+		const observer = new ResizeObserver(measure);
+		observer.observe(pane);
+
+		return () => observer.disconnect();
+	}, [bottomClearance]);
+
 	// Before paint, so a line arriving never shows the pane a frame out of place.
 	// Only while the reader is at the foot: scrolled back, the log is something
 	// being read, and pulling it to the bottom would take that away.
@@ -175,7 +211,7 @@ const EventLogPanel = ({
 		if (!pane || !pinnedRef.current) return;
 
 		pane.scrollTop = pane.scrollHeight;
-	}, [newestId, days.length, foldOverrides]);
+	}, [newestId, days.length, foldOverrides, openCount]);
 
 	// The keys on screen before this render. The column slides by however many
 	// rows joined the bottom, which is not always one: an event that crosses
@@ -187,7 +223,7 @@ const EventLogPanel = ({
 		const column = columnRef.current;
 		const shown = shownKeysRef.current;
 		const onScreen = days.flatMap((day, index) =>
-			isDayOpen(days, index, foldOverrides)
+			isDayOpen(days, index, foldOverrides, openCount)
 				? [day.key, ...day.entries.map(entry => entry.id)]
 				: [day.key],
 		);
@@ -253,7 +289,7 @@ const EventLogPanel = ({
 				    always in the same place however few of them there are. */}
 				<div ref={columnRef} style={{marginTop: 'auto'}}>
 					{days.map((day, index) => {
-						const open = isDayOpen(days, index, foldOverrides);
+						const open = isDayOpen(days, index, foldOverrides, openCount);
 
 						return (
 							<div key={day.key}>

--- a/source/gui/client/components/EventLog.tsx
+++ b/source/gui/client/components/EventLog.tsx
@@ -1,36 +1,46 @@
 // The board's event log: a panel down the left holding one timestamped line
-// per event, the column sliding up by a row as each lands and the oldest lines
-// dissolving off the top.
+// per event, grouped by day. The newest day is open and the rest are folded to
+// a divider each, so a long history is a handful of rows until a reader asks
+// for more of it. The pane scrolls back through what is loaded and stays pinned
+// to the bottom as new lines land — but only while it is already there, so
+// reading back is not yanked away by the next event.
 //
 // A panel rather than a wash over the board — it takes its own width and the
 // board moves over for it, so neither has to be read through the other.
 //
 // The rows it is handed are a slice taken against the moment the board is
-// standing at, never a list grown as events arrive, so what is off the top is
-// not merely invisible — it is not in the document at all, and the panel costs
-// the same on a year of history as on an hour.
+// standing at, never a list grown as events arrive, so the panel costs the same
+// on a year of history as on an hour.
 
-import {useEffect, useRef} from 'react';
 import {
-	formatDayLabel,
-	formatTimeOfDay,
-	isSameDay,
-} from '../../../lib/utils/date.utils.js';
+	memo,
+	useEffect,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+	useState,
+} from 'react';
+import {formatTimeOfDay} from '../../../lib/utils/date.utils.js';
 import {
 	crawlShiftFrames,
 	CRAWL_TIMING,
-	EVENT_LOG_KEYFRAMES,
+	EVENT_LOG_STYLES,
+	groupByDay,
+	isDayOpen,
 	LogEntry,
+	LOG_DOT_COLOR_PROPERTY,
 	LOG_ROW_HEIGHT,
 } from '../lib/event-log';
 import {GUI_THEME, TEXT} from '../lib/gui-theme';
 import {usePrefersReducedMotion} from '../lib/scrubber';
+import {IconChevronDown} from './IconChevronDown';
+import {IconChevronRight} from './IconChevronRight';
 
 const LOG_WIDTH = 380;
 
-// How many rows the top of the log dissolves over. Measured in rows rather
-// than as a share of anything, so the fade is the same depth whatever height
-// the panel happens to have.
+// How many rows the top of the log dissolves over. Measured in rows rather than
+// as a share of anything, so the fade is the same depth whatever height the
+// panel happens to have.
 const FADE_ROWS = 3;
 
 // Dissolves the top of the pane so lines leave rather than being cut off. Both
@@ -39,9 +49,10 @@ const CRAWL_MASK = `linear-gradient(to bottom, transparent 0, #000 ${
 	FADE_ROWS * LOG_ROW_HEIGHT
 }px)`;
 
-// A few pixels across, and no more: it marks a line's kind without becoming
-// the thing the eye lands on.
-const DOT_SIZE = 5;
+// How near the foot counts as being at it. A couple of rows, so a pin survives
+// a sub-pixel scroll position or a rounding difference between scrollHeight and
+// the box it is measured against.
+const PINNED_SLACK_PX = LOG_ROW_HEIGHT * 2;
 
 const dividerRuleStyle: React.CSSProperties = {
 	flex: 1,
@@ -50,46 +61,76 @@ const dividerRuleStyle: React.CSSProperties = {
 	background: GUI_THEME.line,
 };
 
-// The clock alone against each line, with the day called once above the lines
-// that share it — a full date on all of them is the same ten characters twenty
-// times over.
-type Row =
-	| {kind: 'day'; key: string; label: string}
-	| {kind: 'event'; key: string; time: string; label: string; color: string};
+const DayDivider = ({
+	label,
+	count,
+	open,
+	onToggle,
+}: {
+	label: string;
+	count: number;
+	open: boolean;
+	onToggle: () => void;
+}) => (
+	<button
+		type="button"
+		data-testid="log-day"
+		aria-expanded={open}
+		onClick={onToggle}
+		title={open ? `Fold ${label}` : `Show the ${count} lines of ${label}`}
+		style={{
+			display: 'flex',
+			alignItems: 'center',
+			gap: 8,
+			width: '100%',
+			height: LOG_ROW_HEIGHT,
+			padding: 0,
+			background: 'transparent',
+			border: 'none',
+			color: GUI_THEME.dim,
+			fontFamily: 'inherit',
+			fontSize: TEXT.meta,
+			cursor: 'pointer',
+		}}
+	>
+		<span
+			aria-hidden
+			style={{display: 'inline-flex', alignItems: 'center', flexShrink: 0}}
+		>
+			{open ? <IconChevronDown size={11} /> : <IconChevronRight size={11} />}
+		</span>
+		<span style={{flexShrink: 0}}>{label}</span>
+		{/* The rule between the day and its tally, not after both: run together
+		    they read as one number on the end of the date. */}
+		<span aria-hidden style={dividerRuleStyle} />
+		<span
+			style={{
+				flexShrink: 0,
+				color: GUI_THEME.dim2,
+				fontVariantNumeric: 'tabular-nums',
+			}}
+		>
+			{count}
+		</span>
+	</button>
+);
 
-const toRows = (entries: readonly LogEntry[]): Row[] => {
-	const rows: Row[] = [];
-	let previous: Date | null = null;
+// One element, and one text node inside it. The clock and the kind dot are
+// pseudo-elements of this row rather than spans in it — see EVENT_LOG_STYLES —
+// because the panel holds hundreds of these and three spans apiece is three
+// hundred nodes of nothing.
+const EventRow = ({entry}: {entry: LogEntry}) => (
+	<div
+		data-testid="log-line"
+		className="epiq-log-line"
+		data-time={formatTimeOfDay(new Date(entry.t))}
+		style={{[LOG_DOT_COLOR_PROPERTY]: entry.color} as React.CSSProperties}
+	>
+		{entry.label}
+	</div>
+);
 
-	for (const entry of entries) {
-		const at = new Date(entry.t);
-
-		if (!previous || !isSameDay(previous, at)) {
-			rows.push({
-				kind: 'day',
-				key: `day-${entry.id}`,
-				label: formatDayLabel(at),
-			});
-		}
-
-		rows.push({
-			kind: 'event',
-			key: entry.id,
-			// The clock alone: the divider above a run of lines already names the
-			// day they belong to, and repeating it against each of them says the
-			// same thing twenty times.
-			time: formatTimeOfDay(at),
-			label: entry.label,
-			color: entry.color,
-		});
-
-		previous = at;
-	}
-
-	return rows;
-};
-
-export const EventLog = ({
+const EventLogPanel = ({
 	entries,
 	bottomClearance,
 }: {
@@ -100,27 +141,74 @@ export const EventLog = ({
 	bottomClearance: number;
 }) => {
 	const animate = !usePrefersReducedMotion();
+	const scrollRef = useRef<HTMLDivElement | null>(null);
 	const columnRef = useRef<HTMLDivElement | null>(null);
-	const rows = toRows(entries);
+
+	// A day the reader has folded or opened by hand, against the default of the
+	// newest day alone. Keyed by day, so it outlives the slice moving under it.
+	const [foldOverrides, setFoldOverrides] = useState<
+		ReadonlyMap<string, boolean>
+	>(() => new Map());
+
+	// Walked when the log moves, not when the board beside it repaints — which
+	// during a movie is every animation frame.
+	const days = useMemo(() => groupByDay(entries), [entries]);
 	const newestId = entries[entries.length - 1]?.id ?? null;
+
+	// Whether the pane was at the foot before this render's rows landed, which is
+	// what decides whether it follows them down.
+	const pinnedRef = useRef(true);
+
+	const onScroll = () => {
+		const pane = scrollRef.current;
+		if (!pane) return;
+
+		pinnedRef.current =
+			pane.scrollHeight - pane.scrollTop - pane.clientHeight <= PINNED_SLACK_PX;
+	};
+
+	// Before paint, so a line arriving never shows the pane a frame out of place.
+	// Only while the reader is at the foot: scrolled back, the log is something
+	// being read, and pulling it to the bottom would take that away.
+	useLayoutEffect(() => {
+		const pane = scrollRef.current;
+		if (!pane || !pinnedRef.current) return;
+
+		pane.scrollTop = pane.scrollHeight;
+	}, [newestId, days.length, foldOverrides]);
 
 	// The keys on screen before this render. The column slides by however many
 	// rows joined the bottom, which is not always one: an event that crosses
-	// midnight brings a day header down with it, and a fixed shift would leave
+	// midnight brings a day divider down with it, and a fixed shift would leave
 	// the crawl stepping at every boundary.
 	const shownKeysRef = useRef<Set<string>>(new Set());
 
 	useEffect(() => {
 		const column = columnRef.current;
 		const shown = shownKeysRef.current;
-		const appended = rows.filter(row => !shown.has(row.key)).length;
+		const onScreen = days.flatMap((day, index) =>
+			isDayOpen(days, index, foldOverrides)
+				? [day.key, ...day.entries.map(entry => entry.id)]
+				: [day.key],
+		);
+		const appended = onScreen.filter(key => !shown.has(key)).length;
 
-		shownKeysRef.current = new Set(rows.map(row => row.key));
+		shownKeysRef.current = new Set(onScreen);
 
-		if (!column || !animate || newestId === null || appended === 0) return;
+		// Not while scrolled back: the crawl is the newest line arriving at the
+		// foot, and there is nothing to say about that from up the page.
+		if (
+			!column ||
+			!animate ||
+			newestId === null ||
+			appended === 0 ||
+			!pinnedRef.current
+		) {
+			return;
+		}
 
 		column.animate(crawlShiftFrames(appended), CRAWL_TIMING);
-		// Deliberately keyed on the newest line rather than on `rows`, which is
+		// Deliberately keyed on the newest line rather than on `days`, which is
 		// rebuilt every render: the crawl moves when the log does, not when the
 		// board beside it repaints.
 	}, [newestId, animate]);
@@ -135,110 +223,68 @@ export const EventLog = ({
 				minHeight: 0,
 				display: 'flex',
 				flexDirection: 'column',
-				// The lines sit at the foot of the panel, so the newest is always in
-				// the same place however few of them there are.
-				justifyContent: 'flex-end',
 				borderRight: `1px solid ${GUI_THEME.line}`,
 				background: GUI_THEME.panel,
 			}}
 		>
-			<style>{EVENT_LOG_KEYFRAMES}</style>
+			<style>{EVENT_LOG_STYLES}</style>
 
 			<div
+				ref={scrollRef}
+				onScroll={onScroll}
+				data-testid="event-log-scroll"
 				style={{
-					// The lines run the whole height of the panel and are cut off at
-					// its top, where the fade is. Bounded to the pane rather than to a
-					// row count, so the log reaches the top of whatever height it is
-					// given instead of stopping short in a box of its own.
 					flex: 1,
 					minHeight: 0,
+					overflowY: 'auto',
+					overflowX: 'hidden',
+					// A column, so the block below can push itself down with an auto
+					// margin. `justify-content: flex-end` would do the same until the
+					// content overflowed, at which point it puts the overflow above the
+					// scrollable area, where it cannot be reached.
 					display: 'flex',
 					flexDirection: 'column',
-					// Filled from the bottom, so a new line pushes the column up and the
-					// oldest one off the top into the fade.
-					justifyContent: 'flex-end',
-					overflow: 'hidden',
-					// The clearance keeps the lines off whatever floats over the foot of
-					// the board; the two rows past it are what the crawl slides through
-					// on its way up, which would otherwise be clipped as it went.
 					padding: `0 14px ${bottomClearance + LOG_ROW_HEIGHT * 2}px 30px`,
 					maskImage: CRAWL_MASK,
 					WebkitMaskImage: CRAWL_MASK,
 				}}
 			>
-				<div ref={columnRef}>
-					{rows.map(row => (
-						<div
-							key={row.key}
-							data-testid={row.kind === 'day' ? 'log-day' : 'log-line'}
-							style={{
-								display: 'flex',
-								gap: 10,
-								height: LOG_ROW_HEIGHT,
-								lineHeight: `${LOG_ROW_HEIGHT}px`,
-								fontSize: TEXT.meta,
-								// One clipped line each, which is what makes the crawl even:
-								// every row is the height the column slides by.
-								whiteSpace: 'nowrap',
-								animation: animate ? 'epiqLogLine 260ms ease-out' : undefined,
-							}}
-						>
-							{row.kind === 'day' ? (
-								// A rule either side of the day, so it reads as a divider
-								// between one day's lines and the next rather than as another
-								// line of the log.
-								<>
-									<span aria-hidden style={dividerRuleStyle} />
-									<span
-										style={{
-											color: GUI_THEME.dim,
-											flexShrink: 0,
-										}}
-									>
-										{row.label}
-									</span>
-									<span aria-hidden style={dividerRuleStyle} />
-								</>
-							) : (
-								<>
-									<span
-										style={{
-											color: GUI_THEME.dim2,
-											fontVariantNumeric: 'tabular-nums',
-											flexShrink: 0,
-										}}
-									>
-										{row.time}
-									</span>
-									{/* Between the clock and the line, so a run of them makes a
-									    column of its own down the panel. */}
-									<span
-										data-testid="log-dot"
-										aria-hidden
-										style={{
-											width: DOT_SIZE,
-											height: DOT_SIZE,
-											borderRadius: '50%',
-											background: row.color,
-											flexShrink: 0,
-											alignSelf: 'center',
-										}}
-									/>
-									<span
-										style={{
-											color: GUI_THEME.secondary,
-											overflow: 'hidden',
-											textOverflow: 'ellipsis',
-										}}
-									>
-										{row.label}
-									</span>
-								</>
-							)}
-						</div>
-					))}
+				{/* Holds a short log at the foot of the panel, so the newest line is
+				    always in the same place however few of them there are. */}
+				<div ref={columnRef} style={{marginTop: 'auto'}}>
+					{days.map((day, index) => {
+						const open = isDayOpen(days, index, foldOverrides);
+
+						return (
+							<div key={day.key}>
+								<DayDivider
+									label={day.label}
+									count={day.entries.length}
+									open={open}
+									onToggle={() =>
+										setFoldOverrides(previous => {
+											const next = new Map(previous);
+											next.set(day.key, !open);
+											return next;
+										})
+									}
+								/>
+
+								{/* A folded day is its divider and nothing else: no rows are
+								    built for it, so what the panel costs is what is open. */}
+								{open &&
+									day.entries.map(entry => (
+										<EventRow key={entry.id} entry={entry} />
+									))}
+							</div>
+						);
+					})}
 				</div>
 			</div>
 		</aside>
 	);
 };
+
+// Memoised: the board re-renders on every frame of a movie, and the panel's
+// props change only when the log itself does.
+export const EventLog = memo(EventLogPanel);

--- a/source/gui/client/components/TimeScrubber.tsx
+++ b/source/gui/client/components/TimeScrubber.tsx
@@ -793,7 +793,10 @@ export const TimeScrubber = ({
 		? 'Not while the connection is down'
 		: canPlayTimeline(timeline)
 		? "Play this window of the board's history"
-		: timeline && timeline.buckets.length > 0
+		: // Capped, not empty: the server sends counts alone past its cap, so a
+		// window with no events but plenty of buckets holds too much to play,
+		// not too little. One event fails `canPlayTimeline` too, and has both.
+		timeline && timeline.events.length === 0 && timeline.buckets.length > 0
 		? 'Too many events in this window to play it — narrow the window'
 		: 'Not enough history in this window to play';
 

--- a/source/gui/client/lib/event-log.test.ts
+++ b/source/gui/client/lib/event-log.test.ts
@@ -1,6 +1,7 @@
 import {describe, expect, it} from 'vitest';
 import {
 	buildLogEntries,
+	daysToOpen,
 	groupByDay,
 	isDayOpen,
 	lastIndexAtOrBefore,
@@ -224,12 +225,17 @@ describe('isDayOpen', () => {
 		{id: 'c', t: on(3, 9), label: 'c', color: '#111'},
 	]);
 
-	it('opens the newest day and folds the rest', () => {
+	it('opens the newest days and folds the rest', () => {
 		const none = new Map<string, boolean>();
 
-		expect([0, 1, 2].map(i => isDayOpen(days, i, none))).toEqual([
+		expect([0, 1, 2].map(i => isDayOpen(days, i, none, 1))).toEqual([
 			false,
 			false,
+			true,
+		]);
+		expect([0, 1, 2].map(i => isDayOpen(days, i, none, 2))).toEqual([
+			false,
+			true,
 			true,
 		]);
 	});
@@ -240,7 +246,7 @@ describe('isDayOpen', () => {
 			['2026-09-03', false],
 		]);
 
-		expect([0, 1, 2].map(i => isDayOpen(days, i, overrides))).toEqual([
+		expect([0, 1, 2].map(i => isDayOpen(days, i, overrides, 1))).toEqual([
 			true,
 			false,
 			false,
@@ -257,6 +263,44 @@ describe('isDayOpen', () => {
 			{id: 'd', t: on(4, 9), label: 'd', color: '#111'},
 		]);
 
-		expect(isDayOpen(later, 0, overrides)).toBe(true);
+		expect(isDayOpen(later, 0, overrides, 1)).toBe(true);
+	});
+});
+
+describe('daysToOpen', () => {
+	const dayOf = (day: number, lines: number) =>
+		Array.from({length: lines}, (_, index) => ({
+			id: `d${day}-${index}`,
+			t: on(day, 9) + index * 1000,
+			label: 'x',
+			color: '#111',
+		}));
+
+	// Three days of four lines each: an open day costs its lines plus its
+	// divider, a folded one costs the divider alone.
+	const days = groupByDay([...dayOf(1, 4), ...dayOf(2, 4), ...dayOf(3, 4)]);
+
+	it('opens the newest days until the pane is full', () => {
+		// One open day is 1 + 4 rows, plus 2 for the days still folded: 7, which
+		// leaves a tall pane with room to spare.
+		expect(daysToOpen(days, 20)).toBe(3);
+		expect(daysToOpen(days, 11)).toBe(2);
+	});
+
+	// Stopping short of it would leave the panel mostly empty above a run of
+	// folded dates, which is the thing this exists to avoid — and the overflow
+	// is scrollable.
+	it('opens the day that crosses the pane rather than leaving a gap', () => {
+		expect(daysToOpen(days, 10)).toBe(2);
+	});
+
+	// Otherwise a pane too short for one day would open on a list of dates.
+	it('always opens the newest day, however little room there is', () => {
+		expect(daysToOpen(days, 1)).toBe(1);
+		expect(daysToOpen(days, 0)).toBe(1);
+	});
+
+	it('is nothing to open for an empty log', () => {
+		expect(daysToOpen([], 40)).toBe(0);
 	});
 });

--- a/source/gui/client/lib/event-log.test.ts
+++ b/source/gui/client/lib/event-log.test.ts
@@ -1,6 +1,8 @@
 import {describe, expect, it} from 'vitest';
 import {
 	buildLogEntries,
+	groupByDay,
+	isDayOpen,
 	lastIndexAtOrBefore,
 	LOG_LINES,
 	logEntriesUpTo,
@@ -165,5 +167,96 @@ describe('buildLogEntries', () => {
 			EVENT_CATEGORY_COLORS.assigning,
 			EVENT_CATEGORY_COLORS.tickets,
 		]);
+	});
+});
+
+const DAY = 24 * 60 * 60 * 1000;
+const on = (day: number, hour: number) =>
+	new Date(2026, 8, day, hour).getTime();
+
+describe('groupByDay', () => {
+	const rows = [
+		{id: 'a', t: on(1, 9), label: 'a', color: '#111'},
+		{id: 'b', t: on(1, 17), label: 'b', color: '#111'},
+		{id: 'c', t: on(2, 9), label: 'c', color: '#111'},
+	];
+
+	it('splits into days, oldest first, keeping each day whole', () => {
+		const days = groupByDay(rows);
+
+		expect(days.map(day => day.entries.map(entry => entry.id))).toEqual([
+			['a', 'b'],
+			['c'],
+		]);
+	});
+
+	it('labels each day the way its divider reads', () => {
+		expect(groupByDay(rows)[0]!.label).toBe('Tue, Sep 1');
+	});
+
+	// The key is what a fold is remembered against, so it has to name the day
+	// rather than a position in a slice that keeps moving.
+	it('keys a day by the day itself', () => {
+		const days = groupByDay(rows);
+
+		expect(days.map(day => day.key)).toEqual(['2026-09-01', '2026-09-02']);
+	});
+
+	it('is empty for no entries', () => {
+		expect(groupByDay([])).toEqual([]);
+	});
+
+	// Two events a day apart to the minute are still two days.
+	it('splits on the calendar day, not on elapsed time', () => {
+		const days = groupByDay([
+			{id: 'a', t: on(1, 23), label: 'a', color: '#111'},
+			{id: 'b', t: on(1, 23) + DAY, label: 'b', color: '#111'},
+		]);
+
+		expect(days).toHaveLength(2);
+	});
+});
+
+describe('isDayOpen', () => {
+	const days = groupByDay([
+		{id: 'a', t: on(1, 9), label: 'a', color: '#111'},
+		{id: 'b', t: on(2, 9), label: 'b', color: '#111'},
+		{id: 'c', t: on(3, 9), label: 'c', color: '#111'},
+	]);
+
+	it('opens the newest day and folds the rest', () => {
+		const none = new Map<string, boolean>();
+
+		expect([0, 1, 2].map(i => isDayOpen(days, i, none))).toEqual([
+			false,
+			false,
+			true,
+		]);
+	});
+
+	it('lets a reader open an older day, and fold the newest', () => {
+		const overrides = new Map([
+			['2026-09-01', true],
+			['2026-09-03', false],
+		]);
+
+		expect([0, 1, 2].map(i => isDayOpen(days, i, overrides))).toEqual([
+			true,
+			false,
+			false,
+		]);
+	});
+
+	// The override is keyed by day precisely so that it survives the slice
+	// moving: a day opened by hand stays open as new lines push others off.
+	it('keeps a day open once the newest day is a different one', () => {
+		const overrides = new Map([['2026-09-02', true]]);
+		const later = groupByDay([
+			{id: 'b', t: on(2, 9), label: 'b', color: '#111'},
+			{id: 'c', t: on(3, 9), label: 'c', color: '#111'},
+			{id: 'd', t: on(4, 9), label: 'd', color: '#111'},
+		]);
+
+		expect(isDayOpen(later, 0, overrides)).toBe(true);
 	});
 });

--- a/source/gui/client/lib/event-log.ts
+++ b/source/gui/client/lib/event-log.ts
@@ -138,14 +138,45 @@ export const groupByDay = (entries: readonly LogEntry[]): LogDay[] => {
 	return days;
 };
 
-// Whether a day's lines are shown. Every day is folded but the newest, until a
+// How many of the newest days to open before the pane has been measured, and
+// wherever a measurement is not to be had.
+export const DEFAULT_OPEN_DAYS = 3;
+
+// How many of the newest days to open so the pane is filled. A folded day costs
+// one row; an open one costs a row and its lines.
+//
+// The day that crosses the pane's height is opened rather than left folded: it
+// is what fills the last of the pane, the overflow is scrollable, and stopping
+// short of it leaves the panel mostly empty above a run of folded dates — which
+// is the thing this exists to avoid. The newest day is always open for the same
+// reason, however long it is.
+export const daysToOpen = (
+	days: readonly LogDay[],
+	rowsAvailable: number,
+): number => {
+	let openRows = 0;
+	let opened = 0;
+
+	for (let taken = 1; taken <= days.length; taken++) {
+		opened = taken;
+		openRows += 1 + days[days.length - taken]!.entries.length;
+
+		if (openRows + (days.length - taken) >= rowsAvailable) break;
+	}
+
+	return opened;
+};
+
+// Whether a day's lines are shown. The newest `openCount` days are, until a
 // reader says otherwise — and their say has to outlive the slice moving, which
 // is why the override is keyed by day rather than by index.
 export const isDayOpen = (
 	days: readonly LogDay[],
 	index: number,
 	overrides: ReadonlyMap<string, boolean>,
-): boolean => overrides.get(days[index]!.key) ?? index === days.length - 1;
+	openCount: number,
+): boolean =>
+	overrides.get(days[index]!.key) ?? index >= days.length - openCount;
 
 // A seek can replace the whole column at once. Sliding that far would be a
 // swipe rather than a crawl, so the shift is capped at what an ordinary step

--- a/source/gui/client/lib/event-log.ts
+++ b/source/gui/client/lib/event-log.ts
@@ -7,8 +7,9 @@
 // runs, the checkout while the needle is parked, the present while live — but
 // the slice does not.
 
+import {formatDate, formatDayLabel} from '../../../lib/utils/date.utils.js';
 import {GuiCommitEntry, GuiEventTimelineEntry} from './gui-state.model';
-import {EVENT_CATEGORY_COLORS, GUI_THEME} from './gui-theme';
+import {EVENT_CATEGORY_COLORS, GUI_THEME, TEXT} from './gui-theme';
 import {categoryOf} from './scrubber';
 
 // One line of the log. `color` is the dot it is marked with, which is the whole
@@ -47,16 +48,15 @@ export const buildLogEntries = (
 		})),
 	].sort((left, right) => left.t - right.t);
 
-// How many lines the panel is handed. Enough to fill a tall pane to its top —
-// the panel is a column of the board's full height, and a log that stopped
-// short of it would read as a box parked at the bottom rather than as the
-// board's log.
+// How many lines the panel is handed. Well past what one pane shows, because
+// the pane scrolls and reaching back through it is the point — and because
+// folding, not this, is now what bounds the document: a folded day is one row
+// however many events it holds, so the rows actually mounted are the open
+// days' and nothing else.
 //
-// Still a hard cap on the document, which is the point: what the pane cannot
-// show is clipped into the fade, and the panel costs these rows on a year of
-// history exactly as on an hour. Rows past the pane's height are the only
-// waste, and eighty of them is nothing next to a board of cards.
-export const LOG_LINES = 80;
+// Still a hard cap, so the panel costs the same on a decade of history as on
+// an hour.
+export const LOG_LINES = 400;
 
 // The height of one line, which is what the column shifts by as a line lands.
 // Fixed rather than measured: every row is one clipped line, so the shift is
@@ -112,6 +112,41 @@ export const logEntriesUpTo = <T extends {t: number}>(
 	return events.slice(Math.max(0, last - LOG_LINES + 1), last + 1);
 };
 
+// One day's worth of the log, which is the unit the panel folds by.
+export type LogDay = {
+	// Stable across re-slices, so a day left open stays open as lines arrive.
+	key: string;
+	label: string;
+	entries: LogEntry[];
+};
+
+// Split into days, oldest first, each already labelled the way its divider
+// reads. Grouped here rather than in the panel so what a day *is* — and what
+// identifies it across renders — is settled in one place.
+export const groupByDay = (entries: readonly LogEntry[]): LogDay[] => {
+	const days: LogDay[] = [];
+
+	for (const entry of entries) {
+		const at = new Date(entry.t);
+		const key = formatDate(at);
+		const last = days[days.length - 1];
+
+		if (last?.key === key) last.entries.push(entry);
+		else days.push({key, label: formatDayLabel(at), entries: [entry]});
+	}
+
+	return days;
+};
+
+// Whether a day's lines are shown. Every day is folded but the newest, until a
+// reader says otherwise — and their say has to outlive the slice moving, which
+// is why the override is keyed by day rather than by index.
+export const isDayOpen = (
+	days: readonly LogDay[],
+	index: number,
+	overrides: ReadonlyMap<string, boolean>,
+): boolean => overrides.get(days[index]!.key) ?? index === days.length - 1;
+
 // A seek can replace the whole column at once. Sliding that far would be a
 // swipe rather than a crawl, so the shift is capped at what an ordinary step
 // can be — one line, or a line and the day header it brought with it.
@@ -135,14 +170,54 @@ export const CRAWL_TIMING: KeyframeAnimationOptions = {
 	easing: 'ease-out',
 };
 
-// Mounted with the panel, so it carries its own entrance rather than depending
-// on a player being up to define it.
-export const EVENT_LOG_KEYFRAMES = `
+// A line is one element. Its clock and its dot are drawn as pseudo-elements
+// off the row itself rather than as spans inside it, which is the difference
+// between four nodes a line and one — and the panel can hold hundreds.
+//
+// The clock is `attr()`ed off the row, the dot's colour comes in as a custom
+// property, and both are laid out in `ch` so the columns hold at whatever size
+// the row's font ends up.
+export const LOG_TIME_CHARS = 5;
+export const LOG_DOT_COLOR_PROPERTY = '--epiq-log-dot';
+
+// Mounted with the panel, so it carries its own look rather than depending on
+// a player being up to define it.
+export const EVENT_LOG_STYLES = `
+.epiq-log-line {
+	position: relative;
+	height: ${LOG_ROW_HEIGHT}px;
+	line-height: ${LOG_ROW_HEIGHT}px;
+	font-size: ${TEXT.meta}px;
+	color: ${GUI_THEME.secondary};
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	animation: epiqLogLine 260ms ease-out;
+}
+.epiq-log-line::before {
+	content: attr(data-time);
+	display: inline-block;
+	width: ${LOG_TIME_CHARS}ch;
+	margin-right: 14px;
+	color: ${GUI_THEME.dim2};
+	font-variant-numeric: tabular-nums;
+}
+.epiq-log-line::after {
+	content: '';
+	position: absolute;
+	left: calc(${LOG_TIME_CHARS}ch + 4px);
+	top: 50%;
+	width: 5px;
+	height: 5px;
+	margin-top: -2.5px;
+	border-radius: 50%;
+	background: var(${LOG_DOT_COLOR_PROPERTY});
+}
 @keyframes epiqLogLine {
 	from { opacity: 0; }
 	to { opacity: 1; }
 }
 @media (prefers-reduced-motion: reduce) {
-	@keyframes epiqLogLine { from { opacity: 1; } to { opacity: 1; } }
+	.epiq-log-line { animation: none; }
 }
 `;

--- a/source/lib/utils/date.utils.ts
+++ b/source/lib/utils/date.utils.ts
@@ -53,6 +53,11 @@ const MONTH_LABELS = [
 	'Dec',
 ];
 
+// The day as a sortable key, which is what a list groups by. The label a reader
+// sees is formatDayLabel below.
+export const formatDate = (date: Date): string =>
+	`${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+
 export const formatMonth = (date: Date): string =>
 	MONTH_LABELS[date.getMonth()]!;
 

--- a/source/test/e2e-gui/theatre.pw.ts
+++ b/source/test/e2e-gui/theatre.pw.ts
@@ -204,9 +204,18 @@ test('the pop-out puts the log beside the board', async ({
 	// than repeated on every line.
 	await expect(page.getByTestId('log-day').first()).toBeVisible();
 
-	// Every line is marked with its kind, commits included — the dot is the
-	// whole of what separates one from a board event.
-	expect(await page.getByTestId('log-dot').count()).toBe(await lines.count());
+	// Every line is marked with its kind, commits included. The dot is a
+	// pseudo-element rather than a node of its own — the panel holds hundreds of
+	// these — so what is asserted is the colour each row hands it.
+	// Evaluated as a string, like the other DOM reads in this suite: these files
+	// are type-checked against the Node libs, which have no `HTMLElement`.
+	const dotColours = (await page.evaluate(
+		`[...document.querySelectorAll('[data-testid="log-line"]')]` +
+			`.map(row => row.style.getPropertyValue('--epiq-log-dot').trim())`,
+	)) as string[];
+
+	expect(dotColours).toHaveLength(await lines.count());
+	expect(dotColours.every(colour => colour.length > 0)).toBe(true);
 
 	// A panel, not a wash over the board: it takes its own width and the first
 	// swimlane starts to the right of where it ends.
@@ -294,6 +303,38 @@ test('the log picks up what happens on the board while it is open', async ({
 	// board that has already filled it a new line pushes the oldest off the top
 	// instead of adding to the tally.
 	await expect(page.getByTestId('event-log')).toContainText(name);
+
+	await box.click();
+	await expect(page.getByTestId('event-log')).toHaveCount(0);
+	expect(pageErrors).toEqual([]);
+});
+
+// Folding is what bounds the panel: a folded day is one row however many
+// events it holds, so a long history is a handful of rows until asked for.
+test('a day folds to its divider and opens again', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await openBoard(page, appUrl);
+
+	const box = page.getByRole('checkbox', {name: 'Log', exact: true});
+	await box.click();
+
+	const lines = page.getByTestId('log-line');
+	await expect.poll(async () => await lines.count()).toBeGreaterThan(0);
+
+	// The newest day is the one open by default.
+	const day = page.getByTestId('log-day').last();
+	await expect(day).toHaveAttribute('aria-expanded', 'true');
+
+	await day.click();
+	await expect(day).toHaveAttribute('aria-expanded', 'false');
+	await expect(lines).toHaveCount(0);
+
+	await day.click();
+	await expect(day).toHaveAttribute('aria-expanded', 'true');
+	await expect.poll(async () => await lines.count()).toBeGreaterThan(0);
 
 	await box.click();
 	await expect(page.getByTestId('event-log')).toHaveCount(0);


### PR DESCRIPTION
## 6V949JX — the log folds by day, and its pane scrolls

The panel showed only what fitted its height and clipped the rest into the fade. Now each day is a group under its divider — a chevron, the day, and how many lines it holds — and the pane scrolls back through what is loaded.

Days open by default to fill the pane: it measures its own height and opens as many of the newest as fit, including the one that crosses the line, since stopping short of that leaves the panel mostly empty above a run of folded dates and the overflow is scrollable anyway. Three days is the fallback for the first frame, measured in a layout effect so nothing grows on screen. A fold is remembered per *day*, not per position, so a day opened by hand stays open as new lines push others off the slice.

The pane stays pinned to the bottom as lines land, but only while it is already there — scrolled back, the log is something being read.

Two notes for the next reader:

- `justify-content: flex-end` on a scroll container puts the overflow *above* the scrollable area, where it cannot be reached. The column pushes itself down with `margin-top: auto` instead.
- Folding, not the slice, is now what bounds the document, so the cap could rise from 80 lines to 400.

**Fewer nodes.** A line was a `div` and three spans; it is one element with one text node. The clock is `content: attr(data-time)` and the kind dot an `::after`, both pseudo-elements, with the dot's colour arriving as a custom property. Measured on a seeded board: 58 open lines in 125 nodes for the whole panel, against roughly 290 before.

**Less work.** The day grouping is memoised on the entries, the slice on the moment, and the panel wrapped in `memo` — the board re-renders on every animation frame of a movie, and none of that has to follow it. A folded day builds no rows at all.

## 78E8683 — the text filter says when it is on

An accent border and a faint ring while the field holds a filter. It was the only one of the board's narrowings with nothing to say it was active, so a word typed a while ago read as a board that had lost its tickets.

## Verified

1107 unit tests, 122 GUI e2e, on the rebased tree.

A `/code-review high` pass found three, all fixed here:

- **A regression from this stack's own earlier fix.** Wiring the log into `refreshOn` meant *every* state broadcast re-fetched the window while the panel was open — and each re-fetch is a full server-side replay of the event log plus a `git log`. Dragging the needle made one roughly eight times a second. The board's changes now settle for 400ms before the log asks, while the "Scope only" narrowing keeps asking immediately, because that one hides tickets and cannot wait.
- Pressing Play flipped `refreshOn` from a value to null, which is itself a dependency change — so starting a movie fetched a window anchored to *now*, later than the one the movie was planned from, and the log lost the very lines the playhead was about to narrate. The scrubber is handed a counter that simply stops moving during a movie instead.
- The disabled Play button's two explanations were inverted for a one-event window, which has both no playable pair and a bucket, so it read "too many events" when the truth was the opposite.
