### PR TITLE
YCT73R9 open a commit's files the way you left the last one

### DIFF
--- a/source/gui/client/components/IssueCommits.tsx
+++ b/source/gui/client/components/IssueCommits.tsx
@@ -22,6 +22,7 @@ import {
 	stripDiffCommentMarker,
 } from '../../../lib/utils/diff-comment.js';
 import {timeAgo} from '../lib/gui-format.helper';
+import {useOpenFilesByDefault} from '../lib/diff-expansion';
 import {ActionRow, Textarea} from './FormPrimitives';
 import {Button} from './Button';
 import {CopyRef} from './CopyRef';
@@ -744,6 +745,7 @@ const CommitRow = ({
 
 	return (
 		<div
+			data-testid="commit-card"
 			style={{
 				border: `1px solid ${GUI_THEME.line}`,
 				borderRadius: 8,
@@ -925,6 +927,7 @@ export const IssueCommits = ({
 	const [expandedFilesBySha, setExpandedFilesBySha] = useState<
 		Record<string, Set<string>>
 	>({});
+	const [openFilesByDefault, setOpenFilesByDefault] = useOpenFilesByDefault();
 
 	const autoOpenedShas = useRef(new Set<string>());
 	const autoOpenedFiles = useRef(new Set<string>());
@@ -950,8 +953,10 @@ export const IssueCommits = ({
 	}, [expandAll, commits]);
 
 	// Files are only known once a diff has arrived, so this runs as they land.
+	// Outside the reading layout it applies to whichever commits the reader has
+	// opened, since those are the only ones whose diffs are ever fetched.
 	useEffect(() => {
-		if (!expandAll) return;
+		if (!expandAll && !openFilesByDefault) return;
 
 		for (const commit of commits) {
 			const files = diffsBySha[commit.sha]?.files;
@@ -968,7 +973,7 @@ export const IssueCommits = ({
 				]),
 			}));
 		}
-	}, [expandAll, commits, diffsBySha]);
+	}, [expandAll, openFilesByDefault, commits, diffsBySha]);
 
 	// Opens the commit and file a permalink names. Deliberately additive — it
 	// never collapses anything the reader already had open, so following a
@@ -1048,6 +1053,11 @@ export const IssueCommits = ({
 			...prev,
 			[sha]: expand ? new Set(filePaths) : new Set(),
 		}));
+
+		// Asking for all of them is also how you say how you like to read, so
+		// the next commit opened follows suit. Only this wholesale control sets
+		// it: opening one file of interest says nothing about the rest.
+		setOpenFilesByDefault(expand);
 	};
 
 	if (loading) return <Empty>Loading commits…</Empty>;

--- a/source/gui/client/components/IssueCommits.tsx
+++ b/source/gui/client/components/IssueCommits.tsx
@@ -931,6 +931,7 @@ export const IssueCommits = ({
 
 	const autoOpenedShas = useRef(new Set<string>());
 	const autoOpenedFiles = useRef(new Set<string>());
+	const settledFiles = useRef(new Set<string>());
 
 	useEffect(() => {
 		if (!expandAll) return;
@@ -953,27 +954,44 @@ export const IssueCommits = ({
 	}, [expandAll, commits]);
 
 	// Files are only known once a diff has arrived, so this runs as they land.
-	// Outside the reading layout it applies to whichever commits the reader has
-	// opened, since those are the only ones whose diffs are ever fetched.
+	const openEveryFile = (sha: string, files: GuiCommitDiffFile[]) => {
+		setExpandedFilesBySha(prev => ({
+			...prev,
+			[sha]: new Set([
+				...(prev[sha] ?? []),
+				// A lockfile opened unasked is what stalls this view, so the
+				// large ones stay shut until they are asked for by name.
+				...files.filter(file => !isLargeDiff(file)).map(file => file.path),
+			]),
+		}));
+	};
+
 	useEffect(() => {
-		if (!expandAll && !openFilesByDefault) return;
+		if (!expandAll) return;
 
 		for (const commit of commits) {
 			const files = diffsBySha[commit.sha]?.files;
 			if (!files || autoOpenedFiles.current.has(commit.sha)) continue;
 
 			autoOpenedFiles.current.add(commit.sha);
-			setExpandedFilesBySha(prev => ({
-				...prev,
-				[commit.sha]: new Set([
-					...(prev[commit.sha] ?? []),
-					// A lockfile opened unasked is what stalls this view, so the
-					// large ones stay shut until they are asked for by name.
-					...files.filter(file => !isLargeDiff(file)).map(file => file.path),
-				]),
-			}));
+			openEveryFile(commit.sha, files);
 		}
-	}, [expandAll, openFilesByDefault, commits, diffsBySha]);
+	}, [expandAll, commits, diffsBySha]);
+
+	// The remembered habit is asked once per commit, the moment its files first
+	// arrive — which outside the reading layout is when the reader opens it,
+	// those being the only commits ever fetched. Deciding then and remembering
+	// that it was decided is what keeps a later "Expand all" from reaching back
+	// and unfolding commits that were opened while the habit was the other way.
+	useEffect(() => {
+		for (const commit of commits) {
+			const files = diffsBySha[commit.sha]?.files;
+			if (!files || settledFiles.current.has(commit.sha)) continue;
+
+			settledFiles.current.add(commit.sha);
+			if (openFilesByDefault) openEveryFile(commit.sha, files);
+		}
+	}, [openFilesByDefault, commits, diffsBySha]);
 
 	// Opens the commit and file a permalink names. Deliberately additive — it
 	// never collapses anything the reader already had open, so following a
@@ -1056,8 +1074,10 @@ export const IssueCommits = ({
 
 		// Asking for all of them is also how you say how you like to read, so
 		// the next commit opened follows suit. Only this wholesale control sets
-		// it: opening one file of interest says nothing about the rest.
-		setOpenFilesByDefault(expand);
+		// it: opening one file of interest says nothing about the rest. And not
+		// from the reading layout, which unfolds everything whatever the habit
+		// says — there the button means "hide this one", not "and the next".
+		if (!expandAll) setOpenFilesByDefault(expand);
 	};
 
 	if (loading) return <Empty>Loading commits…</Empty>;

--- a/source/gui/client/lib/diff-expansion.ts
+++ b/source/gui/client/lib/diff-expansion.ts
@@ -1,0 +1,29 @@
+import {useState} from 'react';
+
+/**
+ * Whether a commit opens with its files already unfolded.
+ *
+ * The reader's last "Expand all" or "Collapse all" is the answer: reading two
+ * commits in a row is the common case, and having to ask for the same thing
+ * again on the second one is the annoyance. It is per browser rather than per
+ * board, like the panel's dock and width — a reading habit, not a property of
+ * the work.
+ */
+const OPEN_FILES_STORAGE_KEY = 'epiq.commits.openFiles';
+
+export const readStoredOpenFiles = (): boolean =>
+	localStorage.getItem(OPEN_FILES_STORAGE_KEY) === 'true';
+
+// Read in the initializer rather than an effect: the first commit opened after
+// a reload should already know the answer, not unfold a frame later.
+export const useOpenFilesByDefault = (): [boolean, (next: boolean) => void] => {
+	const [openFiles, setOpenFiles] = useState(readStoredOpenFiles);
+
+	return [
+		openFiles,
+		(next: boolean) => {
+			setOpenFiles(next);
+			localStorage.setItem(OPEN_FILES_STORAGE_KEY, String(next));
+		},
+	];
+};

--- a/source/test/e2e-gui/expand-memory.pw.ts
+++ b/source/test/e2e-gui/expand-memory.pw.ts
@@ -38,6 +38,7 @@ test('a commit opens its files the way the last one was left', async ({
 	// and it is the one that speaks for how the reader likes to read.
 	const first = [`first-${ref}-a.txt`, `first-${ref}-b.txt`];
 	const second = [`second-${ref}-a.txt`, `second-${ref}-b.txt`];
+	const third = [`third-${ref}-a.txt`, `third-${ref}-b.txt`];
 	commitLinkedFiles(repoRoot, ref, 'first change', {
 		[first[0]!]: 'alpha\nbeta\n',
 		[first[1]!]: 'gamma\ndelta\n',
@@ -46,47 +47,70 @@ test('a commit opens its files the way the last one was left', async ({
 		[second[0]!]: 'epsilon\nzeta\n',
 		[second[1]!]: 'eta\ntheta\n',
 	});
+	commitLinkedFiles(repoRoot, ref, 'third change', {
+		[third[0]!]: 'iota\nkappa\n',
+		[third[1]!]: 'lambda\nmu\n',
+	});
 
 	await page.waitForTimeout(COMMIT_CACHE_MS);
 	await page.reload();
 	await expect(page.locator('aside')).toContainText(`Expand ${stamp}`);
 	await page.getByRole('button', {name: /^Commits/}).click();
 
-	// The first commit opens shut, as it always has.
+	// Scoped to their own cards throughout: the list is newest first, and more
+	// than one card carries a control by the same name once they are open.
+	const card = (subject: string) =>
+		page.getByTestId('commit-card').filter({hasText: subject});
+
+	// Both open shut, as they always have.
 	await page.getByRole('button', {name: 'first change'}).click();
-	const firstFile = page.getByRole('button', {name: first[0]!});
-	await expect(firstFile).toHaveAttribute('aria-expanded', 'false');
-
-	await page.getByRole('button', {name: 'Expand all'}).click();
-	await expect(firstFile).toHaveAttribute('aria-expanded', 'true');
-
-	// The second one takes the hint without being asked.
 	await page.getByRole('button', {name: 'second change'}).click();
+	const firstFile = page.getByRole('button', {name: first[0]!});
 	const secondFile = page.getByRole('button', {name: second[0]!});
+	await expect(firstFile).toHaveAttribute('aria-expanded', 'false');
+	await expect(secondFile).toHaveAttribute('aria-expanded', 'false');
+
+	await card('second change').getByRole('button', {name: 'Expand all'}).click();
 	await expect(secondFile).toHaveAttribute('aria-expanded', 'true');
-	await expect(page.getByRole('button', {name: second[1]!})).toHaveAttribute(
+
+	// The habit is for what you open next. A commit already sitting open was
+	// left the way the reader left it, and does not unfold underneath them.
+	await expect(firstFile).toHaveAttribute('aria-expanded', 'false');
+	await expect(
+		card('first change').getByRole('button', {name: 'Expand all'}),
+	).toBeVisible();
+
+	// The next one opened takes the hint without being asked.
+	await page.getByRole('button', {name: 'third change'}).click();
+	const thirdFile = page.getByRole('button', {name: third[0]!});
+	await expect(thirdFile).toHaveAttribute('aria-expanded', 'true');
+	await expect(page.getByRole('button', {name: third[1]!})).toHaveAttribute(
 		'aria-expanded',
 		'true',
 	);
-	// Scoped to its own card: the list is newest first, and both commits are
-	// open by now, so an unscoped button matches either one.
-	const secondCard = page
-		.getByTestId('commit-card')
-		.filter({hasText: 'second change'});
-
 	// Already open, so its own control offers the other direction.
 	await expect(
-		secondCard.getByRole('button', {name: 'Collapse all'}),
+		card('third change').getByRole('button', {name: 'Collapse all'}),
 	).toBeVisible();
 
 	// Asking for the opposite is remembered just as readily, across a reload.
-	await secondCard.getByRole('button', {name: 'Collapse all'}).click();
-	await expect(secondFile).toHaveAttribute('aria-expanded', 'false');
+	await card('third change')
+		.getByRole('button', {name: 'Collapse all'})
+		.click();
+	await expect(thirdFile).toHaveAttribute('aria-expanded', 'false');
 
 	await page.reload();
 	await expect(page.locator('aside')).toContainText(`Expand ${stamp}`);
 	await page.getByRole('button', {name: /^Commits/}).click();
 	await page.getByRole('button', {name: 'first change'}).click();
+
+	// The card's own control, not the file's `aria-expanded`: unfolding lands
+	// in an effect, a frame after the collapsed one is painted, so a shut file
+	// is what this would see either way. The button reads off the settled
+	// state, so "Expand all" is only there while they really are all shut.
+	await expect(
+		card('first change').getByRole('button', {name: 'Expand all'}),
+	).toBeVisible();
 	await expect(page.getByRole('button', {name: first[0]!})).toHaveAttribute(
 		'aria-expanded',
 		'false',

--- a/source/test/e2e-gui/expand-memory.pw.ts
+++ b/source/test/e2e-gui/expand-memory.pw.ts
@@ -1,0 +1,96 @@
+import type {Page} from '@playwright/test';
+import {expect, test} from './fixtures.js';
+import {COMMIT_CACHE_MS, commitLinkedFiles} from './linked-commit.js';
+
+const addTicket = async (page: Page, title: string) => {
+	await page.getByTitle('Add issue').first().click();
+	await page.getByPlaceholder('issue name').fill(title);
+	await page.getByPlaceholder('issue name').press('Enter');
+	await expect(page.locator('aside')).toContainText(title);
+};
+
+const refOf = async (page: Page): Promise<string> => {
+	const ref = (
+		await page.locator('aside button[title^="Copy "]').first().textContent()
+	)?.trim();
+	expect(ref).toBeTruthy();
+
+	return ref!;
+};
+
+test.beforeEach(async ({page, appUrl}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+});
+
+// Reading two commits in a row is the common case, and asking for the same
+// unfolding on the second one is the annoyance this remembers away.
+test('a commit opens its files the way the last one was left', async ({
+	page,
+	pageErrors,
+	repoRoot,
+}) => {
+	const stamp = Date.now();
+	await addTicket(page, `Expand ${stamp}`);
+	const ref = await refOf(page);
+
+	// Two files apiece: the wholesale control only appears with more than one,
+	// and it is the one that speaks for how the reader likes to read.
+	const first = [`first-${ref}-a.txt`, `first-${ref}-b.txt`];
+	const second = [`second-${ref}-a.txt`, `second-${ref}-b.txt`];
+	commitLinkedFiles(repoRoot, ref, 'first change', {
+		[first[0]!]: 'alpha\nbeta\n',
+		[first[1]!]: 'gamma\ndelta\n',
+	});
+	commitLinkedFiles(repoRoot, ref, 'second change', {
+		[second[0]!]: 'epsilon\nzeta\n',
+		[second[1]!]: 'eta\ntheta\n',
+	});
+
+	await page.waitForTimeout(COMMIT_CACHE_MS);
+	await page.reload();
+	await expect(page.locator('aside')).toContainText(`Expand ${stamp}`);
+	await page.getByRole('button', {name: /^Commits/}).click();
+
+	// The first commit opens shut, as it always has.
+	await page.getByRole('button', {name: 'first change'}).click();
+	const firstFile = page.getByRole('button', {name: first[0]!});
+	await expect(firstFile).toHaveAttribute('aria-expanded', 'false');
+
+	await page.getByRole('button', {name: 'Expand all'}).click();
+	await expect(firstFile).toHaveAttribute('aria-expanded', 'true');
+
+	// The second one takes the hint without being asked.
+	await page.getByRole('button', {name: 'second change'}).click();
+	const secondFile = page.getByRole('button', {name: second[0]!});
+	await expect(secondFile).toHaveAttribute('aria-expanded', 'true');
+	await expect(page.getByRole('button', {name: second[1]!})).toHaveAttribute(
+		'aria-expanded',
+		'true',
+	);
+	// Scoped to its own card: the list is newest first, and both commits are
+	// open by now, so an unscoped button matches either one.
+	const secondCard = page
+		.getByTestId('commit-card')
+		.filter({hasText: 'second change'});
+
+	// Already open, so its own control offers the other direction.
+	await expect(
+		secondCard.getByRole('button', {name: 'Collapse all'}),
+	).toBeVisible();
+
+	// Asking for the opposite is remembered just as readily, across a reload.
+	await secondCard.getByRole('button', {name: 'Collapse all'}).click();
+	await expect(secondFile).toHaveAttribute('aria-expanded', 'false');
+
+	await page.reload();
+	await expect(page.locator('aside')).toContainText(`Expand ${stamp}`);
+	await page.getByRole('button', {name: /^Commits/}).click();
+	await page.getByRole('button', {name: 'first change'}).click();
+	await expect(page.getByRole('button', {name: first[0]!})).toHaveAttribute(
+		'aria-expanded',
+		'false',
+	);
+
+	expect(pageErrors).toEqual([]);
+});


### PR DESCRIPTION
Every commit opened shut, so reading two in a row meant clicking **Expand all** twice.

Now the wholesale control also says how you like to read: after Expand all, the next commit you open arrives unfolded and its own button offers Collapse all; after Collapse all, commits go back to opening shut. The choice is per browser, in `localStorage`, the way the panel's dock and width already are — a reading habit rather than a property of the work. Only that wholesale control writes it; opening one file of interest says nothing about the rest.

`source/gui/client/lib/diff-expansion.ts` owns the question, in the shape `aside-dock.ts` established: a key, a read, and a hook read in the initializer so the first commit after a reload already knows the answer rather than unfolding a frame later. Lanes view keeps opening everything regardless — that is what the layout is for — and large diffs stay behind their own guard in both directions.

`expand-memory.pw.ts` walks it: expand all on the first commit, open a second and find it already unfolded, collapse all, reload, and find the first opening shut again. Verified red without the change. The new `commit-card` testid scopes the button to its own card — the commit list is newest first, so an unscoped match takes the wrong one.