### PR TITLE
7JDF5K8 Say which lane a move went to, and whether it changed lanes

### DIFF
--- a/source/mcp/epiq-time-travel.ts
+++ b/source/mcp/epiq-time-travel.ts
@@ -112,19 +112,26 @@ export type EventTimelineEntry = {
 	issue: string | null;
 };
 
-// Tag and contributor names come from the log's own create events rather than
-// from the materialized state, which getEventTimeline must not touch. Same
-// technique as filterEventsForBoard: build the index as the scan proceeds.
+// Tag, contributor and swimlane names come from the log's own create events
+// rather than from the materialized state, which getEventTimeline must not
+// touch. Same technique as filterEventsForBoard: build the index as the scan
+// proceeds.
+//
+// A name renamed later reads under the one it was created with, which is what
+// the log itself says happened at the moment being described.
+const NAMING_ACTIONS = new Set<EventAction>([
+	'create.tag',
+	'create.contributor',
+	// Carries the lane's name, and is what lets a move say which lane it went
+	// to.
+	'add.swimlane',
+]);
+
 const buildNameIndex = (events: AppEvent[]): Map<string, string> => {
 	const names = new Map<string, string>();
 
 	for (const event of events) {
-		if (
-			event.action !== 'create.tag' &&
-			event.action !== 'create.contributor'
-		) {
-			continue;
-		}
+		if (!NAMING_ACTIONS.has(event.action)) continue;
 
 		const payload = event.payload as {id?: string; name?: string} | undefined;
 
@@ -132,6 +139,36 @@ const buildNameIndex = (events: AppEvent[]): Map<string, string> => {
 	}
 
 	return names;
+};
+
+// Where each node sat before the move an event describes, keyed by that event's
+// id — which is what separates "moved to another lane" from "reordered inside
+// the one it was in".
+//
+// Over the whole log and in causal order, the order loadMergedEvents already
+// returns: a move inside the window is only tellable apart from a reorder by
+// what came before it, which is routinely outside the window.
+const buildPreviousParentIndex = (
+	events: AppEvent[],
+): Map<string, string | undefined> => {
+	const previousParent = new Map<string, string | undefined>();
+	const parentByNode = new Map<string, string>();
+
+	for (const event of events) {
+		const payload = event.payload as {id?: string; parent?: string} | undefined;
+
+		if (!payload?.id || !payload.parent) continue;
+
+		if (event.action === 'move.node') {
+			previousParent.set(event.id, parentByNode.get(payload.id));
+		}
+
+		// Creations seed it and moves update it, so the next move reads where
+		// this one left the node.
+		parentByNode.set(payload.id, payload.parent);
+	}
+
+	return previousParent;
 };
 
 // Which tag an event is about. Tagging a ticket names it as `tag`; deleting or
@@ -215,9 +252,10 @@ const commentPreview = (md: string): string => {
 const describeTimelineEvent = (
 	event: AppEvent,
 	names: Map<string, string>,
+	previousParents: Map<string, string | undefined>,
 ): string => {
 	const payload = event.payload as
-		| {name?: string; assignee?: string; md?: string}
+		| {name?: string; assignee?: string; md?: string; parent?: string}
 		| undefined;
 	const tag = tagOf(event);
 
@@ -229,6 +267,20 @@ const describeTimelineEvent = (
 		const preview = commentPreview(payload.md);
 
 		return preview ? `${action}: ${preview}` : action;
+	}
+
+	// A move says which lane, and whether it changed lanes at all — "Moved
+	// issue" answers neither, and reordering within a lane is the commoner of
+	// the two. Falls back to the bare action where the lane has no create event
+	// in the log to take a name from.
+	if (event.action === 'move.node' && payload?.parent) {
+		const lane = names.get(payload.parent);
+
+		if (!lane) return action;
+
+		return previousParents.get(event.id) === payload.parent
+			? `Moved within ${lane}`
+			: `Moved to ${lane}`;
 	}
 
 	const detail =
@@ -364,6 +416,10 @@ export const getEventTimeline = async (
 	// ULIDs where it means "bug" or "jola".
 	const names = buildNameIndex(eventsResult.value);
 
+	// Over the unscoped log too: a move inside the window is only tellable from
+	// a reorder by where the ticket sat before it, which is routinely outside.
+	const previousParents = buildPreviousParentIndex(eventsResult.value);
+
 	// Over the unscoped log too, so an issue whose board changed since its
 	// add.issue is still recognised as an issue.
 	const issueIndex = buildIssueIndex(eventsResult.value);
@@ -390,7 +446,7 @@ export const getEventTimeline = async (
 						id: event.id,
 						t,
 						action: event.action,
-						label: describeTimelineEvent(event, names),
+						label: describeTimelineEvent(event, names, previousParents),
 						issue: issueOf(event, issueIndex),
 						...identitiesFor(event, names),
 					},

--- a/source/test/epiq-time-travel.test.ts
+++ b/source/test/epiq-time-travel.test.ts
@@ -501,6 +501,149 @@ describe('epiq-time-travel', () => {
 			expect(restored?.tag?.id).toBe('tag-1');
 		});
 
+		// "Moved issue" says neither which lane nor whether the lane changed, and
+		// reordering inside one lane is the commoner of the two.
+		it('says which lane a move went to', async () => {
+			const baseTime = 1_700_000_000_000;
+			const events = [
+				{
+					id: ulid(baseTime),
+					action: 'add.swimlane',
+					payload: {id: 'lane-todo', name: 'Todo', parent: 'b1'},
+				},
+				{
+					id: ulid(baseTime + 1_000),
+					action: 'add.swimlane',
+					payload: {id: 'lane-done', name: 'Done', parent: 'b1'},
+				},
+				{
+					id: ulid(baseTime + 2_000),
+					action: 'add.issue',
+					payload: {id: 'i1', name: 'Ship v2', parent: 'lane-todo'},
+				},
+				{
+					id: ulid(baseTime + 3_000),
+					action: 'move.node',
+					payload: {id: 'i1', parent: 'lane-done', rank: 'a'},
+				},
+			];
+
+			vi.mocked(loadMergedEvents).mockReturnValue(
+				succeeded('events', events as never),
+			);
+
+			const result = await getEventTimeline();
+
+			expect(isSuccess(result)).toBe(true);
+			if (isFail(result)) return;
+
+			expect(result.value.events.at(-1)?.label).toBe('Moved to Done');
+		});
+
+		// The ticket never left the lane, so "Moved to Todo" would read as a lane
+		// change that did not happen.
+		it('says a reorder inside one lane is within it', async () => {
+			const baseTime = 1_700_000_000_000;
+			const events = [
+				{
+					id: ulid(baseTime),
+					action: 'add.swimlane',
+					payload: {id: 'lane-todo', name: 'Todo', parent: 'b1'},
+				},
+				{
+					id: ulid(baseTime + 1_000),
+					action: 'add.issue',
+					payload: {id: 'i1', name: 'Ship v2', parent: 'lane-todo'},
+				},
+				{
+					id: ulid(baseTime + 2_000),
+					action: 'move.node',
+					payload: {id: 'i1', parent: 'lane-todo', rank: 'b'},
+				},
+			];
+
+			vi.mocked(loadMergedEvents).mockReturnValue(
+				succeeded('events', events as never),
+			);
+
+			const result = await getEventTimeline();
+
+			expect(isSuccess(result)).toBe(true);
+			if (isFail(result)) return;
+
+			expect(result.value.events.at(-1)?.label).toBe('Moved within Todo');
+		});
+
+		// Where the ticket sat before a move is routinely outside the window being
+		// drawn, so the index has to be built over the whole log — otherwise every
+		// move at the start of a window reads as a lane change.
+		it('reads the lane a move came from even when it is outside the window', async () => {
+			const baseTime = 1_700_000_000_000;
+			const events = [
+				{
+					id: ulid(baseTime),
+					action: 'add.swimlane',
+					payload: {id: 'lane-todo', name: 'Todo', parent: 'b1'},
+				},
+				{
+					id: ulid(baseTime + 1_000),
+					action: 'add.issue',
+					payload: {id: 'i1', name: 'Ship v2', parent: 'lane-todo'},
+				},
+				{
+					id: ulid(baseTime + 2_000),
+					action: 'move.node',
+					payload: {id: 'i1', parent: 'lane-todo', rank: 'b'},
+				},
+			];
+
+			vi.mocked(loadMergedEvents).mockReturnValue(
+				succeeded('events', events as never),
+			);
+
+			// A window holding the move alone, not the creation that seeded it.
+			const result = await getEventTimeline({
+				start: baseTime + 1_500,
+				end: baseTime + 3_000,
+			});
+
+			expect(isSuccess(result)).toBe(true);
+			if (isFail(result)) return;
+
+			expect(result.value.events.map(entry => entry.label)).toEqual([
+				'Moved within Todo',
+			]);
+		});
+
+		// A lane with no create event in the log has no name to give, and a raw
+		// ULID reads worse than saying less.
+		it('falls back to the bare action for a lane it cannot name', async () => {
+			const baseTime = 1_700_000_000_000;
+			const events = [
+				{
+					id: ulid(baseTime),
+					action: 'add.issue',
+					payload: {id: 'i1', name: 'Ship v2', parent: 'lane-todo'},
+				},
+				{
+					id: ulid(baseTime + 1_000),
+					action: 'move.node',
+					payload: {id: 'i1', parent: 'lane-unknown', rank: 'a'},
+				},
+			];
+
+			vi.mocked(loadMergedEvents).mockReturnValue(
+				succeeded('events', events as never),
+			);
+
+			const result = await getEventTimeline();
+
+			expect(isSuccess(result)).toBe(true);
+			if (isFail(result)) return;
+
+			expect(result.value.events.at(-1)?.label).toBe('Moved issue');
+		});
+
 		it('sorts the entries by time regardless of log order', async () => {
 			const baseTime = 1_700_000_000_000;
 			const events = [


### PR DESCRIPTION
Every move read `Moved issue`, which answers neither question a reader has — not which lane, and not whether the lane changed at all. A reorder inside one lane, the commoner of the two, read identically to a lane change.

Now: `Moved to Done`, and `Moved within Todo`.

## Both answers come from the log

That is the constraint. `getEventTimeline` renders history at arbitrary past moments and must not touch materialized state, so names are built from the log's own create events — the existing `buildNameIndex` already does this for tags and contributors.

- **Lane names** join that index, off `add.swimlane`'s `{id, name}` payload.
- **Where a ticket sat before a move** is a second index, keyed by the move's own event id. Creations seed it, moves update it.

Both are built over the **unscoped** log, in the causal order `loadMergedEvents` already returns (`getSortedEvents`). That is what makes a reorder tellable at all: the move before the one being described is routinely outside the window being drawn, and without it every move at a window's edge would read as a lane change. There is a test pinning exactly that.

A lane with no create event to name it falls back to the bare action rather than printing a ULID.

## Not a TUI change

The TUI already says this, through `formatMoveLogMain` — off live `nodeRepo` state and with chalk, neither of which the GUI timeline can use. `formatLogAction`'s shared `'move.node': 'Moved issue'` entry is untouched, so nothing changes for the TUI.

## Tests

4 new, and 3 verified red without the fix. The fourth — the fallback for an unnamed lane — cannot be red by construction, since the unfixed code produces `Moved issue` anyway; it is a guard on that path, not a regression test.

Nothing here touches ordering, merge, replay or materialization: it is a read-only labelling path with no new event type.

1124/1124 unit, 127/127 browser. Verified on a scratch board seeded with both kinds of move.