### PR TITLE
SJP4WPK Make log lines clickable, each to the view its event belongs in

### DIFF
--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -79,6 +79,7 @@ import {
 	useTheatrePlayback,
 } from './lib/theatre';
 import {useEventLog} from './lib/use-event-log';
+import {LogDestination} from './lib/log-destination';
 import {Input} from './components/FormPrimitives';
 import {useBoardSelection} from './lib/use-board-selection';
 import {BoardSocketActions, useBoardSocket} from './lib/use-board-socket';
@@ -751,14 +752,33 @@ export const App = () => {
 		[knownTicketRefs, boardSlug, navigate],
 	);
 
-	const selectIssueComments = (nextIssueId: string) => {
+	// Opening a ticket at a named tab, as against `selectIssue`, which carries
+	// whichever tab is already open. Used wherever the thing being followed says
+	// which view it belongs in — a comment reference, a log line.
+	const openIssueTab = (nextIssueId: string, tab: IssueDetailsTab) => {
 		if (!boardSlug) return;
 
 		setCommitDiff(null);
 
 		void navigate(
-			`/board/${boardSlug}/issue/${nodeRef(nextIssueId)}?tab=comments`,
+			`/board/${boardSlug}/issue/${nodeRef(nextIssueId)}?tab=${tab}`,
 		);
+	};
+
+	const selectIssueComments = (nextIssueId: string) =>
+		openIssueTab(nextIssueId, 'comments');
+
+	// A log line goes where the thing it names is read: a commit to its diff, a
+	// comment among the comments, anything else to the ticket's overview. Which
+	// of those it is was decided in lib/log-destination and travelled here on
+	// the row.
+	const openLogDestination = (destination: LogDestination) => {
+		if (destination.kind === 'commit') {
+			openCommitDiff(destination.sha);
+			return;
+		}
+
+		openIssueTab(destination.issueId, destination.tab);
 	};
 
 	const changeIssueDetailsTab = (nextTab: IssueDetailsTab) => {
@@ -1614,6 +1634,7 @@ export const App = () => {
 							<EventLog
 								entries={logEntries}
 								bottomClearance={theatre ? THEATRE_PLAYER_CLEARANCE : 0}
+								onOpen={openLogDestination}
 							/>
 						)}
 

--- a/source/gui/client/components/EventLog.tsx
+++ b/source/gui/client/components/EventLog.tsx
@@ -33,6 +33,11 @@ import {
 	LOG_DOT_COLOR_PROPERTY,
 	LOG_ROW_HEIGHT,
 } from '../lib/event-log';
+import {
+	LogDestination,
+	readDestination,
+	rowAttributes,
+} from '../lib/log-destination';
 import {GUI_THEME, TEXT} from '../lib/gui-theme';
 import {usePrefersReducedMotion} from '../lib/scrubber';
 import {IconChevronDown} from './IconChevronDown';
@@ -115,6 +120,8 @@ const EventRow = ({entry}: {entry: LogEntry}) => (
 		data-testid="log-line"
 		className="epiq-log-line"
 		data-time={formatTimeOfDay(new Date(entry.t))}
+		// Absent on a line that leads nowhere, which is what leaves it inert.
+		{...rowAttributes(entry)}
 		style={{[LOG_DOT_COLOR_PROPERTY]: entry.color} as React.CSSProperties}
 	>
 		{entry.label}
@@ -124,8 +131,13 @@ const EventRow = ({entry}: {entry: LogEntry}) => (
 const EventLogPanel = ({
 	entries,
 	bottomClearance,
+	onOpen,
 }: {
 	entries: readonly LogEntry[];
+	// Following a line. One handler on the pane rather than one per row: the
+	// rows carry where they go, and hundreds of closures would be the expensive
+	// half of a feature whose whole point is that it costs nothing until used.
+	onOpen: (destination: LogDestination) => void;
 	// Room to leave at the foot of the column for whatever is floating over it —
 	// the history player's drawer, when one is up. A row past it, because the
 	// crawl starts each line one row low and slides it up.
@@ -257,6 +269,10 @@ const EventLogPanel = ({
 			<div
 				ref={scrollRef}
 				onScroll={onScroll}
+				onClick={event => {
+					const destination = readDestination(event.target);
+					if (destination) onOpen(destination);
+				}}
 				data-testid="event-log-scroll"
 				style={{
 					flex: 1,

--- a/source/gui/client/components/EventLog.tsx
+++ b/source/gui/client/components/EventLog.tsx
@@ -120,6 +120,11 @@ const EventRow = ({entry}: {entry: LogEntry}) => (
 		data-testid="log-line"
 		className="epiq-log-line"
 		data-time={formatTimeOfDay(new Date(entry.t))}
+		// A row is one clipped line, so a long label is cut off with nowhere to
+		// read the rest. Only the browser knows which rows are actually clipped,
+		// but a title costs nothing until it is hovered, where measuring every row
+		// on every render would not.
+		title={entry.label}
 		// Absent on a line that leads nowhere, which is what leaves it inert.
 		{...rowAttributes(entry)}
 		style={{[LOG_DOT_COLOR_PROPERTY]: entry.color} as React.CSSProperties}

--- a/source/gui/client/lib/event-log.test.ts
+++ b/source/gui/client/lib/event-log.test.ts
@@ -190,11 +190,7 @@ const row = (id: string, t: number, label = id): LogEntry => ({
 });
 
 describe('groupByDay', () => {
-	const rows = [
-		row('a', on(1, 9)),
-		row('b', on(1, 17)),
-		row('c', on(2, 9)),
-	];
+	const rows = [row('a', on(1, 9)), row('b', on(1, 17)), row('c', on(2, 9))];
 
 	it('splits into days, oldest first, keeping each day whole', () => {
 		const days = groupByDay(rows);
@@ -223,10 +219,7 @@ describe('groupByDay', () => {
 
 	// Two events a day apart to the minute are still two days.
 	it('splits on the calendar day, not on elapsed time', () => {
-		const days = groupByDay([
-			row('a', on(1, 23)),
-			row('b', on(1, 23) + DAY),
-		]);
+		const days = groupByDay([row('a', on(1, 23)), row('b', on(1, 23) + DAY)]);
 
 		expect(days).toHaveLength(2);
 	});

--- a/source/gui/client/lib/event-log.test.ts
+++ b/source/gui/client/lib/event-log.test.ts
@@ -7,6 +7,7 @@ import {
 	lastIndexAtOrBefore,
 	LOG_LINES,
 	logEntriesUpTo,
+	LogEntry,
 } from './event-log';
 import {GuiCommitEntry, GuiEventTimelineEntry} from './gui-state.model';
 import {EVENT_CATEGORY_COLORS, GUI_THEME} from './gui-theme';
@@ -175,11 +176,24 @@ const DAY = 24 * 60 * 60 * 1000;
 const on = (day: number, hour: number) =>
 	new Date(2026, 8, day, hour).getTime();
 
+// Grouping and folding care about a row's day and nothing else, so where these
+// tests build rows by hand they say only that much. What a row links to is
+// log-destination's, and is tested there.
+const row = (id: string, t: number, label = id): LogEntry => ({
+	id,
+	t,
+	label,
+	color: '#111',
+	issue: null,
+	action: null,
+	sha: null,
+});
+
 describe('groupByDay', () => {
 	const rows = [
-		{id: 'a', t: on(1, 9), label: 'a', color: '#111'},
-		{id: 'b', t: on(1, 17), label: 'b', color: '#111'},
-		{id: 'c', t: on(2, 9), label: 'c', color: '#111'},
+		row('a', on(1, 9)),
+		row('b', on(1, 17)),
+		row('c', on(2, 9)),
 	];
 
 	it('splits into days, oldest first, keeping each day whole', () => {
@@ -210,8 +224,8 @@ describe('groupByDay', () => {
 	// Two events a day apart to the minute are still two days.
 	it('splits on the calendar day, not on elapsed time', () => {
 		const days = groupByDay([
-			{id: 'a', t: on(1, 23), label: 'a', color: '#111'},
-			{id: 'b', t: on(1, 23) + DAY, label: 'b', color: '#111'},
+			row('a', on(1, 23)),
+			row('b', on(1, 23) + DAY),
 		]);
 
 		expect(days).toHaveLength(2);
@@ -220,9 +234,9 @@ describe('groupByDay', () => {
 
 describe('isDayOpen', () => {
 	const days = groupByDay([
-		{id: 'a', t: on(1, 9), label: 'a', color: '#111'},
-		{id: 'b', t: on(2, 9), label: 'b', color: '#111'},
-		{id: 'c', t: on(3, 9), label: 'c', color: '#111'},
+		row('a', on(1, 9)),
+		row('b', on(2, 9)),
+		row('c', on(3, 9)),
 	]);
 
 	it('opens the newest days and folds the rest', () => {
@@ -258,9 +272,9 @@ describe('isDayOpen', () => {
 	it('keeps a day open once the newest day is a different one', () => {
 		const overrides = new Map([['2026-09-02', true]]);
 		const later = groupByDay([
-			{id: 'b', t: on(2, 9), label: 'b', color: '#111'},
-			{id: 'c', t: on(3, 9), label: 'c', color: '#111'},
-			{id: 'd', t: on(4, 9), label: 'd', color: '#111'},
+			row('b', on(2, 9)),
+			row('c', on(3, 9)),
+			row('d', on(4, 9)),
 		]);
 
 		expect(isDayOpen(later, 0, overrides, 1)).toBe(true);
@@ -269,12 +283,9 @@ describe('isDayOpen', () => {
 
 describe('daysToOpen', () => {
 	const dayOf = (day: number, lines: number) =>
-		Array.from({length: lines}, (_, index) => ({
-			id: `d${day}-${index}`,
-			t: on(day, 9) + index * 1000,
-			label: 'x',
-			color: '#111',
-		}));
+		Array.from({length: lines}, (_, index) =>
+			row(`d${day}-${index}`, on(day, 9) + index * 1000, 'x'),
+		);
 
 	// Three days of four lines each: an open day costs its lines plus its
 	// divider, a folded one costs the divider alone.

--- a/source/gui/client/lib/event-log.ts
+++ b/source/gui/client/lib/event-log.ts
@@ -20,6 +20,15 @@ export type LogEntry = {
 	t: number;
 	label: string;
 	color: string;
+	// What the line was about, which is all a click needs to find its way — see
+	// lib/log-destination. Copied off the source entry rather than worked out
+	// here: every event in the window becomes one of these, and at most one of
+	// them is ever followed.
+	//
+	// A board- or swimlane-level event has no ticket and leads nowhere.
+	issue: string | null;
+	action: string | null;
+	sha: string | null;
 };
 
 // Both series in one column, in clock order. Commits are lines and nothing
@@ -37,6 +46,9 @@ export const buildLogEntries = (
 			// The colour its dot already has on the scatter, so a kind reads the
 			// same in both places.
 			color: EVENT_CATEGORY_COLORS[categoryOf(event.action)],
+			issue: event.issue,
+			action: event.action,
+			sha: null,
 		})),
 		// Prefixed, because a sha and a ULID share no namespace and both end up
 		// as React keys in the same column.
@@ -45,6 +57,12 @@ export const buildLogEntries = (
 			t: commit.time,
 			label: commit.subject,
 			color: GUI_THEME.green,
+			// A commit belongs to whichever ticket its subject is prefixed with,
+			// which the board resolves when the line is clicked — it already has to,
+			// for the scatter's own commit dots.
+			issue: null,
+			action: null,
+			sha: commit.sha,
 		})),
 	].sort((left, right) => left.t - right.t);
 

--- a/source/gui/client/lib/log-destination.test.ts
+++ b/source/gui/client/lib/log-destination.test.ts
@@ -1,0 +1,98 @@
+import {describe, expect, it} from 'vitest';
+import {LogEntry} from './event-log';
+import {
+	destinationFromAttributes,
+	destinationOf,
+	rowAttributes,
+} from './log-destination';
+
+const entry = (over: Partial<LogEntry>): LogEntry => ({
+	id: 'e1',
+	t: 1,
+	label: 'a line',
+	color: '#111',
+	issue: null,
+	action: null,
+	sha: null,
+	...over,
+});
+
+describe('destinationOf', () => {
+	it('sends a commit to its own diff', () => {
+		expect(destinationOf(entry({sha: 'abc123'}))).toEqual({
+			kind: 'commit',
+			sha: 'abc123',
+		});
+	});
+
+	it('sends a comment to the tab it was written on', () => {
+		expect(
+			destinationOf(entry({issue: 'i1', action: 'add.issue.comment'})),
+		).toEqual({kind: 'ticket', issueId: 'i1', tab: 'comments'});
+	});
+
+	// Editing and deleting a comment are read there too — the whole category
+	// goes to one place rather than each action being listed twice.
+	it('sends every kind of comment event to the comments', () => {
+		for (const action of ['edit.issue.comment', 'delete.issue.comment']) {
+			expect(destinationOf(entry({issue: 'i1', action}))).toEqual({
+				kind: 'ticket',
+				issueId: 'i1',
+				tab: 'comments',
+			});
+		}
+	});
+
+	it('sends everything else about a ticket to its overview', () => {
+		for (const action of [
+			'edit.description',
+			'edit.title',
+			'add.issue.tag',
+			'add.issue.assignee',
+			'move.node',
+		]) {
+			expect(destinationOf(entry({issue: 'i1', action}))).toEqual({
+				kind: 'ticket',
+				issueId: 'i1',
+				tab: 'overview',
+			});
+		}
+	});
+
+	// A board or swimlane event happened to no ticket, so a click on it has
+	// nowhere to go — and the row must not pretend otherwise.
+	it('leads nowhere from an event with no ticket', () => {
+		expect(destinationOf(entry({action: 'add.swimlane'}))).toBeNull();
+		expect(rowAttributes(entry({action: 'add.swimlane'}))).toBeUndefined();
+	});
+});
+
+// The row carries the answer and the click reads it back; nothing else knows
+// the attribute names, so the pair is only correct together. Reading is over a
+// bare lookup, which is what a DOM element is to this — the `closest` call that
+// finds the row is covered by the browser test.
+describe('rowAttributes and destinationFromAttributes', () => {
+	const roundTrip = (source: LogEntry) => {
+		const attributes = new Map(Object.entries(rowAttributes(source) ?? {}));
+
+		return destinationFromAttributes(name => attributes.get(name) ?? null);
+	};
+
+	it('carries a commit through the attributes and back', () => {
+		const source = entry({sha: 'abc123'});
+
+		expect(roundTrip(source)).toEqual(destinationOf(source));
+	});
+
+	it('carries a ticket and its tab through the attributes and back', () => {
+		for (const action of ['add.issue.comment', 'edit.description']) {
+			const source = entry({issue: 'i1', action});
+
+			expect(roundTrip(source)).toEqual(destinationOf(source));
+		}
+	});
+
+	it('is null for a row carrying nothing', () => {
+		expect(destinationFromAttributes(() => null)).toBeNull();
+	});
+});

--- a/source/gui/client/lib/log-destination.ts
+++ b/source/gui/client/lib/log-destination.ts
@@ -1,0 +1,90 @@
+// Where a log line goes when it is clicked.
+//
+// One question, in one place. The panel stamps the answer onto the row it was
+// already drawing; the board acts on it. Neither knows the rule, and neither
+// knows the attribute names — `rowAttributes` and `readDestination` are
+// inverses of each other and the only two things that do.
+//
+// Carried on the row as a couple of attributes rather than as a route, a link
+// or a handler per line: a window holds up to twenty thousand events, of which
+// exactly one is ever followed, so the route is built on the click.
+
+import {LogEntry} from './event-log';
+import {categoryOf} from './scrubber';
+
+// The tab a ticket opens on. A comment is read among the comments; everything
+// else a line can be about — a title, a description, a tag, an assignee — is
+// on the overview.
+export type LogTicketTab = 'comments' | 'overview';
+
+export type LogDestination =
+	| {kind: 'commit'; sha: string}
+	| {kind: 'ticket'; issueId: string; tab: LogTicketTab};
+
+const SHA_ATTRIBUTE = 'data-log-sha';
+const ISSUE_ATTRIBUTE = 'data-log-issue';
+const TAB_ATTRIBUTE = 'data-log-tab';
+
+// What a click looks for on its way up the tree. Every row that leads anywhere
+// carries it; the ones that lead nowhere do not, which is what makes them
+// inert without a second check.
+export const LOG_ROW_SELECTOR = `[${SHA_ATTRIBUTE}],[${ISSUE_ATTRIBUTE}]`;
+
+const tabFor = (action: string): LogTicketTab =>
+	categoryOf(action) === 'comments' ? 'comments' : 'overview';
+
+export const destinationOf = (entry: LogEntry): LogDestination | null => {
+	if (entry.sha) return {kind: 'commit', sha: entry.sha};
+
+	// Board- and swimlane-level events happened to no ticket, so there is
+	// nowhere to send a reader who clicks one.
+	if (!entry.issue || !entry.action) return null;
+
+	return {kind: 'ticket', issueId: entry.issue, tab: tabFor(entry.action)};
+};
+
+// Spread onto the row. Undefined where the line leads nowhere, so the row is
+// left exactly as it was and the selector above cannot match it.
+export const rowAttributes = (
+	entry: LogEntry,
+): Record<string, string> | undefined => {
+	const destination = destinationOf(entry);
+	if (!destination) return undefined;
+
+	return destination.kind === 'commit'
+		? {[SHA_ATTRIBUTE]: destination.sha}
+		: {
+				[ISSUE_ATTRIBUTE]: destination.issueId,
+				[TAB_ATTRIBUTE]: destination.tab,
+		  };
+};
+
+// The inverse of `rowAttributes`, over a bare lookup rather than an element:
+// reading what a row says is not a DOM question, and keeping it out of one
+// leaves the pair testable together, which is the only way either is correct.
+export const destinationFromAttributes = (
+	get: (name: string) => string | null,
+): LogDestination | null => {
+	const sha = get(SHA_ATTRIBUTE);
+	if (sha) return {kind: 'commit', sha};
+
+	const issueId = get(ISSUE_ATTRIBUTE);
+	if (!issueId) return null;
+
+	return {
+		kind: 'ticket',
+		issueId,
+		tab: get(TAB_ATTRIBUTE) === 'comments' ? 'comments' : 'overview',
+	};
+};
+
+// The row a click landed in. Null when the click missed every row that leads
+// anywhere — the padding, a day divider, the pane itself.
+export const readDestination = (
+	target: EventTarget | null,
+): LogDestination | null => {
+	const row =
+		target instanceof Element ? target.closest(LOG_ROW_SELECTOR) : null;
+
+	return row ? destinationFromAttributes(name => row.getAttribute(name)) : null;
+};

--- a/source/test/e2e-gui/event-log.pw.ts
+++ b/source/test/e2e-gui/event-log.pw.ts
@@ -216,3 +216,50 @@ test('the log obeys the bar\u2019s own filters', async ({
 	await page.getByTestId('log-toggle').click();
 	expect(pageErrors).toEqual([]);
 });
+
+// The row carries where it goes and one handler on the pane reads it back, so
+// what the unit tests cannot cover is exactly this: that a click on a line
+// lands on the view the line named.
+test('a line goes to where the thing it names is read', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await openBoard(page, appUrl);
+	const boardUrl = page.url();
+
+	// The seeded board is a bare project — its log is the two setup commits and
+	// the board and swimlanes, none of which happened to a ticket. So the line
+	// worth following has to be made here.
+	await page.getByTitle('Add issue').first().click();
+	await page.getByPlaceholder('issue name').fill(`Followed ${Date.now()}`);
+	await page.getByPlaceholder('issue name').press('Enter');
+
+	// Filing one opens it, which is the URL under test — so the board goes back
+	// to showing no ticket before the click that has to produce it.
+	await page.goto(boardUrl);
+	await page.getByTestId('log-toggle').click();
+	await expect(page.getByTestId('event-log')).toBeVisible();
+
+	const ticketLine = page.locator('[data-log-issue][data-log-tab="overview"]');
+	await expect.poll(async () => await ticketLine.count()).toBeGreaterThan(0);
+	await ticketLine.first().click();
+
+	await expect(page).toHaveURL(/\/issue\/[A-Z0-9]{7}\?tab=overview/);
+
+	// Board- and swimlane-level events happened to no ticket, and the setup
+	// commits link to none either. They carry no destination at all, which is
+	// what makes them inert without a second check.
+	await page.goto(boardUrl);
+	const inert = page.locator(
+		'[data-testid="log-line"]:not([data-log-issue]):not([data-log-sha])',
+	);
+	await expect.poll(async () => await inert.count()).toBeGreaterThan(0);
+
+	const before = page.url();
+	await inert.first().click();
+	await expect(page).toHaveURL(before);
+
+	await page.getByTestId('log-toggle').click();
+	expect(pageErrors).toEqual([]);
+});


### PR DESCRIPTION
A log line named something that happened somewhere and there was no way to go there.

- a **commit** line opens that commit's diff on its ticket's Code tab
- a **comment** line opens the ticket's Comments tab
- **anything else about a ticket** — a title, a description, a tag, an assignee — opens its overview
- a **board- or swimlane-level** event happened to no ticket, carries nothing, and stays inert

Every one of those routes already existed. What is new is deciding which one a line wants.

## Where the rule lives

`lib/log-destination.ts` owns it end to end. The panel stamps the answer onto the row it was already drawing and the board acts on it — neither knows the rule, and only that module knows the attribute names:

```
destinationOf(entry)              -> {kind:'commit',sha} | {kind:'ticket',issueId,tab} | null
rowAttributes(entry)              -> the data-* for the row, or undefined
destinationFromAttributes(get)    -> reads them back
readDestination(target)           -> closest() + the above
```

`rowAttributes` and `destinationFromAttributes` are inverses, and are tested as a pair — neither is correct alone.

## Cost

A couple of attributes rather than a route, a link or a handler per line: a window holds up to twenty thousand events, of which exactly one is ever followed, so the route is built on the click. `LogEntry` carries only what the server already told it (`issue`, `action`, `sha`) — three copies, no computation. One delegated handler on the pane, not one closure per row. Rows stay one DOM node each.

`selectIssueComments` becomes a call to a generalised `openIssueTab(id, tab)` rather than a second copy of the same navigation.

## Tests

8 unit tests over the rule and the attribute round trip. The `closest()` half needs a DOM, and this repo's vitest has no DOM environment — rather than add jsdom for one test, the parsing rule is separated from the traversal (reading what a row says is not a DOM question) and the traversal is covered by the browser test.

The browser test files a ticket first: **the e2e fixture board has no tickets** — its log is two setup commits plus the board and four swimlanes, all correctly inert, which the test also asserts against. Filing a ticket opens it, so the board is sent back to showing no ticket before the click that has to produce one.

124/124 browser tests green.

Also carries **W83BMQ0** as its own commit: a `title` on each row, so a clipped line can be read by hovering it.