### PR TITLE
QG0R6V2 let an agent assume its board name mid-session

### DIFF
--- a/source/mcp/epiq-api.ts
+++ b/source/mcp/epiq-api.ts
@@ -6,6 +6,7 @@ import {execGit} from '../git/git-utils.js';
 import {getStateBranch} from '../git/git-constants.js';
 import {ensureLocalStateBranch, ensureStateBranchWorktree} from '../git/git.js';
 import {syncEpiqWithRemote} from '../git/sync.js';
+import {applyActorNameArgument} from '../lib/config/actor-env.js';
 import {loadSettingsFromConfig} from '../lib/config/user-config.js';
 import {createIssueEvents} from '../lib/event/common-events.js';
 import {ulidTimeMs} from '../lib/event/date-utils.js';
@@ -1524,6 +1525,56 @@ export const tombstoneTag = async (
 	if (isFail(results)) return failed(results.message);
 
 	return succeeded('Deleted tag', {id: tag.id, name: tag.name});
+};
+
+/**
+ * Takes a board identity for the rest of this process. The actor is resolved
+ * per write from the environment, so setting it here reaches the very next
+ * event — no relaunch. A name given at launch wins: `applyActorNameArgument`
+ * refuses to rename a process that was already told who it is.
+ */
+export const assumeActor = async (
+	input: ToolInput & {name: string},
+): Promise<Result<{userId: string; userName: string; registered: boolean}>> => {
+	const applied = applyActorNameArgument(input.name, 'name');
+	if (isFail(applied)) return failed(applied.message);
+
+	const bootResult = await boot(input.repoRoot, {pull: false});
+	if (isFail(bootResult)) return bootResult;
+
+	const actorResult = getActor();
+	if (isFail(actorResult)) return actorResult;
+
+	const stateResult = getStateResult();
+	if (isFail(stateResult)) return stateResult;
+
+	const actor = actorResult.value;
+
+	// Registered here rather than left to the first write, because the log file
+	// name is a lossy storage key — `claude/peter` sanitizes to `claude-peter`
+	// — and the registry is where display names are read from.
+	const isRegistered = Boolean(stateResult.value.contributors[actor.userId]);
+
+	if (!isRegistered) {
+		const results = materializeAndPersistAll(
+			[
+				{
+					id: ulid(),
+					...actor,
+					action: 'create.contributor',
+					payload: {id: actor.userId, name: actor.userName},
+				} satisfies AppEvent<'create.contributor'>,
+			],
+			bootResult.value.stateBranchRoot,
+		);
+
+		if (isFail(results)) return failed(results.message);
+	}
+
+	return succeeded(`Assumed ${actor.userName}`, {
+		...actor,
+		registered: !isRegistered,
+	});
 };
 
 export const restoreTag = async (

--- a/source/mcp/server.ts
+++ b/source/mcp/server.ts
@@ -22,6 +22,7 @@ import {
 	restoreTag,
 	addIssueComment,
 	addIssueTag,
+	assumeActor,
 	closeIssue,
 	createIssue,
 	createSwimlane,
@@ -479,6 +480,19 @@ export const createMcpServer = () => {
 			}),
 		},
 		exclusiveTool(moveIssue),
+	);
+
+	server.registerTool(
+		'epiq_actor_assume',
+		{
+			description:
+				'Take a board identity for the rest of this session, so your writes are attributed to you rather than to the user. Pass the name you announced — the model provider, a slash, then a short human first name, e.g. "claude/peter". Takes effect on the very next write; no relaunch. A name the server was launched with wins, and re-assuming the same name is harmless. Reuse an existing agent identity (epiq_contributor_list) before inventing one: a name is permanent once it has authored anything.',
+			inputSchema: z.object({
+				name: z.string().min(1).max(80),
+				repoRoot: z.string().optional(),
+			}),
+		},
+		exclusiveTool(assumeActor),
 	);
 
 	server.registerTool(

--- a/source/test/actor-assume.test.ts
+++ b/source/test/actor-assume.test.ts
@@ -1,0 +1,170 @@
+import fs from 'node:fs';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {getStateBranchRoot} from '../git/git-storage.js';
+import {ACTOR_NAME_ENV, deriveActorId} from '../lib/config/actor-env.js';
+import {createDefaultEvents} from '../lib/event/event-boot.js';
+import {materializeAndPersistAll} from '../lib/event/event-materialize-and-persist.js';
+import {getPersistFileName} from '../lib/event/event-persist.js';
+import {AppEvent} from '../lib/event/event.model.js';
+import {isFail} from '../lib/model/result-types.js';
+import {
+	assumeActor,
+	createIssue,
+	listBoards,
+	listSwimlanes,
+} from '../mcp/epiq-api.js';
+import {getEventsFile, setupRepo, useTempHome} from './helpers/git-repo.js';
+
+// Taking a name mid-session works because the actor is resolved per write from
+// the environment, never cached at boot.
+
+useTempHome();
+
+const clearActorEnv = () => {
+	delete process.env[ACTOR_NAME_ENV];
+};
+
+beforeEach(clearActorEnv);
+afterEach(clearActorEnv);
+
+describe('assumeActor', () => {
+	it('takes the name for the rest of the process', async () => {
+		const {repoRoot} = await setupRepo();
+
+		const result = await assumeActor({repoRoot, name: 'claude/peter'});
+
+		expect(isFail(result)).toBe(false);
+		expect(!isFail(result) && result.value.userName).toBe('claude/peter');
+		expect(!isFail(result) && result.value.userId).toBe(
+			deriveActorId('claude/peter'),
+		);
+		expect(process.env[ACTOR_NAME_ENV]).toBe('claude/peter');
+	});
+
+	// The log file name is a lossy storage key — the slash does not survive it —
+	// so an unregistered agent would show up as `claude-peter` wherever names are
+	// resolved. Registering at assume time is what keeps the announced name and
+	// the board's name the same string.
+	it('registers the name, because the log file name cannot carry it', async () => {
+		expect(
+			getPersistFileName({
+				userId: deriveActorId('claude/peter'),
+				userName: 'claude/peter',
+			}),
+		).toContain('claude-peter');
+
+		const {repoRoot} = await setupRepo();
+		const result = await assumeActor({repoRoot, name: 'claude/peter'});
+
+		expect(!isFail(result) && result.value.registered).toBe(true);
+
+		// Asserted on the log rather than on the returned flag: the flag says what
+		// was intended, and this says what was actually written for every replay
+		// to read the name back from.
+		const branchRoot = getStateBranchRoot({repoRoot});
+		if (isFail(branchRoot)) throw new Error(branchRoot.message);
+
+		const written = fs.readFileSync(
+			getEventsFile({
+				root: branchRoot.value,
+				fileName: getPersistFileName({
+					userId: deriveActorId('claude/peter'),
+					userName: 'claude/peter',
+				}),
+			}),
+			'utf-8',
+		);
+
+		expect(written).toContain('create.contributor');
+		expect(written).toContain('claude/peter');
+	});
+
+	// Idempotent: an agent re-announcing itself must not mint a second
+	// contributor for an id that already has one.
+	it('registers once, however often the same name is assumed', async () => {
+		const {repoRoot} = await setupRepo();
+
+		await assumeActor({repoRoot, name: 'claude/peter'});
+		const again = await assumeActor({repoRoot, name: 'claude/peter'});
+
+		expect(!isFail(again) && again.value.registered).toBe(false);
+	});
+
+	// A name given at launch is the one the session was told to use; a tool call
+	// must not quietly move the session onto another identity mid-stream.
+	it('refuses a name that fights the one the server was launched with', async () => {
+		process.env[ACTOR_NAME_ENV] = 'claude/peter';
+
+		const {repoRoot} = await setupRepo();
+		const result = await assumeActor({repoRoot, name: 'codex/fred'});
+
+		expect(isFail(result)).toBe(true);
+		expect(process.env[ACTOR_NAME_ENV]).toBe('claude/peter');
+	});
+
+	it('rejects a name that is only whitespace', async () => {
+		const {repoRoot} = await setupRepo();
+
+		expect(isFail(await assumeActor({repoRoot, name: '   '}))).toBe(true);
+	});
+
+	it('rejects a name past the length the log file name can hold', async () => {
+		const {repoRoot} = await setupRepo();
+
+		expect(
+			isFail(await assumeActor({repoRoot, name: 'c/'.padEnd(200, 'x')})),
+		).toBe(true);
+	});
+
+	// The point of the whole feature: not that the tool reports a name, but that
+	// the next thing written to the board is signed with it.
+	it('signs the writes that follow, not just its own answer', async () => {
+		const {repoRoot} = await setupRepo();
+
+		const assumed = await assumeActor({repoRoot, name: 'claude/peter'});
+		if (isFail(assumed)) throw new Error(assumed.message);
+
+		const branchRoot = getStateBranchRoot({repoRoot});
+		if (isFail(branchRoot)) throw new Error(branchRoot.message);
+
+		// A board to file against. Written as the agent, which is also what a real
+		// project has: whoever ran init is a contributor from the first event.
+		const defaults = createDefaultEvents(assumed.value);
+		if (isFail(defaults)) throw new Error(defaults.message);
+
+		const seeded = materializeAndPersistAll(
+			[...defaults.value] as AppEvent[],
+			branchRoot.value,
+		);
+		if (isFail(seeded)) throw new Error(seeded.message);
+
+		const boards = await listBoards({repoRoot});
+		if (isFail(boards)) throw new Error(boards.message);
+
+		const swimlanes = await listSwimlanes({
+			repoRoot,
+			boardId: boards.value[0]!.id,
+		});
+		if (isFail(swimlanes)) throw new Error(swimlanes.message);
+
+		const created = await createIssue({
+			repoRoot,
+			title: 'written by the agent',
+			parentId: swimlanes.value[0]!.id,
+		});
+		if (isFail(created)) throw new Error(created.message);
+
+		// Attribution is the file the event landed in: the actor id is parsed back
+		// out of the log's name, never carried in the payload.
+		const agentLog = fs.readFileSync(
+			getEventsFile({
+				root: branchRoot.value,
+				fileName: getPersistFileName(assumed.value),
+			}),
+			'utf-8',
+		);
+
+		expect(agentLog).toContain('written by the agent');
+		expect(assumed.value.userId).toBe(deriveActorId('claude/peter'));
+	});
+});

--- a/source/test/mcp-lock.test.ts
+++ b/source/test/mcp-lock.test.ts
@@ -11,6 +11,7 @@ vi.mock('../mcp/epiq-api.js', () => ({
 	restoreTag: vi.fn(),
 	addIssueComment: vi.fn(),
 	addIssueTag: vi.fn(),
+	assumeActor: vi.fn(),
 	closeIssue: vi.fn(),
 	createIssue: vi.fn(),
 	createSwimlane: vi.fn(),


### PR DESCRIPTION
Adds `epiq_actor_assume({name})`, so an agent can take its own board identity without the user relaunching the session.

**Why it works with no new plumbing.** Nothing between a tool call and the resolved actor caches: `getActor()` runs per write, `loadSettingsFromConfig()` has no memo, `readEpiqConfig()` re-reads the file, and `resolveEnvActor` reads `process.env` live. `applyActorNameArgument` already sets `EPIQ_USER_NAME` on the server's own process — it was just never wired to a tool. So the name takes effect on the very next event.

**Why it registers a contributor.** `sanitizeFilePart` is lossy by design, so `claude/peter` becomes `claude-peter` in the log file name, and that name is a storage key, never a display value. Without a `create.contributor` the agent would show up under the mangled name wherever names resolve. Registering at assume time keeps the announced name and the board's name the same string. It is skipped when the id is already registered, so re-announcing mints nothing.

**Safety comes from the existing guards.** A name given at launch wins (`applyActorNameArgument` refuses to rename a process already told who it is), re-assuming the same name is idempotent, and `resolveEnvActor` still refuses to fork the configured user or write under their id.

No lock. The log is a CRDT that welcomes concurrent writers — union merge, order derived from `refId` plus the ULID tiebreak — so two agents sharing a name converge; they just stop being tellable apart. That is caught by the agent announcing its name at the start of a session, where a human can redirect it, rather than by machinery that would need consensus.

**Tests** — `source/test/actor-assume.test.ts`, seven cases against a real temp project: the name is taken and derived to the right id, it is registered with the slash intact, registration happens once, a launch-time name wins, whitespace and over-long names are refused, and — the one that matters — an issue created afterwards lands in the agent's own log file. Each was verified red: stubbing out the registration fails two, stubbing out the env application fails four.

Full gate run locally: 1125 unit tests, `test:collab` (15), `test:e2e` (17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MPdHcEfnJuCzudDEncDLo