### PR TITLE
1FZCS5K drop the player's pop-out; the Log box is the log's one control

### DIFF
--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -204,9 +204,8 @@ export const App = () => {
 	// Bumped per answered time-travel request. The player's clock waits on it
 	// rather than stacking a checkout on one the server has not answered yet.
 	const [scrubAck, setScrubAck] = useState(0);
-	// The log panel is open. Owned here rather than in the scrubber or the
-	// player: it is a panel in the board's own row, the board moves over for it,
-	// and its checkbox and the player's pop-out are two controls over one flag.
+	// The log panel is open. Owned here rather than in the scrubber: it is a
+	// panel in the board's own row, and the board moves over for it.
 	const [logOpen, setLogOpen] = usePersistedFlag(LOG_STORAGE_KEY, false);
 	const [showIssues, setShowIssues] = usePersistedFlag(
 		SHOW_ISSUES_STORAGE_KEY,
@@ -1965,8 +1964,6 @@ export const App = () => {
 					<TheatrePlayer
 						plan={theatre}
 						playback={playback}
-						logOpen={logOpen}
-						onToggleLog={() => setLogOpen(!logOpen)}
 						onExit={exitTheatre}
 					/>
 				)}

--- a/source/gui/client/components/IconPlayback.tsx
+++ b/source/gui/client/components/IconPlayback.tsx
@@ -65,21 +65,3 @@ export const IconClose = ({size = 14}: {size?: number}) => (
 		<line x1="18" y1="6" x2="6" y2="18" />
 	</svg>
 );
-
-export const IconPopOut = ({size = 12}: {size?: number}) => (
-	<svg
-		width={size}
-		height={size}
-		viewBox="0 0 24 24"
-		fill="none"
-		stroke="currentColor"
-		strokeWidth="2"
-		strokeLinecap="round"
-		strokeLinejoin="round"
-		aria-hidden="true"
-	>
-		<polyline points="14 4 20 4 20 10" />
-		<line x1="20" y1="4" x2="12" y2="12" />
-		<path d="M18 15v4a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V7a1 1 0 0 1 1-1h4" />
-	</svg>
-);

--- a/source/gui/client/components/ScrubberLayout.tsx
+++ b/source/gui/client/components/ScrubberLayout.tsx
@@ -145,7 +145,7 @@ export const ScrubberLayout = ({
 	canPlay: boolean;
 	playTitle: string;
 	onPlay: () => void;
-	// The event log panel, switched here and from the player's own pop-out.
+	// The event log panel, switched from the box in this row.
 	logOpen: boolean;
 	onChangeLogOpen: (next: boolean) => void;
 	// The history player is up and owns the board's position. Nothing on the bar

--- a/source/gui/client/components/TheatrePlayer.tsx
+++ b/source/gui/client/components/TheatrePlayer.tsx
@@ -7,13 +7,7 @@ import {formatDateTime} from '../../../lib/utils/date.utils.js';
 import {GUI_THEME, TEXT} from '../lib/gui-theme';
 import {clamp, usePrefersReducedMotion} from '../lib/scrubber';
 import {THEATRE_KEYFRAMES, TheatrePlan, TheatrePlayback} from '../lib/theatre';
-import {
-	IconClose,
-	IconPause,
-	IconPlay,
-	IconPopOut,
-	IconReplay,
-} from './IconPlayback';
+import {IconClose, IconPause, IconPlay, IconReplay} from './IconPlayback';
 
 // How far an arrow key moves the bar, as a share of the whole movie.
 const SEEK_STEP = 0.02;
@@ -44,16 +38,10 @@ const transportButtonStyle = (primary: boolean): React.CSSProperties => ({
 export const TheatrePlayer = ({
 	plan,
 	playback,
-	logOpen,
-	onToggleLog,
 	onExit,
 }: {
 	plan: TheatrePlan;
 	playback: TheatrePlayback;
-	// Owned above: the log is a panel in the board's own row, so the layout has
-	// to know about it, not just the drawer that opens it.
-	logOpen: boolean;
-	onToggleLog: () => void;
 	onExit: () => void;
 }) => {
 	const animate = !usePrefersReducedMotion();
@@ -364,35 +352,6 @@ export const TheatrePlayer = ({
 									new Date(plan.events[0]!.t),
 							  )}`}
 					</span>
-
-					{/* Beside the line it expands: the caption is the last of the log,
-					    and this is the rest of it. */}
-					<button
-						type="button"
-						data-testid="theatre-log-toggle"
-						aria-pressed={logOpen}
-						onClick={onToggleLog}
-						title={
-							logOpen
-								? 'Hide the log'
-								: 'Show every event as it plays, over the board'
-						}
-						aria-label={logOpen ? 'Hide the log' : 'Show the log'}
-						style={{
-							background: 'transparent',
-							border: 'none',
-							padding: 0,
-							marginLeft: 'auto',
-							color: logOpen ? GUI_THEME.accent : GUI_THEME.dim,
-							cursor: 'pointer',
-							display: 'inline-flex',
-							alignItems: 'center',
-							flexShrink: 0,
-							transition: 'color 160ms ease',
-						}}
-					>
-						<IconPopOut size={12} />
-					</button>
 				</div>
 			</div>
 		</>

--- a/source/gui/client/components/TimeScrubber.tsx
+++ b/source/gui/client/components/TimeScrubber.tsx
@@ -139,8 +139,8 @@ export const TimeScrubber = ({
 	refreshOn: unknown;
 	// Opens the history player over this window.
 	onPlayTheatre: () => void;
-	// The event log panel, which the player's own pop-out also switches. Owned
-	// above because the panel is in the board's row, not in this bar.
+	// The event log panel. Owned above because the panel is in the board's row,
+	// not in this bar.
 	logOpen: boolean;
 	onChangeLogOpen: (next: boolean) => void;
 	// The two series. Owned above because the log is drawn from them too, and it

--- a/source/test/e2e-gui/event-log.pw.ts
+++ b/source/test/e2e-gui/event-log.pw.ts
@@ -1,27 +1,30 @@
 // The event log panel: what it holds, when it updates, and how it folds. The
-// player is one of three things that can drive it (see theatre.pw.ts) and is
-// used here only where the behaviour under test is the log's.
+// player is used here only where the behaviour under test is the log's.
 
 import {expect, test} from './fixtures.js';
 import {openBoard, returnToLive} from './live-board.js';
 
 // The crawl is a slice of the script, not a list grown as events land, which
 // is what keeps a long movie from adding a node per event to the overlay.
-test('the pop-out puts the log beside the board', async ({
+test('the log fills beside the board as the movie plays', async ({
 	page,
 	appUrl,
 	pageErrors,
 }) => {
 	await openBoard(page, appUrl);
-	await page.getByTestId('theatre-play').click();
 
 	const log = page.getByTestId('event-log');
+	const box = page.getByTestId('log-toggle');
+
 	await expect(log).toHaveCount(0);
 
-	const toggle = page.getByTestId('theatre-log-toggle');
-	await toggle.click();
+	// Opened before the movie: the bar stands down while the player owns the
+	// board's position, so the Log box is not there to click once it is up.
+	await box.click();
 	await expect(log).toBeVisible();
-	await expect(toggle).toHaveAttribute('aria-pressed', 'true');
+
+	await page.getByTestId('theatre-play').click();
+	await expect(page.getByTestId('theatre-player')).toBeVisible();
 
 	// Lines arrive as the movie plays. How many the panel holds at most is
 	// event-log.test.ts's job — a bound asserted here would only be a bound on
@@ -57,15 +60,16 @@ test('the pop-out puts the log beside the board', async ({
 	expect(logBox.width).toBeGreaterThan(100);
 	expect(lane.x).toBeGreaterThanOrEqual(logBox.x + logBox.width);
 
-	await toggle.click();
+	await page.getByTestId('theatre-exit').click();
+	await box.click();
 	await expect(log).toHaveCount(0);
 
 	await returnToLive(page);
 	expect(pageErrors).toEqual([]);
 });
 
-// The panel is the board's, not the movie's: the pop-out and the Log box are
-// two controls over one flag, and leaving the player does not take it away.
+// The panel is the board's, not the movie's: the Log box is the only control
+// over it, and leaving the player does not take it away.
 test('the log stays on the board after the player leaves', async ({
 	page,
 	appUrl,


### PR DESCRIPTION
The event log panel now lives in the main UI with its own Log box in the scrubber's control row, so the pop-out in the theatre player was a second control over the same flag. Removed it, along with `IconPopOut` and the `logOpen`/`onToggleLog` props it needed.

The log is still reachable while a movie plays — it is opened from the board before the player goes up, and stays put across entering and leaving the player.

`event-log.pw.ts`'s first test drove the panel from the pop-out; it now opens it from the Log box before starting the movie (the bar stands down once the player owns the board's position) and asserts the same things.

Verified: `npm run build`, `npm run build:gui`, prettier, the full vitest suite (1112 tests), and the `event-log` + `theatre` Playwright suites (12 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MPdHcEfnJuCzudDEncDLo