### PR TITLE
14HBAF8 Log readability: say what a comment said, widen the pane, drop the fade

### DIFF
--- a/source/gui/client/components/EventLog.tsx
+++ b/source/gui/client/components/EventLog.tsx
@@ -38,18 +38,7 @@ import {usePrefersReducedMotion} from '../lib/scrubber';
 import {IconChevronDown} from './IconChevronDown';
 import {IconChevronRight} from './IconChevronRight';
 
-const LOG_WIDTH = 380;
-
-// How many rows the top of the log dissolves over. Measured in rows rather than
-// as a share of anything, so the fade is the same depth whatever height the
-// panel happens to have.
-const FADE_ROWS = 3;
-
-// Dissolves the top of the pane so lines leave rather than being cut off. Both
-// spellings, since the unprefixed property is not in Safari.
-const CRAWL_MASK = `linear-gradient(to bottom, transparent 0, #000 ${
-	FADE_ROWS * LOG_ROW_HEIGHT
-}px)`;
+const LOG_WIDTH = 440;
 
 // How near the foot counts as being at it. A couple of rows, so a pin survives
 // a sub-pixel scroll position or a rounding difference between scrollHeight and
@@ -281,8 +270,6 @@ const EventLogPanel = ({
 					display: 'flex',
 					flexDirection: 'column',
 					padding: `0 14px ${bottomClearance + LOG_ROW_HEIGHT * 2}px 30px`,
-					maskImage: CRAWL_MASK,
-					WebkitMaskImage: CRAWL_MASK,
 				}}
 			>
 				{/* Holds a short log at the foot of the panel, so the newest line is

--- a/source/mcp/epiq-time-travel.ts
+++ b/source/mcp/epiq-time-travel.ts
@@ -197,14 +197,39 @@ const issueOf = (
 
 // The TUI's phrasing minus the details that need state. A renamed tag reads
 // under its original name, which is what the log itself says happened.
+// How much of a comment the timeline carries. A window can hold twenty
+// thousand events and every one of them is shipped to the browser, so the whole
+// body is not on offer — enough to recognise which comment it was.
+const COMMENT_PREVIEW_CHARS = 90;
+
+// The first line of a comment, flattened. A body is markdown and often several
+// paragraphs; a log line is one line.
+const commentPreview = (md: string): string => {
+	const firstLine = md.trim().split('\n')[0]?.trim() ?? '';
+
+	return firstLine.length > COMMENT_PREVIEW_CHARS
+		? `${firstLine.slice(0, COMMENT_PREVIEW_CHARS).trimEnd()}…`
+		: firstLine;
+};
+
 const describeTimelineEvent = (
 	event: AppEvent,
 	names: Map<string, string>,
 ): string => {
 	const payload = event.payload as
-		| {name?: string; assignee?: string}
+		| {name?: string; assignee?: string; md?: string}
 		| undefined;
 	const tag = tagOf(event);
+
+	const action = event.action ? formatLogAction(event.action) : '';
+
+	// A comment says what it said, after a colon — "Commented" alone is the one
+	// action whose own name tells the reader nothing about it.
+	if (payload?.md !== undefined) {
+		const preview = commentPreview(payload.md);
+
+		return preview ? `${action}: ${preview}` : action;
+	}
 
 	const detail =
 		tag !== undefined
@@ -214,8 +239,6 @@ const describeTimelineEvent = (
 			: payload?.name !== undefined
 			? `"${payload.name}"`
 			: '';
-
-	const action = event.action ? formatLogAction(event.action) : '';
 
 	return [action, detail].filter(Boolean).join(' ');
 };


### PR DESCRIPTION
Three things the log got wrong once there was enough of it to actually read.

**A comment line said only "Commented."** Every other line names what happened — a title, a tag, a person — so a run of comments was a wall of the same word. The label now carries the comment's first line after a colon: `Commented: Had a look — the window derivation is the part to watch.`

Only the first line, and capped at 90 characters. A body is markdown and often several paragraphs, a log line is one line — and a window can hold twenty thousand events, every one of which is shipped to the browser, so the whole body is not on offer.

**The pane was too narrow** for lines that now have something to say. 380px → 440px.

**The fade is gone.** It earned its place when the top of the pane was a hard clip; the pane scrolls and folds now, so all it did was dim lines somebody was reading.

## Verified

1112 unit tests, 123 GUI e2e. Checked in a browser against a seeded board: comments read as intended, the pane measures 441px, and the mask is `none`.

Split out of `38G1FH7 — Break up App.tsx and ScrubberParts.tsx before the next feature lands in them`, which is a pure refactor and must not carry behaviour changes: the suite passing unchanged is its only safety net, and a failure there has to mean the refactor broke something rather than "a feature moved".
