### PR TITLE
H88JV7A Derive the timeline once per state of the log, not once per request

### DIFF
--- a/source/mcp/epiq-api.ts
+++ b/source/mcp/epiq-api.ts
@@ -19,7 +19,7 @@ import {
 import {materializeAndPersistAll} from '../lib/event/event-materialize-and-persist.js';
 import {getPersistFileName} from '../lib/event/event-persist.js';
 import {AppEvent, MovePosition} from '../lib/event/event.model.js';
-import {filterEventsForBoard} from './epiq-time-travel.js';
+import {filterEventsForBoard} from './timeline-index.js';
 import {resolveReopenParentFromLog} from '../lib/event/log-utils.js';
 import {CLOSED_SWIMLANE_ID} from '../lib/event/static-ids.js';
 import {

--- a/source/mcp/epiq-time-travel.ts
+++ b/source/mcp/epiq-time-travel.ts
@@ -11,10 +11,6 @@ import {
 	openEditorDiffNonBlocking,
 	openEditorOnFileNonBlocking,
 } from '../lib/editor/editor.js';
-import {getEventTime, toEffectiveUlidTimes} from '../lib/event/date-utils.js';
-import {AppEvent, EventAction} from '../lib/event/event.model.js';
-import {formatLogAction} from '../lib/event/format-log-utils.js';
-import {getStringColor} from '../lib/utils/color.js';
 import {
 	loadEffectiveEventTimes,
 	loadMergedEvents,
@@ -25,7 +21,6 @@ import {
 	materializeAll,
 	partitionMaterializeResults,
 } from '../lib/event/event-materialize.js';
-import {minOf} from '../lib/utils/minmax.js';
 import {failed, isFail, Result, succeeded} from '../lib/model/result-types.js';
 import {readProjectFile} from '../lib/project-setup/project-setup.js';
 import {fileManager} from '../lib/storage/file-manager.js';
@@ -36,6 +31,7 @@ import {
 	patchState,
 	resetState,
 } from '../lib/state/state.js';
+import {EventTimelineEntry, getTimelineEntries} from './timeline-index.js';
 import {ApiTimeTravelStatus} from './api-state.model.js';
 
 type ToolInput = {repoRoot?: string};
@@ -90,243 +86,6 @@ export const getTimeTravelStatus = (): ApiTimeTravelStatus => {
 
 export type EventTimelineBucket = {t: number; count: number};
 
-// Colour resolved here rather than on the client: getStringColor pulls in
-// chalk, which the GUI bundle cannot take.
-export type EventIdentity = {id: string; name: string; color: string};
-
-export type EventTimelineEntry = {
-	// The event's own id, so a client can match a dot to a ticket's log line.
-	id: string;
-	t: number;
-	action: EventAction;
-	// Phrased like a TUI log line — "Tagged with bug", "Commented".
-	label: string;
-	// Who performed the event. On a comment that is its author.
-	actor: EventIdentity | null;
-	// The tag or contributor the event is *about*, where it has one — the thing
-	// the scatter colours a tagging or assigning dot by.
-	tag: EventIdentity | null;
-	assignee: EventIdentity | null;
-	// The ticket the event happened to, where it happened to one. Null for
-	// board- and swimlane-level events, which belong to no ticket.
-	issue: string | null;
-};
-
-// Tag, contributor and swimlane names come from the log's own create events
-// rather than from the materialized state, which getEventTimeline must not
-// touch. Same technique as filterEventsForBoard: build the index as the scan
-// proceeds.
-//
-// A name renamed later reads under the one it was created with, which is what
-// the log itself says happened at the moment being described.
-const NAMING_ACTIONS = new Set<EventAction>([
-	'create.tag',
-	'create.contributor',
-	// Carries the lane's name, and is what lets a move say which lane it went
-	// to.
-	'add.swimlane',
-]);
-
-const buildNameIndex = (events: AppEvent[]): Map<string, string> => {
-	const names = new Map<string, string>();
-
-	for (const event of events) {
-		if (!NAMING_ACTIONS.has(event.action)) continue;
-
-		const payload = event.payload as {id?: string; name?: string} | undefined;
-
-		if (payload?.id && payload.name) names.set(payload.id, payload.name);
-	}
-
-	return names;
-};
-
-// Where each node sat before the move an event describes, keyed by that event's
-// id — which is what separates "moved to another lane" from "reordered inside
-// the one it was in".
-//
-// Over the whole log and in causal order, the order loadMergedEvents already
-// returns: a move inside the window is only tellable apart from a reorder by
-// what came before it, which is routinely outside the window.
-const buildPreviousParentIndex = (
-	events: AppEvent[],
-): Map<string, string | undefined> => {
-	const previousParent = new Map<string, string | undefined>();
-	const parentByNode = new Map<string, string>();
-
-	for (const event of events) {
-		const payload = event.payload as {id?: string; parent?: string} | undefined;
-
-		if (!payload?.id || !payload.parent) continue;
-
-		if (event.action === 'move.node') {
-			previousParent.set(event.id, parentByNode.get(payload.id));
-		}
-
-		// Creations seed it and moves update it, so the next move reads where
-		// this one left the node.
-		parentByNode.set(payload.id, payload.parent);
-	}
-
-	return previousParent;
-};
-
-// Which tag an event is about. Tagging a ticket names it as `tag`; deleting or
-// restoring the tag itself names it as the event's own `id`.
-const tagOf = (event: AppEvent): string | undefined => {
-	// Optional like filterEventsForBoard's: a malformed log entry must not take
-	// the whole timeline down with it.
-	const payload = event.payload as {id?: string; tag?: string} | undefined;
-
-	return event.action === 'tombstone.tag' || event.action === 'restore.tag'
-		? payload?.id
-		: payload?.tag;
-};
-
-// Which ids are tickets, and what hangs off what: a payload's `id` names a node
-// of some kind, and nothing else in it says which kind. Built as the scan
-// proceeds, like filterEventsForBoard's.
-type IssueIndex = {
-	issueIds: Set<string>;
-	parentById: Map<string, string>;
-};
-
-const buildIssueIndex = (events: AppEvent[]): IssueIndex => {
-	const issueIds = new Set<string>();
-	const parentById = new Map<string, string>();
-
-	for (const event of events) {
-		const payload = event.payload as {id?: string; parent?: string} | undefined;
-		const id = payload?.id;
-		if (!id) continue;
-
-		if (event.action === 'add.issue') issueIds.add(id);
-		if (payload.parent) parentById.set(id, payload.parent);
-	}
-
-	return {issueIds, parentById};
-};
-
-// Which ticket an event is about. Comments and attachments name it as `issue`,
-// their own `id` being the comment's; anything else that happened under a
-// ticket — the ticket itself, or a field node hanging off it — is found by
-// walking up from the id the event carries.
-const issueOf = (
-	event: AppEvent,
-	{issueIds, parentById}: IssueIndex,
-): string | null => {
-	const payload = event.payload as {id?: string; issue?: string} | undefined;
-
-	if (payload?.issue) return payload.issue;
-
-	const seen = new Set<string>();
-	let current = payload?.id;
-
-	while (current !== undefined && !seen.has(current)) {
-		if (issueIds.has(current)) return current;
-
-		seen.add(current);
-		current = parentById.get(current);
-	}
-
-	return null;
-};
-
-// The TUI's phrasing minus the details that need state. A renamed tag reads
-// under its original name, which is what the log itself says happened.
-// How much of a comment the timeline carries. A window can hold twenty
-// thousand events and every one of them is shipped to the browser, so the whole
-// body is not on offer — enough to recognise which comment it was.
-const COMMENT_PREVIEW_CHARS = 90;
-
-// The first line of a comment, flattened. A body is markdown and often several
-// paragraphs; a log line is one line.
-const commentPreview = (md: string): string => {
-	const firstLine = md.trim().split('\n')[0]?.trim() ?? '';
-
-	return firstLine.length > COMMENT_PREVIEW_CHARS
-		? `${firstLine.slice(0, COMMENT_PREVIEW_CHARS).trimEnd()}…`
-		: firstLine;
-};
-
-const describeTimelineEvent = (
-	event: AppEvent,
-	names: Map<string, string>,
-	previousParents: Map<string, string | undefined>,
-): string => {
-	const payload = event.payload as
-		| {name?: string; assignee?: string; md?: string; parent?: string}
-		| undefined;
-	const tag = tagOf(event);
-
-	const action = event.action ? formatLogAction(event.action) : '';
-
-	// A comment says what it said, after a colon — "Commented" alone is the one
-	// action whose own name tells the reader nothing about it.
-	if (payload?.md !== undefined) {
-		const preview = commentPreview(payload.md);
-
-		return preview ? `${action}: ${preview}` : action;
-	}
-
-	// A move says which lane, and whether it changed lanes at all — "Moved
-	// issue" answers neither, and reordering within a lane is the commoner of
-	// the two. Falls back to the bare action where the lane has no create event
-	// in the log to take a name from.
-	if (event.action === 'move.node' && payload?.parent) {
-		const lane = names.get(payload.parent);
-
-		if (!lane) return action;
-
-		return previousParents.get(event.id) === payload.parent
-			? `Moved within ${lane}`
-			: `Moved to ${lane}`;
-	}
-
-	const detail =
-		tag !== undefined
-			? names.get(tag) ?? ''
-			: payload?.assignee !== undefined
-			? names.get(payload.assignee) ?? ''
-			: payload?.name !== undefined
-			? `"${payload.name}"`
-			: '';
-
-	return [action, detail].filter(Boolean).join(' ');
-};
-
-// A referenced id with no create event in the log still gets an entry, under
-// the id itself: dropping it would silently thin the filter's list.
-const identityFor = (
-	id: string | undefined,
-	names: Map<string, string>,
-): EventIdentity | null => {
-	if (!id) return null;
-
-	const name = names.get(id) ?? id;
-
-	return {id, name, color: getStringColor(name)};
-};
-
-const identitiesFor = (
-	event: AppEvent,
-	names: Map<string, string>,
-): Pick<EventTimelineEntry, 'actor' | 'tag' | 'assignee'> => {
-	const payload = event.payload as {assignee?: string} | undefined;
-
-	return {
-		actor: event.userId
-			? {
-					id: event.userId,
-					name: event.userName ?? event.userId,
-					color: getStringColor(event.userName ?? event.userId),
-			  }
-			: null,
-		tag: identityFor(tagOf(event), names),
-		assignee: identityFor(payload?.assignee, names),
-	};
-};
-
 export type EventTimeline = {
 	bucketMs: number;
 	buckets: EventTimelineBucket[];
@@ -339,59 +98,20 @@ export type EventTimeline = {
 	latest: number;
 };
 
-// The id -> parent map is built as the scan proceeds, so each event is
-// attributed using the hierarchy as it stood then. No-board events are dropped.
-export const filterEventsForBoard = (
-	events: AppEvent[],
-	boardId: string,
-): AppEvent[] => {
-	const parentById = new Map<string, string>();
-	const boardIds = new Set<string>();
+// The first entry at or after `t`, or the length where none is. The entries
+// are in time order, so a window is two of these and the slice between them.
+const firstAtOrAfter = (entries: readonly {t: number}[], t: number): number => {
+	let low = 0;
+	let high = entries.length;
 
-	const resolveBoard = (id: string): string | null => {
-		const seen = new Set<string>();
-		let current: string | undefined = id;
+	while (low < high) {
+		const mid = (low + high) >> 1;
 
-		while (current && !seen.has(current)) {
-			if (boardIds.has(current)) return current;
-			seen.add(current);
-			current = parentById.get(current);
-		}
-
-		return null;
-	};
-
-	const matching: AppEvent[] = [];
-
-	for (const event of events) {
-		const payload = event.payload as {
-			id?: string;
-			parent?: string;
-			issue?: string;
-		};
-		const id = payload?.id;
-		if (!id) continue;
-
-		// Before matching, so a board's own add event is attributed to it.
-		if (event.action === 'add.board') {
-			boardIds.add(id);
-		}
-
-		// Comments and attachments hang off `issue`: their `id` is the comment's
-		// or attachment's own, so without this they resolve to no board at all
-		// and drop out of every board-scoped view.
-		const parent = payload.parent ?? payload.issue;
-
-		if (parent) {
-			parentById.set(id, parent);
-		}
-
-		if (id === boardId || resolveBoard(id) === boardId) {
-			matching.push(event);
-		}
+		if (entries[mid]!.t < t) low = mid + 1;
+		else high = mid;
 	}
 
-	return matching;
+	return low;
 };
 
 // Pure read: never touches the materialized state singleton, so it is safe
@@ -403,65 +123,17 @@ export const getEventTimeline = async (
 	if (isFail(stateBranchRootResult))
 		return failed(stateBranchRootResult.message);
 
-	const eventsResult = loadMergedEvents(stateBranchRootResult.value);
-	if (isFail(eventsResult)) return failed(eventsResult.message);
+	// Derived once per state of the log and reused, which is what keeps a scrub
+	// off the whole history: every step below is over the window alone.
+	const entriesResult = getTimelineEntries(stateBranchRootResult.value);
+	if (isFail(entriesResult)) return failed(entriesResult.message);
 
-	const scopedEvents = input.boardId
-		? filterEventsForBoard(eventsResult.value, input.boardId)
-		: eventsResult.value;
-
-	// Indexed over the unscoped log, and over all of it rather than the window.
-	// Tags and contributors are global — their create events hang off no board,
-	// so scoping first leaves every name unresolved and the timeline shows raw
-	// ULIDs where it means "bug" or "jola".
-	const names = buildNameIndex(eventsResult.value);
-
-	// Over the unscoped log too: a move inside the window is only tellable from
-	// a reorder by where the ticket sat before it, which is routinely outside.
-	const previousParents = buildPreviousParentIndex(eventsResult.value);
-
-	// Over the unscoped log too, so an issue whose board changed since its
-	// add.issue is still recognised as an issue.
-	const issueIndex = buildIssueIndex(eventsResult.value);
-
-	// Effective times over the full log, not the board-scoped subset, so a
-	// poisoned id's dot lands where the scrub/checkout path will cut.
-	const effectiveTimes = toEffectiveUlidTimes(
-		eventsResult.value.map(event => getEventTime(event)),
-	);
-	const timeByEventId = new Map(
-		eventsResult.value.map((event, index) => [
-			event.id,
-			effectiveTimes[index] ?? null,
-		]),
-	);
-
-	const timed = scopedEvents.flatMap(event => {
-		const t = timeByEventId.get(event.id) ?? null;
-
-		return t === null
-			? []
-			: [
-					{
-						id: event.id,
-						t,
-						action: event.action,
-						label: describeTimelineEvent(event, names, previousParents),
-						issue: issueOf(event, issueIndex),
-						...identitiesFor(event, names),
-					},
-			  ];
-	});
+	const timed = entriesResult.value;
 
 	const now = Date.now();
 	const windowEnd = input.end ?? now;
-	// Folded, not spread: `timed` can hold one entry per event in the whole log.
-	const windowStart =
-		input.start ??
-		minOf(
-			timed.map(entry => entry.t),
-			windowEnd,
-		);
+	// The entries are in time order, so the earliest is the first of them.
+	const windowStart = input.start ?? timed[0]?.t ?? windowEnd;
 
 	if (windowEnd <= windowStart) {
 		return succeeded('Empty time window', {
@@ -473,9 +145,17 @@ export const getEventTimeline = async (
 		});
 	}
 
+	// A range over a sorted axis rather than a scan of it: at half a million
+	// events the difference is the whole cost of a request.
+	const from = firstAtOrAfter(timed, windowStart);
+	const until = firstAtOrAfter(timed, windowEnd);
+
 	const inWindow = timed
-		.filter(entry => entry.t >= windowStart && entry.t < windowEnd)
-		.sort((a, b) => a.t - b.t);
+		.slice(from, until)
+		// The board narrowing happens here, over the window, rather than over the
+		// log: which board an event belongs to was settled when it was derived.
+		.filter(entry => !input.boardId || entry.board === input.boardId)
+		.map(({board: _board, ...entry}) => entry);
 
 	const times = inWindow.map(entry => entry.t);
 

--- a/source/mcp/test/epiq-api.test.ts
+++ b/source/mcp/test/epiq-api.test.ts
@@ -396,6 +396,9 @@ vi.mock('../../lib/repository/node-repo.js', () => ({
 
 vi.mock('../epiq-time-travel.js', () => ({
 	getTimeTravelStatus: vi.fn(() => ({mode: 'live', asOfTime: null})),
+}));
+
+vi.mock('../timeline-index.js', () => ({
 	// Stand-in for the real tree walk; fixtures carry boardId on the payload.
 	filterEventsForBoard: vi.fn(
 		(events: {payload?: {boardId?: string}}[], boardId: string) =>

--- a/source/mcp/timeline-index.ts
+++ b/source/mcp/timeline-index.ts
@@ -1,0 +1,424 @@
+// The timeline's derived view of the log: every event as the entry a client
+// receives, in the order their effective times put them, each carrying the
+// board it belongs to.
+//
+// Built once per state of the log and held, because deriving it is O(the whole
+// history) and answering a window off it is O(the window). A board that twenty
+// people have worked on for five years is around half a million events; at that
+// size the derivation is most of a second and the answer is a hundredth of a
+// millisecond.
+//
+// Rebuilt rather than appended to. `toEffectiveUlidTimes` is a forward scan and
+// looks appendable, but the order comes from the causal forest — an event
+// synced from another actor lands wherever its `refId` puts it, which is
+// routinely in the middle. Appending would be wrong in exactly the case this
+// exists for.
+
+import {existsSync, readdirSync, statSync} from 'node:fs';
+import path from 'node:path';
+import {getEventTime, toEffectiveUlidTimes} from '../lib/event/date-utils.js';
+import {AppEvent, EventAction} from '../lib/event/event.model.js';
+import {loadMergedEvents} from '../lib/event/event-load.js';
+import {formatLogAction} from '../lib/event/format-log-utils.js';
+import {failed, isFail, Result, succeeded} from '../lib/model/result-types.js';
+import {getEventsDirPath} from '../lib/storage/paths.js';
+import {getStringColor} from '../lib/utils/color.js';
+
+// Colour resolved here rather than on the client: getStringColor pulls in
+// chalk, which the GUI bundle cannot take.
+export type EventIdentity = {id: string; name: string; color: string};
+
+export type EventTimelineEntry = {
+	// The event's own id, so a client can match a dot to a ticket's log line.
+	id: string;
+	t: number;
+	action: EventAction;
+	// Phrased like a TUI log line — "Tagged with bug", "Commented".
+	label: string;
+	// Who performed the event. On a comment that is its author.
+	actor: EventIdentity | null;
+	// The tag or contributor the event is *about*, where it has one — the thing
+	// the scatter colours a tagging or assigning dot by.
+	tag: EventIdentity | null;
+	assignee: EventIdentity | null;
+	// The ticket the event happened to, where it happened to one. Null for
+	// board- and swimlane-level events, which belong to no ticket.
+	issue: string | null;
+};
+
+// Tag, contributor and swimlane names come from the log's own create events
+// rather than from the materialized state, which getEventTimeline must not
+// touch. Same technique as filterEventsForBoard: build the index as the scan
+// proceeds.
+//
+// A name renamed later reads under the one it was created with, which is what
+// the log itself says happened at the moment being described.
+const NAMING_ACTIONS = new Set<EventAction>([
+	'create.tag',
+	'create.contributor',
+	// Carries the lane's name, and is what lets a move say which lane it went
+	// to.
+	'add.swimlane',
+]);
+
+const buildNameIndex = (events: AppEvent[]): Map<string, string> => {
+	const names = new Map<string, string>();
+
+	for (const event of events) {
+		if (!NAMING_ACTIONS.has(event.action)) continue;
+
+		const payload = event.payload as {id?: string; name?: string} | undefined;
+
+		if (payload?.id && payload.name) names.set(payload.id, payload.name);
+	}
+
+	return names;
+};
+
+// Where each node sat before the move an event describes, keyed by that event's
+// id — which is what separates "moved to another lane" from "reordered inside
+// the one it was in".
+//
+// Over the whole log and in causal order, the order loadMergedEvents already
+// returns: a move inside the window is only tellable apart from a reorder by
+// what came before it, which is routinely outside the window.
+const buildPreviousParentIndex = (
+	events: AppEvent[],
+): Map<string, string | undefined> => {
+	const previousParent = new Map<string, string | undefined>();
+	const parentByNode = new Map<string, string>();
+
+	for (const event of events) {
+		const payload = event.payload as {id?: string; parent?: string} | undefined;
+
+		if (!payload?.id || !payload.parent) continue;
+
+		if (event.action === 'move.node') {
+			previousParent.set(event.id, parentByNode.get(payload.id));
+		}
+
+		// Creations seed it and moves update it, so the next move reads where
+		// this one left the node.
+		parentByNode.set(payload.id, payload.parent);
+	}
+
+	return previousParent;
+};
+
+// Which tag an event is about. Tagging a ticket names it as `tag`; deleting or
+// restoring the tag itself names it as the event's own `id`.
+const tagOf = (event: AppEvent): string | undefined => {
+	// Optional like filterEventsForBoard's: a malformed log entry must not take
+	// the whole timeline down with it.
+	const payload = event.payload as {id?: string; tag?: string} | undefined;
+
+	return event.action === 'tombstone.tag' || event.action === 'restore.tag'
+		? payload?.id
+		: payload?.tag;
+};
+
+// Which ids are tickets, and what hangs off what: a payload's `id` names a node
+// of some kind, and nothing else in it says which kind. Built as the scan
+// proceeds, like filterEventsForBoard's.
+type IssueIndex = {
+	issueIds: Set<string>;
+	parentById: Map<string, string>;
+};
+
+const buildIssueIndex = (events: AppEvent[]): IssueIndex => {
+	const issueIds = new Set<string>();
+	const parentById = new Map<string, string>();
+
+	for (const event of events) {
+		const payload = event.payload as {id?: string; parent?: string} | undefined;
+		const id = payload?.id;
+		if (!id) continue;
+
+		if (event.action === 'add.issue') issueIds.add(id);
+		if (payload.parent) parentById.set(id, payload.parent);
+	}
+
+	return {issueIds, parentById};
+};
+
+// Which ticket an event is about. Comments and attachments name it as `issue`,
+// their own `id` being the comment's; anything else that happened under a
+// ticket — the ticket itself, or a field node hanging off it — is found by
+// walking up from the id the event carries.
+const issueOf = (
+	event: AppEvent,
+	{issueIds, parentById}: IssueIndex,
+): string | null => {
+	const payload = event.payload as {id?: string; issue?: string} | undefined;
+
+	if (payload?.issue) return payload.issue;
+
+	const seen = new Set<string>();
+	let current = payload?.id;
+
+	while (current !== undefined && !seen.has(current)) {
+		if (issueIds.has(current)) return current;
+
+		seen.add(current);
+		current = parentById.get(current);
+	}
+
+	return null;
+};
+
+// The TUI's phrasing minus the details that need state. A renamed tag reads
+// under its original name, which is what the log itself says happened.
+// How much of a comment the timeline carries. A window can hold twenty
+// thousand events and every one of them is shipped to the browser, so the whole
+// body is not on offer — enough to recognise which comment it was.
+const COMMENT_PREVIEW_CHARS = 90;
+
+// The first line of a comment, flattened. A body is markdown and often several
+// paragraphs; a log line is one line.
+const commentPreview = (md: string): string => {
+	const firstLine = md.trim().split('\n')[0]?.trim() ?? '';
+
+	return firstLine.length > COMMENT_PREVIEW_CHARS
+		? `${firstLine.slice(0, COMMENT_PREVIEW_CHARS).trimEnd()}…`
+		: firstLine;
+};
+
+const describeTimelineEvent = (
+	event: AppEvent,
+	names: Map<string, string>,
+	previousParents: Map<string, string | undefined>,
+): string => {
+	const payload = event.payload as
+		| {name?: string; assignee?: string; md?: string; parent?: string}
+		| undefined;
+	const tag = tagOf(event);
+
+	const action = event.action ? formatLogAction(event.action) : '';
+
+	// A comment says what it said, after a colon — "Commented" alone is the one
+	// action whose own name tells the reader nothing about it.
+	if (payload?.md !== undefined) {
+		const preview = commentPreview(payload.md);
+
+		return preview ? `${action}: ${preview}` : action;
+	}
+
+	// A move says which lane, and whether it changed lanes at all — "Moved
+	// issue" answers neither, and reordering within a lane is the commoner of
+	// the two. Falls back to the bare action where the lane has no create event
+	// in the log to take a name from.
+	if (event.action === 'move.node' && payload?.parent) {
+		const lane = names.get(payload.parent);
+
+		if (!lane) return action;
+
+		return previousParents.get(event.id) === payload.parent
+			? `Moved within ${lane}`
+			: `Moved to ${lane}`;
+	}
+
+	const detail =
+		tag !== undefined
+			? names.get(tag) ?? ''
+			: payload?.assignee !== undefined
+			? names.get(payload.assignee) ?? ''
+			: payload?.name !== undefined
+			? `"${payload.name}"`
+			: '';
+
+	return [action, detail].filter(Boolean).join(' ');
+};
+
+// A referenced id with no create event in the log still gets an entry, under
+// the id itself: dropping it would silently thin the filter's list.
+const identityFor = (
+	id: string | undefined,
+	names: Map<string, string>,
+): EventIdentity | null => {
+	if (!id) return null;
+
+	const name = names.get(id) ?? id;
+
+	return {id, name, color: getStringColor(name)};
+};
+
+const identitiesFor = (
+	event: AppEvent,
+	names: Map<string, string>,
+): Pick<EventTimelineEntry, 'actor' | 'tag' | 'assignee'> => {
+	const payload = event.payload as {assignee?: string} | undefined;
+
+	return {
+		actor: event.userId
+			? {
+					id: event.userId,
+					name: event.userName ?? event.userId,
+					color: getStringColor(event.userName ?? event.userId),
+			  }
+			: null,
+		tag: identityFor(tagOf(event), names),
+		assignee: identityFor(payload?.assignee, names),
+	};
+};
+
+// Which board each event belongs to, positionally. The id -> parent map is
+// built as the scan proceeds, so each event is attributed using the hierarchy
+// as it stood then.
+//
+// Resolved once here rather than per request: walking every event's parent
+// chain is O(the whole history), and a window needs it for its own events only.
+const boardsForEvents = (events: AppEvent[]): (string | null)[] => {
+	const parentById = new Map<string, string>();
+	const boardIds = new Set<string>();
+
+	const resolveBoard = (id: string): string | null => {
+		const seen = new Set<string>();
+		let current: string | undefined = id;
+
+		while (current && !seen.has(current)) {
+			if (boardIds.has(current)) return current;
+			seen.add(current);
+			current = parentById.get(current);
+		}
+
+		return null;
+	};
+
+	return events.map(event => {
+		const payload = event.payload as {
+			id?: string;
+			parent?: string;
+			issue?: string;
+		};
+		const id = payload?.id;
+		if (!id) return null;
+
+		// Before resolving, so a board's own add event is attributed to it.
+		if (event.action === 'add.board') boardIds.add(id);
+
+		// Comments and attachments hang off `issue`: their `id` is the comment's
+		// or attachment's own, so without this they resolve to no board at all
+		// and drop out of every board-scoped view.
+		const parent = payload.parent ?? payload.issue;
+		if (parent) parentById.set(id, parent);
+
+		// A board is its own board, which is what keeps its add and its edits in
+		// its own timeline.
+		return boardIds.has(id) ? id : resolveBoard(id);
+	});
+};
+
+// Events with no board are dropped, as they always were.
+export const filterEventsForBoard = (
+	events: AppEvent[],
+	boardId: string,
+): AppEvent[] => {
+	const boards = boardsForEvents(events);
+
+	return events.filter((_, index) => boards[index] === boardId);
+};
+
+// One event, ready to send. `board` is not part of what a client receives — it
+// is how a request narrows to its own board without walking the log again.
+export type TimelineEntry = EventTimelineEntry & {board: string | null};
+
+// Every event the log holds, in effective-time order.
+export const buildTimelineEntries = (events: AppEvent[]): TimelineEntry[] => {
+	const names = buildNameIndex(events);
+	const previousParents = buildPreviousParentIndex(events);
+	const issueIndex = buildIssueIndex(events);
+	const boards = boardsForEvents(events);
+
+	// Over the whole log, so a poisoned id's dot lands where the scrub and
+	// checkout paths will cut.
+	const effectiveTimes = toEffectiveUlidTimes(
+		events.map(event => getEventTime(event)),
+	);
+
+	const entries = events.flatMap((event, index) => {
+		const t = effectiveTimes[index] ?? null;
+
+		return t === null
+			? []
+			: [
+					{
+						id: event.id,
+						t,
+						action: event.action,
+						label: describeTimelineEvent(event, names, previousParents),
+						issue: issueOf(event, issueIndex),
+						board: boards[index] ?? null,
+						...identitiesFor(event, names),
+					},
+			  ];
+	});
+
+	// Sorted here rather than per request: effective times are not the order the
+	// log is stored in, and a window is a range over this axis.
+	return entries.sort((left, right) => left.t - right.t);
+};
+
+// What the log looked like when the entries were built.
+//
+// Every actor writes its own file, so this covers the directory rather than one
+// file: a teammate's events arriving is their file growing, or appearing for
+// the first time, and either moves the signature. Append-only means a size that
+// has not moved is content that has not moved; mtime catches a file a sync
+// replaced wholesale rather than appended to.
+const logSignature = (stateBranchRoot: string): string => {
+	const dir = getEventsDirPath(stateBranchRoot);
+	if (!existsSync(dir)) return 'none';
+
+	return readdirSync(dir)
+		.filter(file => file.endsWith('.jsonl'))
+		.sort()
+		.map(file => {
+			const {size, mtimeMs} = statSync(path.join(dir, file));
+
+			return `${file}:${size}:${mtimeMs}`;
+		})
+		.join('|');
+};
+
+// Held for the life of the process, and only ever for one root: the GUI server
+// serves one project, and a second entry would be a second copy of a history
+// this large.
+let cache: {root: string; signature: string; entries: TimelineEntry[]} | null =
+	null;
+
+// The whole log as timeline entries, rebuilt only when the log has moved. The
+// raw events are dropped on the way out — they are three times the weight of
+// what is derived from them, and nothing downstream of here reads them.
+export const getTimelineEntries = (
+	stateBranchRoot: string,
+): Result<readonly TimelineEntry[]> => {
+	// Read before the log, never after. Any file can gain lines from another
+	// machine between two reads, sync included: taken first, a write that lands
+	// in the gap is cached under the older signature and rebuilt on the next
+	// request. Taken afterwards, those same entries would be stored under the
+	// signature of a log they do not match, and nothing would ever rebuild them.
+	const signature = logSignature(stateBranchRoot);
+
+	if (
+		cache &&
+		cache.root === stateBranchRoot &&
+		cache.signature === signature
+	) {
+		return succeeded('Timeline entries, cached', cache.entries);
+	}
+
+	const eventsResult = loadMergedEvents(stateBranchRoot);
+	if (isFail(eventsResult)) return failed(eventsResult.message);
+
+	const entries = buildTimelineEntries(eventsResult.value);
+
+	cache = {root: stateBranchRoot, signature, entries};
+
+	return succeeded('Timeline entries, built', entries);
+};
+
+// The tests drive the log through a mocked loader, so they need the cache gone
+// between cases; a signature is no help where the files never existed.
+export const clearTimelineCache = (): void => {
+	cache = null;
+};

--- a/source/test/epiq-time-travel.test.ts
+++ b/source/test/epiq-time-travel.test.ts
@@ -8,6 +8,10 @@ vi.mock('../git/git-storage.js', () => ({
 
 vi.mock('../lib/storage/paths.js', () => ({
 	resolveClosestEpiqProjectRoot: vi.fn(),
+	// The timeline index stats the log files to notice when they move. These
+	// tests hand it events through the mocked loader instead, so it must find no
+	// directory — and clearTimelineCache below is what stands in for a signature.
+	getEventsDirPath: vi.fn(() => '/epiq-timeline-index-no-such-dir'),
 }));
 
 vi.mock('../lib/event/event-load.js', () => ({
@@ -73,6 +77,7 @@ import {
 	openEditorOnFileNonBlocking,
 } from '../lib/editor/editor.js';
 import {resolveClosestEpiqProjectRoot} from '../lib/storage/paths.js';
+import {clearTimelineCache} from '../mcp/timeline-index.js';
 import {
 	loadEffectiveEventTimes,
 	loadMergedEvents,
@@ -112,6 +117,7 @@ describe('epiq-time-travel', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		resetCommitTimelineCacheForTests();
+		clearTimelineCache();
 
 		// An ambient global in the real app, so it cannot be vi.mock'd.
 		(globalThis as {logger?: unknown}).logger = {

--- a/source/test/timeline-index.test.ts
+++ b/source/test/timeline-index.test.ts
@@ -1,0 +1,189 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {ulid} from 'ulid';
+
+vi.mock('../lib/event/event-load.js', () => ({
+	loadMergedEvents: vi.fn(),
+}));
+
+// A real directory: what the cache watches is the log's own files, and a mocked
+// filesystem would prove nothing about a teammate's file arriving in it.
+vi.mock('../lib/storage/paths.js', async () => ({
+	...(await vi.importActual<typeof import('../lib/storage/paths.js')>(
+		'../lib/storage/paths.js',
+	)),
+	getEventsDirPath: (root: string) => path.join(root, 'events'),
+}));
+
+import {loadMergedEvents} from '../lib/event/event-load.js';
+import {succeeded} from '../lib/model/result-types.js';
+import {
+	buildTimelineEntries,
+	clearTimelineCache,
+	getTimelineEntries,
+} from '../mcp/timeline-index.js';
+
+let root = '';
+const eventsDir = () => path.join(root, 'events');
+
+const writeLog = (actor: string, lines: number) => {
+	fs.writeFileSync(
+		path.join(eventsDir(), `${actor}.jsonl`),
+		'x\n'.repeat(lines),
+	);
+};
+
+const baseTime = 1_700_000_000_000;
+
+const event = (n: number, over: Record<string, unknown> = {}) => ({
+	id: ulid(baseTime + n * 1000),
+	action: 'add.issue',
+	payload: {id: `i${n}`, name: `Ticket ${n}`, parent: 'lane-1'},
+	userId: 'u-1',
+	userName: 'jo',
+	...over,
+});
+
+const served = (events: unknown[]) => {
+	vi.mocked(loadMergedEvents).mockReturnValue(
+		succeeded('events', events as never),
+	);
+};
+
+describe('timeline-index', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		clearTimelineCache();
+		root = fs.mkdtempSync(path.join(os.tmpdir(), 'epiq-timeline-'));
+		fs.mkdirSync(eventsDir());
+		served([event(1), event(2)]);
+	});
+
+	afterEach(() => {
+		fs.rmSync(root, {recursive: true, force: true});
+	});
+
+	describe('getTimelineEntries', () => {
+		// The point of the whole thing: dragging the needle asks repeatedly for
+		// windows over a log that has not moved.
+		it('derives the log once and reuses it while nothing changes', () => {
+			getTimelineEntries(root);
+			getTimelineEntries(root);
+			getTimelineEntries(root);
+
+			expect(vi.mocked(loadMergedEvents)).toHaveBeenCalledTimes(1);
+		});
+
+		it('rebuilds once this machine has written an event', () => {
+			writeLog('u-1', 2);
+			getTimelineEntries(root);
+
+			writeLog('u-1', 3);
+			getTimelineEntries(root);
+
+			expect(vi.mocked(loadMergedEvents)).toHaveBeenCalledTimes(2);
+		});
+
+		// Every actor appends to its own file, so a teammate's first event is a
+		// file that was not there before — not a file that grew.
+		it('rebuilds when a teammate’s log appears for the first time', () => {
+			writeLog('u-1', 2);
+			getTimelineEntries(root);
+
+			writeLog('u-2', 1);
+			getTimelineEntries(root);
+
+			expect(vi.mocked(loadMergedEvents)).toHaveBeenCalledTimes(2);
+		});
+
+		it('rebuilds when a teammate’s existing log grows', () => {
+			writeLog('u-1', 2);
+			writeLog('u-2', 1);
+			getTimelineEntries(root);
+
+			writeLog('u-2', 4);
+			getTimelineEntries(root);
+
+			expect(vi.mocked(loadMergedEvents)).toHaveBeenCalledTimes(2);
+		});
+
+		// A sync can replace a file rather than append to it, leaving the length
+		// where it was.
+		it('rebuilds when a log is rewritten to the same length', () => {
+			fs.writeFileSync(path.join(eventsDir(), 'u-1.jsonl'), 'aaaa');
+			getTimelineEntries(root);
+
+			const later = new Date(Date.now() + 5_000);
+			fs.writeFileSync(path.join(eventsDir(), 'u-1.jsonl'), 'bbbb');
+			fs.utimesSync(path.join(eventsDir(), 'u-1.jsonl'), later, later);
+			getTimelineEntries(root);
+
+			expect(vi.mocked(loadMergedEvents)).toHaveBeenCalledTimes(2);
+		});
+
+		it('serves a different project without answering from the first', () => {
+			getTimelineEntries(root);
+
+			const other = fs.mkdtempSync(path.join(os.tmpdir(), 'epiq-timeline-'));
+			fs.mkdirSync(path.join(other, 'events'));
+			getTimelineEntries(other);
+
+			expect(vi.mocked(loadMergedEvents)).toHaveBeenCalledTimes(2);
+			fs.rmSync(other, {recursive: true, force: true});
+		});
+	});
+
+	describe('buildTimelineEntries', () => {
+		it('puts the entries in effective-time order, whatever the log holds', () => {
+			const entries = buildTimelineEntries([
+				event(3),
+				event(1),
+				event(2),
+			] as never);
+
+			expect(entries.map(entry => entry.t)).toEqual(
+				[...entries.map(entry => entry.t)].sort((a, b) => a - b),
+			);
+		});
+
+		// Resolved once at build time so a request can narrow to its own board
+		// over the window rather than walking the log again.
+		it('carries the board each event belongs to', () => {
+			const entries = buildTimelineEntries([
+				{
+					id: ulid(baseTime),
+					action: 'add.board',
+					payload: {id: 'b1', name: 'Default'},
+					userId: 'u-1',
+					userName: 'jo',
+				},
+				{
+					id: ulid(baseTime + 1000),
+					action: 'add.swimlane',
+					payload: {id: 'lane-1', name: 'Todo', parent: 'b1'},
+					userId: 'u-1',
+					userName: 'jo',
+				},
+				event(2),
+			] as never);
+
+			expect(entries.map(entry => entry.board)).toEqual(['b1', 'b1', 'b1']);
+		});
+
+		it('leaves an event under no board with none', () => {
+			const entries = buildTimelineEntries([
+				{
+					id: ulid(baseTime),
+					action: 'create.tag',
+					payload: {id: 'tag-1', name: 'bug'},
+					userId: 'u-1',
+					userName: 'jo',
+				},
+			] as never);
+
+			expect(entries[0]?.board).toBeNull();
+		});
+	});
+});


### PR DESCRIPTION
`getEventTimeline` was O(the whole history) per call: every request re-read every log file, rebuilt the causal order, and made five more full passes before it looked at the window. It fires on every window change and every drag of the needle — during which nothing about the log has changed.

## Sized against the target

Twenty people for five years, at this board's observed rate (~400 events per person-month), is ~500,000 events. Measured there before choosing a design:

| | at 500k |
|---|---|
| parsed events | 259 MB |
| derived timeline entries | 75 MB |
| a request over a 5,000-event window | **0.01 ms** (was ~557 ms) |

So the derived entries are what is kept and the raw events are dropped — a third of the weight, and everything a request needs. They are sorted by effective time once, so a window is a binary search and a slice instead of a scan.

## Rebuilt, not appended to

`toEffectiveUlidTimes` is a forward scan and looks appendable. It is not safe to append: the order comes from the causal forest, so an event synced from a teammate lands wherever its `refId` puts it — routinely in the middle. That is exactly the case this ticket exists for, so the index is rebuilt when the log moves and reused when it has not.

## Multi-writer correctness

The signature that decides staleness covers the **events directory**, not a file. Each actor writes its own log, so:

- a teammate's first event is a file that **appeared**, not one that grew — `readdirSync` catches it
- a teammate's later events grow their file — size catches it
- a sync can replace a file at the **same length** — mtime catches it

and it is read **before** the log, never after. A write landing in the gap is cached under the older signature and rebuilt next request; the other order would store entries under a signature they do not match and never rebuild them. Four tests cover these cases against a real directory, because a mocked filesystem would prove nothing about a teammate's file arriving in one.

## Structure

`source/mcp/timeline-index.ts` owns the timeline's derived view of the log end to end — the label, name, issue and board derivation moved out of `epiq-time-travel.ts`, which drops from 1157 to 837 lines.

Which board an event belongs to is resolved during the build, so a request narrows over its own window instead of walking the log again. `filterEventsForBoard` is rebuilt on that same resolver rather than keeping a second copy of the walk.

## Tests

9 new (cache contract + build), and the 77 existing timeline tests pass unchanged against the cached path, which is the check that output did not move.

`epiq-api.test.ts` mocked `filterEventsForBoard` from its old module, so moving it silently un-mocked the real tree-walk and failed a board-scoping test. The mock now points at the new module. Worth noting the mock is a stand-in (`payload.boardId === boardId`), so that suite never exercised the real walk either way — the board-scoped tests in `epiq-time-travel.test.ts` are what cover it.

1140/1140 unit, 127/127 browser.