### PR TITLE
GSQ7DPM Give the scoped outline room to breathe, and a squarer corner

### DIFF
--- a/source/gui/client/components/ScrubberLayout.tsx
+++ b/source/gui/client/components/ScrubberLayout.tsx
@@ -281,6 +281,7 @@ export const ScrubberLayout = ({
 						{chart.scoped && (
 							<div
 								aria-hidden
+								data-testid="scrubber-scoped"
 								style={{
 									position: 'absolute',
 									inset: `${-SCOPED_OUTLINE_INSET_Y}px ${-SCOPED_OUTLINE_INSET_X}px`,

--- a/source/gui/client/components/ScrubberLayout.tsx
+++ b/source/gui/client/components/ScrubberLayout.tsx
@@ -18,6 +18,8 @@ import {
 	LayoutMode,
 	ScrubberAxis,
 	SCOPED_OUTLINE_COLOR,
+	SCOPED_OUTLINE_INSET_X,
+	SCOPED_OUTLINE_INSET_Y,
 	SCRUBBER_KEYFRAMES,
 	Segment,
 	SeriesPresence,
@@ -262,25 +264,39 @@ export const ScrubberLayout = ({
 							// Crosshair, not a hand: a press picks a moment but a drag picks
 							// out a range, and the pointer has to say the second is on offer.
 							cursor: chart.connected ? 'crosshair' : 'default',
-							// Outline rather than a border: it takes up no space, so
-							// narrowing the board cannot reflow the charts under the
-							// pointer that just clicked.
-							outline: chart.scoped
-								? `1px solid ${SCOPED_OUTLINE_COLOR}`
-								: undefined,
-							outlineOffset: 5,
-							borderRadius: 4,
 							// A drag must never turn into a native text selection or a drag
 							// of the axis labels underneath the pointer.
 							userSelect: 'none',
 							WebkitUserSelect: 'none',
 						}}
 					>
+						{/* The box that says the board is showing this window and
+					    nothing else. Positioned rather than an outline: it takes up
+					    no space either way, so narrowing cannot reflow the charts
+					    under the pointer that just clicked, but insets can differ
+					    per edge where an outline's offset cannot. It needs more room
+					    at the sides than above — the needle's grip overhangs the
+					    live end by half its width — and less above, where the
+					    controls are only TRACK_HIT_PADDING away. */}
+						{chart.scoped && (
+							<div
+								aria-hidden
+								style={{
+									position: 'absolute',
+									inset: `${-SCOPED_OUTLINE_INSET_Y}px ${-SCOPED_OUTLINE_INSET_X}px`,
+									border: `1px solid ${SCOPED_OUTLINE_COLOR}`,
+									// Cornered like the row's buttons, not like a card: this is
+									// chrome around the chart, and 4px read as a pill on a line
+									// this thin.
+									borderRadius: 2,
+									pointerEvents: 'none',
+								}}
+							/>
+						)}
+
 						{/* The gap above the charts, made part of the track for the
 					    pointer and nothing else. Absolutely positioned so it draws
-					    nothing, takes no room, and leaves the scoped outline on the
-					    box it already framed — a padding here would carry that
-					    outline up with it. */}
+					    nothing and takes no room. */}
 						<div
 							aria-hidden
 							style={{

--- a/source/gui/client/lib/scrubber.ts
+++ b/source/gui/client/lib/scrubber.ts
@@ -43,7 +43,10 @@ export const EVENTS_MODE_VERTICAL_PADDING =
 // claims for the pointer without drawing in it: aiming at the top of a tall bar
 // otherwise lands just over it, on nothing. It is exactly the gap, so the strip
 // reaches the controls and no further.
-export const TRACK_HIT_PADDING = 8;
+//
+// Wide enough to hold the scoped outline as well, which is drawn outside the
+// charts and would otherwise run along the underside of the controls.
+export const TRACK_HIT_PADDING = 12;
 
 export const HOVER_HINT_WIDTH = 220;
 
@@ -55,6 +58,14 @@ export const NEEDLE_COLOR = 'rgba(255, 255, 255, 0.62)';
 // Ties the board's narrowing to the window doing it: the accent the checkbox
 // wears while it is on, dimmed to sit around a chart rather than in a row.
 export const SCOPED_OUTLINE_COLOR = 'rgba(118, 212, 255, 0.45)';
+
+// How far that box sits outside the charts. Wider at the sides than above and
+// below: the needle's grip is NEEDLE_GRIP_WIDTH across and centred on its
+// stem, so at the live end it hangs half of that past the charts' own edge and
+// would otherwise be drawn on the line. Above, TRACK_HIT_PADDING is all the
+// room there is before the controls.
+export const SCOPED_OUTLINE_INSET_X = 12;
+export const SCOPED_OUTLINE_INSET_Y = 7;
 
 // Brighter than either highlight: this one is being drawn by hand and has to
 // read against whatever it is dragged over.

--- a/source/test/e2e-gui/window-filter.pw.ts
+++ b/source/test/e2e-gui/window-filter.pw.ts
@@ -88,11 +88,8 @@ test('the scope filter narrows the board to what the window holds, and lets go a
 	await page.goto(zoomed(boardUrl, now - HOUR_MS, now + HOUR_MS));
 	await expect(scopeOnly).toBeChecked();
 	await expect(card(page, title)).toBeVisible();
-	// The timeline is outlined while it is the thing doing the hiding.
-	await expect(page.getByTestId('scrubber-track')).toHaveCSS(
-		'outline-style',
-		'solid',
-	);
+	// The timeline is boxed while it is the thing doing the hiding.
+	await expect(page.getByTestId('scrubber-scoped')).toBeVisible();
 
 	// A stretch that ended before the repository existed holds no event, so it
 	// holds no ticket either.
@@ -105,10 +102,7 @@ test('the scope filter narrows the board to what the window holds, and lets go a
 	await scopeOnly.click();
 	await expect(card(page, title)).toBeVisible();
 	await expect(page).not.toHaveURL(/window=1/);
-	await expect(page.getByTestId('scrubber-track')).not.toHaveCSS(
-		'outline-style',
-		'solid',
-	);
+	await expect(page.getByTestId('scrubber-scoped')).toHaveCount(0);
 
 	// Ticked again on the same page, the ticket goes away a second time — so
 	// the empty board above was the filter and not a board still loading.


### PR DESCRIPTION
The box that frames the charts while **Scope only** is on ran along the underside of the controls and straight through the needle's grip.

Measured on the live page, before → after:

| | before | after |
|---|---|---|
| needle grip → box | 1px | **7px** |
| controls → box | 3px | **5px** |
| corner radius | 4px | **2px** |

## Why it needed more than a bigger offset

The needle's grip is `NEEDLE_GRIP_WIDTH` across and centred on its stem, so at the live end it hangs half that width past the charts' own edge. `outline-offset` is one number for all four edges, and there is no single number that works: the sides need more clearance than the gap above the charts can spare.

So the box is a positioned element now — still absolute, still `pointerEvents: 'none'`, so it takes no layout space and toggling the scope still cannot reflow the charts under the pointer that just clicked. The insets differ per edge: `-7px` vertical, `-12px` horizontal.

`TRACK_HIT_PADDING` goes 8 → 12 alongside it. Its comment says the pointer strip is exactly the gap above the charts, so the two move together rather than drifting apart.

## Test

`window-filter.pw.ts` asserted `outline-style: solid` on the track, which the change broke — the full suite caught it. Both assertions now key off a `scrubber-scoped` testid on the box itself, which is what they meant in the first place: that the timeline is boxed while it is the one hiding tickets, not which CSS property draws the box.

123/123 browser tests green.