### PR TITLE
5PGJ2VT filter the board by actor, not just assignee

### DIFF
--- a/source/lib/command-line/command-modifiers.ts
+++ b/source/lib/command-line/command-modifiers.ts
@@ -363,6 +363,7 @@ export const getCmdModifiers = (
 		[CmdKeywords.FILTER]: [
 			'tag',
 			'assignee',
+			'actor',
 			'description',
 			'title',
 			'ref',

--- a/source/lib/model/app-state.model.ts
+++ b/source/lib/model/app-state.model.ts
@@ -41,7 +41,7 @@ export type Contributor = {
 };
 
 export type Filter = {
-	target: 'tag' | 'assignee' | 'description' | 'title' | 'ref';
+	target: 'tag' | 'assignee' | 'actor' | 'description' | 'title' | 'ref';
 	operator: '=' | '!=';
 	value: string;
 };

--- a/source/lib/utils/filter.ts
+++ b/source/lib/utils/filter.ts
@@ -1,3 +1,4 @@
+import {AppEvent} from '../event/event.model.js';
 import {Filter, Tag} from '../model/app-state.model.js';
 import {NavNode} from '../model/navigation-node.model.js';
 import {getState} from '../state/state.js';
@@ -10,6 +11,7 @@ export type FilterField =
 	| 'description'
 	| 'tag'
 	| 'assignee'
+	| 'actor'
 	| 'ref';
 
 const getTagNames = (ticket: NavNode<'TICKET'>): string[] => {
@@ -29,6 +31,63 @@ const getAssigneeNames = (ticket: NavNode<'TICKET'>): string[] => {
 			const contributor = contributors[assignee];
 			return contributor ? contributor.name : undefined;
 		})
+		.filter((name): name is string => Boolean(name));
+};
+
+/**
+ * Who has worked each node, from the log rather than from the node: authorship
+ * is not materialized onto nodes, and does not need to be — every event already
+ * carries the actor it was written by.
+ *
+ * Rebuilt only when the log is replaced, because a filter is re-evaluated per
+ * ticket on every keystroke and the log is the longest thing in state.
+ */
+let indexedLog: AppEvent[] | null = null;
+let actorsByNode = new Map<string, Set<string>>();
+
+const getActorsByNode = (): Map<string, Set<string>> => {
+	const eventLog = getState().eventLog ?? [];
+
+	if (eventLog === indexedLog) return actorsByNode;
+
+	const byNode = new Map<string, Set<string>>();
+
+	for (const event of eventLog) {
+		if (!event.userId) continue;
+
+		const payload = event.payload as {id?: unknown; issue?: unknown};
+
+		// `id` is the node an event targets; `issue` is how a comment names the
+		// ticket it belongs to. Ids are unique across kinds, so a tag or
+		// contributor event naming its own id can never match a ticket.
+		for (const target of [payload.id, payload.issue]) {
+			if (typeof target !== 'string') continue;
+
+			const actors = byNode.get(target) ?? new Set<string>();
+			actors.add(event.userId);
+			byNode.set(target, actors);
+		}
+	}
+
+	indexedLog = eventLog;
+	actorsByNode = byNode;
+
+	return byNode;
+};
+
+/**
+ * Names of everyone who has written an event against this ticket. Resolved
+ * through the registry by id, never off the log's file name, which is a
+ * sanitized storage key.
+ */
+const getActorNames = (ticket: NavNode<'TICKET'>): string[] => {
+	const {contributors} = getState();
+	const actors = getActorsByNode().get(ticket.id);
+
+	if (!actors) return [];
+
+	return [...actors]
+		.map(id => contributors[id]?.name)
 		.filter((name): name is string => Boolean(name));
 };
 
@@ -54,6 +113,13 @@ export const ticketMatchesFilter = (
 		case 'assignee': {
 			const assigneeNames = getAssigneeNames(ticket).map(normalizeText);
 			return assigneeNames.some(name => name.includes(query));
+		}
+
+		// Who did the work, as against `assignee`'s who it is for. A board worked
+		// by several agents is unreadable without it.
+		case 'actor': {
+			const actorNames = getActorNames(ticket).map(normalizeText);
+			return actorNames.some(name => name.includes(query));
 		}
 
 		case 'ref': {

--- a/source/test/filter-actor.test.ts
+++ b/source/test/filter-actor.test.ts
@@ -1,0 +1,99 @@
+import {describe, expect, it, vi} from 'vitest';
+import {Filter} from '../lib/model/app-state.model.js';
+import {nodes} from '../lib/state/node-builder.js';
+import {ticketMatchesFilter} from '../lib/utils/filter.js';
+
+// Authorship is not on the node — it is only ever in the log — so the actor
+// filter is the one filter that reads events rather than props.
+
+const TICKET = '01KS22YK9AXCMATZXTR5JZCS5M';
+const OTHER = '01KS22YK9AXCMATZXTR5JZCS5N';
+
+const PETER = 'HVK8KMV924DBNFBDQV8RCZ9S06';
+const FRED = 'HVK8KMV924DBNFBDQV8RCZ9S07';
+
+const event = (
+	userId: string,
+	action: string,
+	payload: Record<string, unknown>,
+) => ({id: ['x', null], userId, userName: 'ignored', action, payload});
+
+vi.mock('../lib/state/state.js', () => ({
+	getState: () => ({
+		tags: {},
+		contributors: {
+			[PETER]: {id: PETER, name: 'claude/peter'},
+			[FRED]: {id: FRED, name: 'codex/fred'},
+			unregistered: {id: 'unregistered', name: ''},
+		},
+		eventLog: [
+			event(PETER, 'add.ticket', {id: TICKET, name: 'Fix bug'}),
+			event(FRED, 'add.issue.comment', {id: 'c1', issue: TICKET, md: 'hi'}),
+			event(FRED, 'add.ticket', {id: OTHER, name: 'Other'}),
+			// A contributor event naming its own id, which is not a node.
+			event(PETER, 'create.contributor', {id: PETER, name: 'claude/peter'}),
+			// An author the registry has never seen.
+			event('ghost', 'edit.ticket.title', {id: TICKET, title: 'Fix bug'}),
+		],
+	}),
+}));
+
+const ticket = nodes.ticket(TICKET, 'Fix bug', 'lane', 'a0');
+const other = nodes.ticket(OTHER, 'Other', 'lane', 'a1');
+
+const byActor = (value: string): Filter => ({
+	target: 'actor',
+	operator: '=',
+	value,
+});
+
+describe('actor filter', () => {
+	it('matches the actor who created the ticket', () => {
+		expect(ticketMatchesFilter(ticket, byActor('claude/peter'))).toBe(true);
+	});
+
+	// The case the filter exists for: an agent that worked a ticket it did not
+	// open still counts as having worked it.
+	it('matches an actor who only commented', () => {
+		expect(ticketMatchesFilter(ticket, byActor('codex/fred'))).toBe(true);
+	});
+
+	it('does not match an actor who never touched the ticket', () => {
+		expect(ticketMatchesFilter(other, byActor('claude/peter'))).toBe(false);
+	});
+
+	it('matches on a partial name, like the other filters', () => {
+		expect(ticketMatchesFilter(ticket, byActor('peter'))).toBe(true);
+	});
+
+	it('is case-insensitive', () => {
+		expect(ticketMatchesFilter(ticket, byActor('CLAUDE/PETER'))).toBe(true);
+	});
+
+	// The slash is what separates provider from name, and the log file name
+	// cannot hold it — so a filter that only saw file names would never match.
+	it('matches across the provider separator', () => {
+		expect(ticketMatchesFilter(ticket, byActor('claude/'))).toBe(true);
+	});
+
+	it('does not match a name no contributor holds', () => {
+		expect(ticketMatchesFilter(ticket, byActor('claude/nobody'))).toBe(false);
+	});
+
+	// Resolved through the registry by id: an id with no registry entry has no
+	// name to match, rather than falling back to the log's sanitized file name.
+	it('ignores an author the registry does not know', () => {
+		expect(ticketMatchesFilter(ticket, byActor('ghost'))).toBe(false);
+	});
+
+	// An id is unique across kinds, so an event naming a contributor or tag id
+	// must never be read as touching a ticket.
+	it('does not treat a contributor id as a node it touched', () => {
+		expect(ticketMatchesFilter(other, byActor('codex/fred'))).toBe(true);
+		expect(ticketMatchesFilter(other, byActor('claude/peter'))).toBe(false);
+	});
+
+	it('matches every ticket when the query is empty', () => {
+		expect(ticketMatchesFilter(ticket, byActor(''))).toBe(true);
+	});
+});


### PR DESCRIPTION
`:filter actor claude/peter` narrows the board to the tickets an actor has actually worked. Assignee says who a ticket is for; actor says who did it — and a board worked by several agents is hard to read without the second.

**Where authorship comes from.** Nodes carry no author — `authorId` exists only on `CommentState` — so this reads the event log, which every event already stamps with its actor. No materialization change, no new event type, no new state.

`getActorsByNode` indexes `payload.id` (the node an event targets) and `payload.issue` (how a comment names its ticket) per actor. Ids are unique across kinds, so an event naming a tag or contributor id can never be mistaken for touching a ticket. The index is memoized on the event log's identity and rebuilt only when the log is replaced — `ticketMatchesFilter` runs per ticket on every keystroke, and the log is the longest thing in state.

Names resolve through the contributor registry by id, never off the log's file name, which is a lossy storage key (`sanitizeFilePart` turns `claude/peter` into `claude-peter`). An author the registry has never seen simply has no name to match, rather than matching a mangled one.

Scope: "actor" means authored any event against the ticket — created, edited, commented, moved, tagged. Creator-only would miss the agent that did the work on someone else's ticket, which is the case this exists for.

**Tests** — `source/test/filter-actor.test.ts`, ten cases: creator matches, commenter matches, untouched ticket does not, partial and case-insensitive matching, matching across the `provider/name` slash, an unregistered author is ignored, and a contributor id is never read as a node. Verified red: stubbing the match fails six of them. Full local gate: 1137 unit tests, `test:e2e` (17) — re-run because a new FILTER modifier changes TUI autocomplete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MPdHcEfnJuCzudDEncDLo