### PR TITLE
FQYNN32 set diff code at the app's own text size

### DIFF
--- a/source/gui/client/components/CodeSnippet.tsx
+++ b/source/gui/client/components/CodeSnippet.tsx
@@ -1,6 +1,11 @@
 import {useState} from 'react';
 import {File} from '@pierre/diffs/react';
 import {GUI_THEME, TEXT} from '../lib/gui-theme';
+import {
+	CODE_FONT,
+	CODE_LINE_HEIGHT,
+	CODE_TEXT_VARS,
+} from '../lib/code-text.style';
 import {CopyShaButton} from './CopyShaButton';
 import {IconChevronDown} from './IconChevronDown';
 import {IconChevronRight} from './IconChevronRight';
@@ -16,13 +21,8 @@ const PIERRE_THEME = 'github-dark';
 // `--diffs-bg` on the shadow host, where only its own CSS can reach.
 const SNIPPET_CSS = `:host { --diffs-bg: ${GUI_THEME.bg}; background-color: ${GUI_THEME.bg}; }`;
 
-const CODE_FONT =
-	'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace';
-
-// Pinned on the highlighter through its own CSS variables so the gutter drawn
-// beside it lands on the same line grid.
-const LINE_HEIGHT = 20;
-const FONT_SIZE = TEXT.ui;
+// The gutter drawn beside the highlighter has to sit on its line grid, so the
+// block's own top padding is pinned here too.
 const BLOCK_GAP = 8;
 
 const bareButton: React.CSSProperties = {
@@ -143,10 +143,9 @@ export const CodeSnippet = ({
 				<div
 					style={
 						{
+							...CODE_TEXT_VARS,
 							display: 'flex',
 							background: GUI_THEME.bg,
-							'--diffs-line-height': `${LINE_HEIGHT}px`,
-							'--diffs-font-size': `${FONT_SIZE}px`,
 							'--diffs-gap-block': `${BLOCK_GAP}px`,
 						} as React.CSSProperties
 					}
@@ -160,8 +159,8 @@ export const CodeSnippet = ({
 								padding: `${BLOCK_GAP}px 8px 0 12px`,
 								textAlign: 'right',
 								fontFamily: CODE_FONT,
-								fontSize: FONT_SIZE,
-								lineHeight: `${LINE_HEIGHT}px`,
+								fontSize: TEXT.ui,
+								lineHeight: `${CODE_LINE_HEIGHT}px`,
 								color: GUI_THEME.dim,
 								userSelect: 'none',
 							}}

--- a/source/gui/client/components/DiffPanel.tsx
+++ b/source/gui/client/components/DiffPanel.tsx
@@ -7,6 +7,7 @@ import {
 	SelectedLineRange,
 } from '@pierre/diffs/react';
 import {GUI_THEME} from '../lib/gui-theme';
+import {CODE_TEXT_VARS} from '../lib/code-text.style';
 import {GuiCommitDiffFile} from '../lib/gui-state.model';
 import {diffLineCount, isLargeDiff} from '../../../lib/utils/diff-size.js';
 import {Button} from './Button';
@@ -60,6 +61,7 @@ export const FileDiffView = <LAnnotation = undefined,>({
 }) => (
 	<div
 		style={{
+			...CODE_TEXT_VARS,
 			marginBottom: 16,
 			border: `1px solid ${GUI_THEME.line}`,
 			borderRadius: 8,

--- a/source/gui/client/lib/code-text.style.ts
+++ b/source/gui/client/lib/code-text.style.ts
@@ -1,0 +1,26 @@
+import {CSSProperties} from 'react';
+import {TEXT} from './gui-theme';
+
+/**
+ * How code is set wherever the app shows it: the diff panel, a commit's files,
+ * a snippet quoted into a comment. The highlighter's own defaults are a step
+ * larger than the app's mono chrome and set in a sans stack, which reads as a
+ * different app embedded in this one — these pin it to the surrounding text
+ * instead. Everything is a CSS variable the highlighter reads, so it inherits
+ * through its shadow root from whatever element carries this.
+ */
+export const CODE_FONT =
+	'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace';
+
+// Sized for the app's mono text, and a line grid anything drawn alongside the
+// highlighter (a gutter, an annotation) has to land on.
+export const CODE_LINE_HEIGHT = 20;
+
+export const CODE_TEXT_VARS = {
+	'--diffs-font-family': CODE_FONT,
+	'--diffs-font-size': `${TEXT.ui}px`,
+	'--diffs-line-height': `${CODE_LINE_HEIGHT}px`,
+	// The file path above a diff is chrome, so it follows the app's chrome
+	// rather than the sans stack the highlighter would pick for it.
+	'--diffs-header-font-family': CODE_FONT,
+} as CSSProperties;


### PR DESCRIPTION
The highlighter's own defaults — 13px code, a sans-serif file header — read a step larger than the app's 12px mono chrome, so a diff looked like a different app embedded in the panel.

A new `source/gui/client/lib/code-text.style.ts` owns how code is set anywhere in the GUI: mono family, `TEXT.ui` size, the 20px line grid, and the file header's family, as `--diffs-*` variables that inherit into the highlighter's shadow root. `FileDiffView` (the commit diff panel and a ticket's Commits tab) spreads them, and `CodeSnippet` now takes the same values instead of restating its own — so a snippet quoted into a comment and the diff it came from stay identical by construction.

Style only; no behaviour change. Checked against a scratch project in the browser, and the pre-push gate is green.