### PR TITLE
HYGB77Q show which log lines are clickable, on hover and in the cursor

### DIFF
--- a/source/gui/client/components/EventLog.tsx
+++ b/source/gui/client/components/EventLog.tsx
@@ -30,16 +30,20 @@ import {
 	groupByDay,
 	isDayOpen,
 	LogEntry,
+	LOG_ARROW_CLASS,
 	LOG_DOT_COLOR_PROPERTY,
+	LOG_PANE_PADDING_X,
 	LOG_ROW_HEIGHT,
 } from '../lib/event-log';
 import {
 	LogDestination,
+	linkedRowFrom,
 	readDestination,
 	rowAttributes,
 } from '../lib/log-destination';
 import {GUI_THEME, TEXT} from '../lib/gui-theme';
 import {usePrefersReducedMotion} from '../lib/scrubber';
+import {IconArrowUpRight} from './IconArrowUpRight';
 import {IconChevronDown} from './IconChevronDown';
 import {IconChevronRight} from './IconChevronRight';
 
@@ -255,6 +259,23 @@ const EventLogPanel = ({
 		// board beside it repaints.
 	}, [newestId, animate]);
 
+	// The arrow that marks the row under the pointer is one node for the whole
+	// panel, carried to whichever row that is. Moved through its ref rather
+	// than by state: hovering sweeps across rows, and re-rendering the column
+	// at every one of them is the cost this panel is built to avoid.
+	const arrowRef = useRef<HTMLSpanElement>(null);
+
+	const markRow = (target: EventTarget | null) => {
+		const arrow = arrowRef.current;
+		if (!arrow) return;
+
+		const row = linkedRowFrom(target);
+		// `offsetTop` is inside the scrolled column, which is what the arrow is
+		// positioned in too — so it rides the scroll with the row it is on.
+		if (row) arrow.style.top = `${row.offsetTop}px`;
+		arrow.style.opacity = row ? '1' : '0';
+	};
+
 	return (
 		<aside
 			data-testid="event-log"
@@ -278,21 +299,42 @@ const EventLogPanel = ({
 					const destination = readDestination(event.target);
 					if (destination) onOpen(destination);
 				}}
+				// One pair of handlers for the pane, like the click above: the rows
+				// say where they go, and hundreds of listeners would be the costly
+				// half of a panel whose lines are one node each.
+				onMouseOver={event => markRow(event.target)}
+				onMouseLeave={() => markRow(null)}
 				data-testid="event-log-scroll"
 				style={{
 					flex: 1,
 					minHeight: 0,
 					overflowY: 'auto',
 					overflowX: 'hidden',
+					// The arrow is placed against this, in the column's own
+					// coordinates rather than the window's.
+					position: 'relative',
 					// A column, so the block below can push itself down with an auto
 					// margin. `justify-content: flex-end` would do the same until the
 					// content overflowed, at which point it puts the overflow above the
 					// scrollable area, where it cannot be reached.
 					display: 'flex',
 					flexDirection: 'column',
-					padding: `0 14px ${bottomClearance + LOG_ROW_HEIGHT * 2}px 30px`,
+					padding: `0 ${LOG_PANE_PADDING_X}px ${
+						bottomClearance + LOG_ROW_HEIGHT * 2
+					}px 30px`,
 				}}
 			>
+				{/* Hidden until a row that leads somewhere is under the pointer, and
+				    inert throughout — the row is what takes the click. */}
+				<span
+					ref={arrowRef}
+					className={LOG_ARROW_CLASS}
+					data-testid="log-row-arrow"
+					aria-hidden="true"
+				>
+					<IconArrowUpRight size={11} />
+				</span>
+
 				{/* Holds a short log at the foot of the panel, so the newest line is
 				    always in the same place however few of them there are. */}
 				<div ref={columnRef} style={{marginTop: 'auto'}}>

--- a/source/gui/client/components/IconArrowUpRight.tsx
+++ b/source/gui/client/components/IconArrowUpRight.tsx
@@ -1,0 +1,16 @@
+export const IconArrowUpRight = ({size = 16}: {size?: number}) => (
+	<svg
+		width={size}
+		height={size}
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		strokeWidth="2"
+		strokeLinecap="round"
+		strokeLinejoin="round"
+		aria-hidden="true"
+	>
+		<line x1="7" y1="17" x2="17" y2="7" />
+		<polyline points="7 7 17 7 17 17" />
+	</svg>
+);

--- a/source/gui/client/lib/event-log.ts
+++ b/source/gui/client/lib/event-log.ts
@@ -10,6 +10,7 @@
 import {formatDate, formatDayLabel} from '../../../lib/utils/date.utils.js';
 import {GuiCommitEntry, GuiEventTimelineEntry} from './gui-state.model';
 import {EVENT_CATEGORY_COLORS, GUI_THEME, TEXT} from './gui-theme';
+import {LOG_ROW_SELECTOR} from './log-destination';
 import {categoryOf} from './scrubber';
 
 // One line of the log. `color` is the dot it is marked with, which is the whole
@@ -229,6 +230,24 @@ export const CRAWL_TIMING: KeyframeAnimationOptions = {
 export const LOG_TIME_CHARS = 5;
 export const LOG_DOT_COLOR_PROPERTY = '--epiq-log-dot';
 
+// The gap between the column of lines and either side of the panel. Shared
+// with the arrow below, which hangs at the end of a line rather than at the
+// edge of the panel it happens to be drawn in.
+export const LOG_PANE_PADDING_X = 14;
+
+// The rows that lead somewhere, and only those. The attribute names belong to
+// `log-destination` — it hands over the selector rather than the names, so
+// what these rules point at cannot drift from what a click follows.
+const linkedRow = (suffix = ''): string =>
+	LOG_ROW_SELECTOR.split(',')
+		.map(attribute => `.epiq-log-line${attribute}${suffix}`)
+		.join(',');
+
+// One arrow for the whole panel, moved onto whichever row is hovered — see
+// EventLog, and the same node budget the pseudo-elements above are about. It
+// is decorative: the row is the target, so nothing here takes a pointer.
+export const LOG_ARROW_CLASS = 'epiq-log-arrow';
+
 // Mounted with the panel, so it carries its own look rather than depending on
 // a player being up to define it.
 export const EVENT_LOG_STYLES = `
@@ -262,11 +281,37 @@ export const EVENT_LOG_STYLES = `
 	border-radius: 50%;
 	background: var(${LOG_DOT_COLOR_PROPERTY});
 }
+${linkedRow()} {
+	cursor: pointer;
+}
+${linkedRow(':hover')} {
+	color: ${GUI_THEME.primary};
+	background: ${GUI_THEME.hover};
+}
+.${LOG_ARROW_CLASS} {
+	position: absolute;
+	right: ${LOG_PANE_PADDING_X}px;
+	display: flex;
+	align-items: center;
+	height: ${LOG_ROW_HEIGHT}px;
+	padding: 0 3px;
+	border-radius: 4px;
+	color: ${GUI_THEME.secondary};
+	/* Opaque, so a long line is cut off behind it rather than running under —
+	   and mixed exactly as the row it sits on is, so it does not read as a
+	   patch laid over one. */
+	background: linear-gradient(${GUI_THEME.hover}, ${GUI_THEME.hover}),
+		${GUI_THEME.panel};
+	opacity: 0;
+	pointer-events: none;
+	transition: opacity 120ms ease;
+}
 @keyframes epiqLogLine {
 	from { opacity: 0; }
 	to { opacity: 1; }
 }
 @media (prefers-reduced-motion: reduce) {
 	.epiq-log-line { animation: none; }
+	.${LOG_ARROW_CLASS} { transition: none; }
 }
 `;

--- a/source/gui/client/lib/gui-theme.tsx
+++ b/source/gui/client/lib/gui-theme.tsx
@@ -28,6 +28,10 @@ export const GUI_THEME = {
 	tertiary: 'rgb(31 33 43)',
 	dim: '#585d78',
 	dim2: 'rgb(100 107 133)',
+	// What anything the pointer is over takes on, throughout: buttons, rows,
+	// menu items. A lift off whatever it sits on rather than a colour of its
+	// own, so it reads the same on the panel as on the board.
+	hover: 'rgba(255,255,255,0.04)',
 	accent: '#76d4ff',
 	green: '#8ce99a',
 	red: '#ff8787',

--- a/source/gui/client/lib/log-destination.ts
+++ b/source/gui/client/lib/log-destination.ts
@@ -9,7 +9,9 @@
 // or a handler per line: a window holds up to twenty thousand events, of which
 // exactly one is ever followed, so the route is built on the click.
 
-import {LogEntry} from './event-log';
+// Type-only on purpose: the styles in `event-log` need the row selector from
+// here, and a value import back the other way would close that loop.
+import type {LogEntry} from './event-log';
 import {categoryOf} from './scrubber';
 
 // The tab a ticket opens on. A comment is read among the comments; everything
@@ -80,11 +82,18 @@ export const destinationFromAttributes = (
 
 // The row a click landed in. Null when the click missed every row that leads
 // anywhere — the padding, a day divider, the pane itself.
+// The row under a pointer, when that row leads somewhere. The click path asks
+// where it goes; the panel asks only where it is, to mark it as a target. Both
+// find it the same way, and neither spells the selector out.
+export const linkedRowFrom = (target: EventTarget | null): HTMLElement | null =>
+	target instanceof Element
+		? target.closest<HTMLElement>(LOG_ROW_SELECTOR)
+		: null;
+
 export const readDestination = (
 	target: EventTarget | null,
 ): LogDestination | null => {
-	const row =
-		target instanceof Element ? target.closest(LOG_ROW_SELECTOR) : null;
+	const row = linkedRowFrom(target);
 
 	return row ? destinationFromAttributes(name => row.getAttribute(name)) : null;
 };

--- a/source/test/e2e-gui/event-log.pw.ts
+++ b/source/test/e2e-gui/event-log.pw.ts
@@ -46,7 +46,10 @@ test('the log fills beside the board as the movie plays', async ({
 			`.map(row => row.style.getPropertyValue('--epiq-log-dot').trim())`,
 	)) as string[];
 
-	expect(dotColours).toHaveLength(await lines.count());
+	// Against the rows that one read saw, not a count fetched separately: the
+	// movie is still running, and a line arriving between the two reads made
+	// this fail for saying nothing about the panel.
+	expect(dotColours.length).toBeGreaterThan(0);
 	expect(dotColours.every(colour => colour.length > 0)).toBe(true);
 
 	// A panel, not a wash over the board: it takes its own width and the first

--- a/source/test/e2e-gui/event-log.pw.ts
+++ b/source/test/e2e-gui/event-log.pw.ts
@@ -263,3 +263,59 @@ test('a line goes to where the thing it names is read', async ({
 	await page.getByTestId('log-toggle').click();
 	expect(pageErrors).toEqual([]);
 });
+
+test('a line that leads somewhere says so under the pointer', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await openBoard(page, appUrl);
+	const boardUrl = page.url();
+
+	// As above: the seeded board's own log is board- and swimlane-level events,
+	// so a line that leads anywhere has to be made here.
+	await page.getByTitle('Add issue').first().click();
+	await page.getByPlaceholder('issue name').fill(`Pointed ${Date.now()}`);
+	await page.getByPlaceholder('issue name').press('Enter');
+
+	await page.goto(boardUrl);
+	await page.getByTestId('log-toggle').click();
+	await expect(page.getByTestId('event-log')).toBeVisible();
+
+	const arrow = page.getByTestId('log-row-arrow');
+	await expect(arrow).toHaveCSS('opacity', '0');
+
+	const linking = page.locator('[data-log-issue]').first();
+	await expect.poll(async () => await linking.count()).toBeGreaterThan(0);
+	await expect(linking).toHaveCSS('cursor', 'pointer');
+
+	await linking.hover();
+	await expect(arrow).toHaveCSS('opacity', '1');
+
+	// On the hovered row, not merely somewhere in the panel: one arrow serves
+	// every row, so where it sits is the whole of what it says.
+	const rowBox = await linking.boundingBox();
+	const arrowBox = await arrow.boundingBox();
+	expect(rowBox).not.toBeNull();
+	expect(arrowBox).not.toBeNull();
+	expect(Math.abs(arrowBox!.y - rowBox!.y)).toBeLessThanOrEqual(1);
+	// And at the end of the line rather than out in the panel's margin.
+	expect(arrowBox!.x + arrowBox!.width).toBeLessThanOrEqual(
+		rowBox!.x + rowBox!.width + 1,
+	);
+
+	// A line that leads nowhere stays inert, and takes the arrow away with it.
+	const inert = page
+		.locator(
+			'[data-testid="log-line"]:not([data-log-issue]):not([data-log-sha])',
+		)
+		.first();
+	await expect.poll(async () => await inert.count()).toBeGreaterThan(0);
+	await expect(inert).not.toHaveCSS('cursor', 'pointer');
+
+	await inert.hover();
+	await expect(arrow).toHaveCSS('opacity', '0');
+
+	await page.getByTestId('log-toggle').click();
+	expect(pageErrors).toEqual([]);
+});


### PR DESCRIPTION
`SJP4WPK` made most log lines open something, but nothing said so: a line that navigates looked exactly like a board-level one that does nothing, and the pointer stayed an arrow over both.

On the rows that carry a destination, and only those: `cursor: pointer`, a hover state, and a small arrow at the end of the line. The rows that lead nowhere stay inert, because they carry no attributes for any of it to match.

**A row is still one node.** Both its pseudo-elements are spoken for (clock, kind dot), and a button per row would double what the panel costs for something visible on one row at a time — so there is one arrow for the whole panel, absolutely positioned in the scrolled column and moved onto whichever row is hovered. It rides the scroll because it is positioned in the same coordinates as the rows. It is decorative: `pointer-events: none`, no handler, no interactive element nested inside a clickable row. Moved through a ref rather than by state, since hovering sweeps across rows and a state per row would re-render the column at every one.

The cursor and hover state are pure CSS, and the selector is composed from `log-destination`'s exported `LOG_ROW_SELECTOR` — that module still owns the attribute names, and what lights up cannot drift from what a click follows. `readDestination` and the new hover path now share its `linkedRowFrom` lookup, and its back-import of `LogEntry` became `import type` so the new edge from `event-log` does not close a runtime cycle.

Two notes beyond the ticket:

- `GUI_THEME.bgHighlight` was invisible against the panel, so the app's actual hover tone — `rgba(255,255,255,0.04)`, currently restated in eight components — is now named `GUI_THEME.hover` and used here. The arrow composites the same tint over the panel so it reads as part of the row rather than a patch laid over it. **4BBH20B** tracks pointing the other eight at it; not swept in here.
- `event-log.pw.ts` had a race of its own: it read every row's dot colour in one `evaluate`, then compared that array's length against a `count()` taken afterwards, while the movie was still adding lines. It now asserts against the rows that one read saw.