### PR TITLE
9QFSDGZ Stress the board at team scale, and fix what it found

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"start:gui": "IS_LOCAL=true tsx source/Index.tsx gui",
 		"test": "prettier --check \"**/*.{ts,tsx}\" && vitest run --coverage --exclude \"source/test/e2e/**\" --exclude \"source/test/e2e-collab/**\"",
 		"test:containers": "sh source/scripts/test-containers.sh",
+		"stress": "sh source/scripts/stress.sh",
 		"test:collab": "docker run --rm -v \"$PWD\":/app:ro -v /app/node_modules -w /app epiq-e2e npm run test:collab:ci",
 		"test:collab:ci": "vitest run source/test/e2e-collab/",
 		"test:e2e:ci": "export IS_CI=true && ([ -n \"${EPIQ_SKIP_BUILD:-}\" ] || npm run build:npm) && vitest run source/test/e2e/",

--- a/source/gui/api/instance.ts
+++ b/source/gui/api/instance.ts
@@ -4,7 +4,13 @@ import path from 'node:path';
 // The port a GUI asks for first. A second epiq on the same machine only lands
 // somewhere else because this one was taken, which is the whole reason an
 // instance needs to be identifiable.
-export const PREFERRED_GUI_PORT = 3710;
+//
+// Settable, because the port is not only this process's business: a browser
+// reaching the server through a forwarded port sends that port in its Origin,
+// and the guard on the websocket handshake refuses a handshake whose origin
+// port is not the one the server bound. Anything in front of the server has to
+// be able to make the two agree.
+export const PREFERRED_GUI_PORT = Number(process.env['EPIQ_GUI_PORT']) || 3710;
 
 export const INSTANCE_PATH = '/api/instance';
 export const INSTANCE_APP = 'epiq';

--- a/source/lib/event/log-signature.ts
+++ b/source/lib/event/log-signature.ts
@@ -1,0 +1,37 @@
+// Whether the log has moved.
+//
+// Deriving anything from the log — the board, the timeline — costs a pass over
+// all of it, and between two reads it has usually not changed at all. This is
+// what lets a reader answer "is what I built still true?" without reading the
+// log to find out.
+//
+// Every actor writes its own file, so it covers the directory rather than one
+// file: a teammate's events arriving is their file growing, or appearing for the
+// first time, and either moves the signature. Append-only means a size that has
+// not moved is content that has not moved; mtime catches a file a sync replaced
+// wholesale rather than appended to.
+//
+// Read it BEFORE the log, never after. Any file can gain lines from another
+// machine between two reads, sync included: taken first, a write landing in the
+// gap is cached under the older signature and rebuilt on the next request.
+// Taken afterwards, that write would be stored under the signature of a log it
+// does not match, and nothing would ever rebuild it.
+
+import {existsSync, readdirSync, statSync} from 'node:fs';
+import path from 'node:path';
+import {getEventsDirPath} from '../storage/paths.js';
+
+export const logSignature = (stateBranchRoot: string): string => {
+	const dir = getEventsDirPath(stateBranchRoot);
+	if (!existsSync(dir)) return 'none';
+
+	return readdirSync(dir)
+		.filter(file => file.endsWith('.jsonl'))
+		.sort()
+		.map(file => {
+			const {size, mtimeMs} = statSync(path.join(dir, file));
+
+			return `${file}:${size}:${mtimeMs}`;
+		})
+		.join('|');
+};

--- a/source/lib/repository/node-repo.ts
+++ b/source/lib/repository/node-repo.ts
@@ -14,7 +14,7 @@ import {
 	ReturnFail,
 	succeeded,
 } from '../model/result-types.js';
-import {getState, patchState, updateState} from '../state/state.js';
+import {getState, patchState, setStateEntry, updateState} from '../state/state.js';
 import {getOrderedChildren} from './rank.js';
 
 /**
@@ -135,16 +135,10 @@ export const nodeRepo = {
 		if (!issue) return failed('Unable to create comment, missing issue');
 		if (!isTicketNode(issue)) return failed('Can only comment on issues');
 
-		const result = updateState(s => ({
-			...s,
-			comments: {
-				...(s.comments ?? {}),
-				[comment.id]: {
-					...comment,
-					deleted: false,
-				},
-			},
-		}));
+		const result = setStateEntry('comments', comment.id, {
+			...comment,
+			deleted: false,
+		});
 
 		if (isFail(result)) return failed('Unable to create comment');
 
@@ -169,13 +163,7 @@ export const nodeRepo = {
 			deleted: false,
 		};
 
-		const result = updateState(s => ({
-			...s,
-			comments: {
-				...(s.comments ?? {}),
-				[commentId]: updatedComment,
-			},
-		}));
+		const result = setStateEntry('comments', commentId, updatedComment);
 
 		if (isFail(result)) return failed('Unable to edit comment');
 
@@ -191,13 +179,7 @@ export const nodeRepo = {
 			deleted: true,
 		};
 
-		const result = updateState(s => ({
-			...s,
-			comments: {
-				...(s.comments ?? {}),
-				[commentId]: updatedComment,
-			},
-		}));
+		const result = setStateEntry('comments', commentId, updatedComment);
 
 		if (isFail(result)) return failed('Unable to delete comment');
 
@@ -671,13 +653,7 @@ export const nodeRepo = {
 	createNode<T extends AnyContext>(
 		node: NavNode<T>,
 	): Result<NavNode<AnyContext>> {
-		const result = updateState(s => ({
-			...s,
-			nodes: {
-				...s.nodes,
-				[node.id]: node,
-			},
-		}));
+		const result = setStateEntry('nodes', node.id, node);
 
 		if (isFail(result)) return failed('Unable to create node');
 
@@ -693,13 +669,7 @@ export const nodeRepo = {
 			readonly: true,
 		};
 
-		const result = updateState(s => ({
-			...s,
-			nodes: {
-				...s.nodes,
-				[id]: updatedNode,
-			},
-		}));
+		const result = setStateEntry('nodes', id, updatedNode);
 
 		if (isFail(result)) return failed(result.message);
 
@@ -707,13 +677,7 @@ export const nodeRepo = {
 	},
 
 	updateNode(node: NavNode<AnyContext>) {
-		const result = updateState(s => ({
-			...s,
-			nodes: {
-				...s.nodes,
-				[node.id]: node,
-			},
-		}));
+		const result = setStateEntry('nodes', node.id, node);
 
 		if (isFail(result)) return result;
 		return succeeded('Updated node', node);

--- a/source/lib/repository/node-repo.ts
+++ b/source/lib/repository/node-repo.ts
@@ -201,6 +201,27 @@ export const nodeRepo = {
 		);
 	},
 
+	// Every issue's comments, in one pass over them.
+	//
+	// The caller that wants them all wanted `getCommentsByIssue` per issue, and
+	// that reads every comment on the board each time: O(issues x comments),
+	// which on a board with a hundred thousand of each is ten billion
+	// comparisons and a page that never finishes loading.
+	getCommentsGroupedByIssue(): Map<string, CommentState[]> {
+		const byIssue = new Map<string, CommentState[]>();
+
+		for (const comment of Object.values(getState().comments ?? {})) {
+			if (comment.deleted) continue;
+
+			const existing = byIssue.get(comment.issue);
+
+			if (existing) existing.push(comment);
+			else byIssue.set(comment.issue, [comment]);
+		}
+
+		return byIssue;
+	},
+
 	createAttachment(attachment: AttachmentState): Result<AttachmentState> {
 		const issue = this.getNode(attachment.issue);
 
@@ -258,6 +279,22 @@ export const nodeRepo = {
 		return Object.values(getState().attachments ?? {}).filter(
 			attachment => attachment.issue === issueId && !attachment.deleted,
 		);
+	},
+
+	// The same one pass, for the same reason.
+	getAttachmentsGroupedByIssue(): Map<string, AttachmentState[]> {
+		const byIssue = new Map<string, AttachmentState[]>();
+
+		for (const attachment of Object.values(getState().attachments ?? {})) {
+			if (attachment.deleted) continue;
+
+			const existing = byIssue.get(attachment.issue);
+
+			if (existing) existing.push(attachment);
+			else byIssue.set(attachment.issue, [attachment]);
+		}
+
+		return byIssue;
 	},
 
 	editValue(targetId: string, md: string): Result<{md: string}> {

--- a/source/lib/repository/node-repo.ts
+++ b/source/lib/repository/node-repo.ts
@@ -14,7 +14,12 @@ import {
 	ReturnFail,
 	succeeded,
 } from '../model/result-types.js';
-import {getState, patchState, setStateEntry, updateState} from '../state/state.js';
+import {
+	getState,
+	patchState,
+	setStateEntry,
+	updateState,
+} from '../state/state.js';
 import {getOrderedChildren} from './rank.js';
 
 /**

--- a/source/lib/state/state.ts
+++ b/source/lib/state/state.ts
@@ -243,6 +243,61 @@ export function withDeferredDerive<T>(fn: () => T): Result<T> {
 export const patchState = (patch: Partial<BaseState>) =>
 	updateState(old => ({...old, ...patch}));
 
+// The keyed collections of the base state — the ones a single event writes one
+// entry of.
+type StateMapKey = {
+	[K in keyof BaseState]-?: NonNullable<BaseState[K]> extends Record<
+		string,
+		object
+	>
+		? K
+		: never;
+}[keyof BaseState];
+
+/**
+ * Writes one entry of a keyed collection.
+ *
+ * Inside a replay batch the collection is written in place. Rebuilding it per
+ * write is what made a replay quadratic a second time: `{...s.nodes, [id]: n}`
+ * copies every node a board has, once per event, so a log twice as long cost
+ * four times as much — 5k events took 1.1s, 40k took 96s. Deferring the derive
+ * fixed the index being rebuilt per event; it never touched this.
+ *
+ * Outside a batch it copies, because a reader holding the previous state must
+ * not see it change underneath them. Nothing reads derived state mid-batch —
+ * that is what makes the write safe rather than merely faster.
+ */
+export function setStateEntry<K extends StateMapKey>(
+	key: K,
+	id: string,
+	value: NonNullable<BaseState[K]>[string],
+): Result<string> {
+	if (!deferring) {
+		return updateState(
+			old =>
+				({
+					...old,
+					[key]: {...((old[key] ?? {}) as object), [id]: value},
+				}) as BaseState,
+		);
+	}
+
+	const prev = getState();
+	const collection = (prev[key] ?? {}) as Record<string, unknown>;
+
+	collection[id] = value;
+
+	// The batch still has to carry what it wrote, or the flush finds nothing to
+	// derive from. Spreading the state's own keys is a fixed, small cost — it is
+	// the collection that grows.
+	const nextBase = {...prev, [key]: collection} as BaseState;
+
+	deferredBase = nextBase;
+	_appState = {...prev, ...nextBase};
+
+	return succeeded('State updated', null);
+}
+
 export const isChildSelected = (
 	parent: NavNode<AnyContext>,
 	i: number,

--- a/source/lib/state/state.ts
+++ b/source/lib/state/state.ts
@@ -278,7 +278,7 @@ export function setStateEntry<K extends StateMapKey>(
 				({
 					...old,
 					[key]: {...((old[key] ?? {}) as object), [id]: value},
-				}) as BaseState,
+				} as BaseState),
 		);
 	}
 

--- a/source/lib/utils/color.ts
+++ b/source/lib/utils/color.ts
@@ -139,8 +139,15 @@ export const stringToHslHexColor = (value: string): string => {
 	return rgbToHex(rgb);
 };
 
-export const getStringColor = (id: string, config = TAGS_DEFAULT): string => {
-	const normalized = normalizeName(id);
+// Tolerates a missing name rather than throwing on one. Callers colour things
+// the log does not have to name — a comment whose author was never written, an
+// event from a build that knew a field this one does not — and a colour is
+// never worth taking a request down for.
+export const getStringColor = (
+	id: string | undefined,
+	config = TAGS_DEFAULT,
+): string => {
+	const normalized = normalizeName(id ?? '');
 
 	if (normalized && config[normalized]) return config[normalized];
 

--- a/source/mcp/epiq-api.ts
+++ b/source/mcp/epiq-api.ts
@@ -11,6 +11,7 @@ import {loadSettingsFromConfig} from '../lib/config/user-config.js';
 import {createIssueEvents} from '../lib/event/common-events.js';
 import {ulidTimeMs} from '../lib/event/date-utils.js';
 import {bootStateFromEventLog} from '../lib/event/event-boot.js';
+import {logSignature} from '../lib/event/log-signature.js';
 import {
 	loadEventActors,
 	loadMergedEvents,
@@ -35,7 +36,7 @@ import {
 	resolveAndPersistRankForCreate,
 	resolveAndPersistRankForMove,
 } from '../lib/repository/rank.js';
-import {getSafeState} from '../lib/state/state.js';
+import {getSafeState, isStateInitialized} from '../lib/state/state.js';
 import {setSynced, setSyncFailed, setSyncing} from '../lib/state/sync-state.js';
 import {recordRecentProject} from '../lib/config/recent-projects.js';
 import {resolveClosestEpiqProjectRoot} from '../lib/storage/paths.js';
@@ -247,6 +248,10 @@ const resolveRepoRoot = (repoRoot?: string): Result<string> => {
 	return succeeded('Resolved Epiq repo root', result.value);
 };
 
+// The log this process last booted from. Held for the life of it, and for one
+// root: a server serves one project.
+let lastBoot: {root: string; signature: string} | null = null;
+
 const boot = async (
 	repoRoot?: string,
 	options?: {pull?: boolean},
@@ -301,6 +306,34 @@ const boot = async (
 		}
 	}
 
+	const booted = {
+		repoRoot: repoRootResult.value,
+		stateBranchRoot: stateBranchRootResult.value,
+	};
+
+	// Before the load, never after — see log-signature for why that order is
+	// the one that stays correct when another machine writes mid-read.
+	const signature = logSignature(stateBranchRootResult.value);
+
+	// Reading the board should not mean deriving it again. Every call came
+	// through here re-reading the whole log and replaying every event: on a
+	// twenty-person decade that is 169 MB and 960,000 events, about eight
+	// seconds, for a board that had not changed since the last request a moment
+	// earlier.
+	//
+	// Only while live. A checkout in the past is materialized by the time-travel
+	// path and would be thrown away by a boot; `bootStateFromEventLog` refuses
+	// that case too, and skipping must not quietly take its place.
+	if (
+		lastBoot &&
+		lastBoot.root === stateBranchRootResult.value &&
+		lastBoot.signature === signature &&
+		isStateInitialized() &&
+		getTimeTravelStatus().mode === 'live'
+	) {
+		return succeeded('Booted Epiq state, unchanged', booted);
+	}
+
 	const eventsResult = loadMergedEventsWithUnreadable(
 		stateBranchRootResult.value,
 	);
@@ -312,10 +345,11 @@ const boot = async (
 	);
 	if (isFail(bootResult)) return failed(bootResult.message);
 
-	return succeeded('Booted Epiq state', {
-		repoRoot: repoRootResult.value,
-		stateBranchRoot: stateBranchRootResult.value,
-	});
+	// Recorded after the boot, so a failed one is retried rather than remembered
+	// as done.
+	lastBoot = {root: stateBranchRootResult.value, signature};
+
+	return succeeded('Booted Epiq state', booted);
 };
 
 const getActor = (): Result<Actor> => {

--- a/source/mcp/epiq-api.ts
+++ b/source/mcp/epiq-api.ts
@@ -1136,6 +1136,16 @@ export const getEpiqState = async (input: ToolInput = {}) => {
 	});
 };
 
+// How far back the closed lane is sent. It is the one collection that grows
+// without bound — everything a team finishes lands there and stays — so a
+// decade of a twenty-person board is ninety-five thousand closed tickets
+// against a couple of hundred open ones.
+//
+// A year is what a reader is plausibly still looking for by eye. Reaching
+// further back is a request of its own rather than a cost every board pays on
+// every load.
+const CLOSED_TICKET_WINDOW_MS = 365 * 24 * 60 * 60 * 1000;
+
 // Reads whatever is currently materialized, live or a historical checkout. Must
 // never boot: booting discards an active time-travel checkout.
 export const deriveGuiState = (): Result<ApiState> => {
@@ -1147,6 +1157,8 @@ export const deriveGuiState = (): Result<ApiState> => {
 
 	const nodes = Object.values(stateResult.value.nodes);
 	const boards = nodes.filter(n => isBoardNode(n) && !n.isDeleted);
+
+	const closedSince = Date.now() - CLOSED_TICKET_WINDOW_MS;
 
 	const swimlanesByBoardId = new Map<string, Swimlane[]>();
 	const ticketsBySwimlaneId = new Map<string, Ticket[]>();
@@ -1161,10 +1173,31 @@ export const deriveGuiState = (): Result<ApiState> => {
 		}
 
 		if (isTicketNode(node) && node.parentNodeId) {
+			// Everything a team ever finished lands in the closed lane and stays,
+			// so it is the one collection with no ceiling: a decade of a
+			// twenty-person board is ninety-five thousand tickets against a
+			// couple of hundred open ones, and sending them all is most of an
+			// 88 MB payload the browser has to parse before it can draw.
+			if (
+				node.parentNodeId === CLOSED_SWIMLANE_ID &&
+				ulidTimeMs(node.id) < closedSince
+			) {
+				continue;
+			}
+
 			const list = ticketsBySwimlaneId.get(node.parentNodeId) ?? [];
 			list.push(node);
 			ticketsBySwimlaneId.set(node.parentNodeId, list);
 		}
+	}
+
+	// The tickets the payload actually carries. Comments and attachments are
+	// built for these rather than for every ticket that has ever existed: a
+	// closed ticket nobody is sent does not need its conversation sent either.
+	const sentIssueIds = new Set<string>();
+
+	for (const tickets of ticketsBySwimlaneId.values()) {
+		for (const ticket of tickets) sentIssueIds.add(ticket.id);
 	}
 
 	const settingsRes = loadSettingsFromConfig();
@@ -1172,12 +1205,16 @@ export const deriveGuiState = (): Result<ApiState> => {
 
 	const commentsByIssueId: ApiState['commentsByIssueId'] = {};
 
-	for (const issue of nodes.filter(isTicketNode)) {
-		if (issue.isDeleted) continue;
+	// Grouped once rather than asked for per issue: asking per issue reads every
+	// comment on the board each time, which on a board with a hundred thousand
+	// of each never finishes.
+	const commentsByIssue = nodeRepo.getCommentsGroupedByIssue();
 
-		commentsByIssueId[issue.id] = nodeRepo
-			.getCommentsByIssue(issue.id)
-			.map(comment => {
+	for (const issue of nodes.filter(isTicketNode)) {
+		if (issue.isDeleted || !sentIssueIds.has(issue.id)) continue;
+
+		commentsByIssueId[issue.id] = (commentsByIssue.get(issue.id) ?? []).map(
+			comment => {
 				const contributor = nodeRepo.getContributor(comment.authorId);
 
 				return {
@@ -1197,7 +1234,8 @@ export const deriveGuiState = (): Result<ApiState> => {
 					},
 					createdAt: ulidTimeMs(comment.id),
 				};
-			});
+			},
+		);
 	}
 
 	const attachmentOwners = new Map<string, string>();
@@ -1209,21 +1247,23 @@ export const deriveGuiState = (): Result<ApiState> => {
 
 	const attachmentsByIssueId: ApiState['attachmentsByIssueId'] = {};
 
-	for (const issue of nodes.filter(isTicketNode)) {
-		if (issue.isDeleted) continue;
+	const attachmentsByIssue = nodeRepo.getAttachmentsGroupedByIssue();
 
-		attachmentsByIssueId[issue.id] = nodeRepo
-			.getAttachmentsByIssue(issue.id)
-			.map(attachment => ({
-				id: attachment.id,
-				issueId: attachment.issue,
-				name: attachment.name,
-				fileName: getAttachmentFileName(attachment.hash, attachment.ext),
-				bytes: attachment.bytes,
-				createdAt: ulidTimeMs(attachment.id),
-				canDelete:
-					attachmentOwners.get(attachment.id) === settingsRes.value.userId,
-			}));
+	for (const issue of nodes.filter(isTicketNode)) {
+		if (issue.isDeleted || !sentIssueIds.has(issue.id)) continue;
+
+		attachmentsByIssueId[issue.id] = (
+			attachmentsByIssue.get(issue.id) ?? []
+		).map(attachment => ({
+			id: attachment.id,
+			issueId: attachment.issue,
+			name: attachment.name,
+			fileName: getAttachmentFileName(attachment.hash, attachment.ext),
+			bytes: attachment.bytes,
+			createdAt: ulidTimeMs(attachment.id),
+			canDelete:
+				attachmentOwners.get(attachment.id) === settingsRes.value.userId,
+		}));
 	}
 
 	return succeeded('Retrieved Epiq GUI state', {

--- a/source/mcp/epiq-api.ts
+++ b/source/mcp/epiq-api.ts
@@ -1187,7 +1187,13 @@ export const deriveGuiState = (): Result<ApiState> => {
 					author: {
 						id: comment.authorId,
 						name: contributor?.name ?? 'Unknown',
-						color: getStringColor(contributor?.name ?? comment.authorId),
+						// The author is optional in the log by design — the payload
+						// schema leaves it unconstrained so an event already written
+						// without one is not thrown away. So it can be missing here,
+						// and a colour is not worth taking the whole board down for.
+						color: getStringColor(
+							contributor?.name ?? comment.authorId ?? 'Unknown',
+						),
 					},
 					createdAt: ulidTimeMs(comment.id),
 				};

--- a/source/mcp/test/epiq-api.test.ts
+++ b/source/mcp/test/epiq-api.test.ts
@@ -391,6 +391,8 @@ vi.mock('../../lib/repository/node-repo.js', () => ({
 		getContributor: vi.fn((id: string) => contributorRegistry[id]),
 		getCommentsByIssue: vi.fn(() => []),
 		getAttachmentsByIssue: vi.fn(() => []),
+		getCommentsGroupedByIssue: vi.fn(() => new Map()),
+		getAttachmentsGroupedByIssue: vi.fn(() => new Map()),
 	},
 }));
 

--- a/source/mcp/timeline-index.ts
+++ b/source/mcp/timeline-index.ts
@@ -14,14 +14,12 @@
 // routinely in the middle. Appending would be wrong in exactly the case this
 // exists for.
 
-import {existsSync, readdirSync, statSync} from 'node:fs';
-import path from 'node:path';
 import {getEventTime, toEffectiveUlidTimes} from '../lib/event/date-utils.js';
 import {AppEvent, EventAction} from '../lib/event/event.model.js';
 import {loadMergedEvents} from '../lib/event/event-load.js';
+import {logSignature} from '../lib/event/log-signature.js';
 import {formatLogAction} from '../lib/event/format-log-utils.js';
 import {failed, isFail, Result, succeeded} from '../lib/model/result-types.js';
-import {getEventsDirPath} from '../lib/storage/paths.js';
 import {getStringColor} from '../lib/utils/color.js';
 
 // Colour resolved here rather than on the client: getStringColor pulls in
@@ -356,28 +354,6 @@ export const buildTimelineEntries = (events: AppEvent[]): TimelineEntry[] => {
 	// Sorted here rather than per request: effective times are not the order the
 	// log is stored in, and a window is a range over this axis.
 	return entries.sort((left, right) => left.t - right.t);
-};
-
-// What the log looked like when the entries were built.
-//
-// Every actor writes its own file, so this covers the directory rather than one
-// file: a teammate's events arriving is their file growing, or appearing for
-// the first time, and either moves the signature. Append-only means a size that
-// has not moved is content that has not moved; mtime catches a file a sync
-// replaced wholesale rather than appended to.
-const logSignature = (stateBranchRoot: string): string => {
-	const dir = getEventsDirPath(stateBranchRoot);
-	if (!existsSync(dir)) return 'none';
-
-	return readdirSync(dir)
-		.filter(file => file.endsWith('.jsonl'))
-		.sort()
-		.map(file => {
-			const {size, mtimeMs} = statSync(path.join(dir, file));
-
-			return `${file}:${size}:${mtimeMs}`;
-		})
-		.join('|');
 };
 
 // Held for the life of the process, and only ever for one root: the GUI server

--- a/source/scripts/stress.sh
+++ b/source/scripts/stress.sh
@@ -15,12 +15,13 @@
 
 set -eu
 
-# What the browser on this machine opens. Inside the container the GUI binds
-# 3710 on loopback — its own design — so socat bridges the two: it cannot
-# listen on 3710 itself, since 0.0.0.0 covers loopback and node would then find
-# the port taken and quietly move to another one.
+# One port, end to end. The GUI binds loopback by design, so a published port
+# cannot reach it and socat has to bridge — but the bridge must not change the
+# number: a browser sends the port it dialled in its Origin, and the websocket
+# handshake is refused when that is not the port the server bound. So the
+# server is told to use this one too, and socat listens on the container's own
+# address rather than 0.0.0.0, which would take the port from under it.
 PORT="${STRESS_PORT:-3720}"
-GUI_PORT=3710
 
 SERVE="${STRESS_SERVE:-true}"
 MEMORY="${STRESS_MEMORY:-6g}"
@@ -60,6 +61,7 @@ exec docker run --rm ${TTY_FLAGS} --init \
 	-e STRESS_YEARS="${STRESS_YEARS:-}" \
 	-e STRESS_SERVE="${SERVE}" \
 	-e NODE_OPTIONS="--max-old-space-size=${NODE_HEAP}" \
+	-e EPIQ_GUI_PORT="${PORT}" \
 	-v "$PWD":/app:ro \
 	-v /app/node_modules \
 	-w /app \
@@ -68,7 +70,8 @@ exec docker run --rm ${TTY_FLAGS} --init \
 		if [ '${SERVE}' = 'true' ]; then
 			apt-get update >/dev/null 2>&1
 			apt-get install -y socat >/dev/null 2>&1
-			socat TCP-LISTEN:${PORT},fork,reuseaddr TCP:127.0.0.1:${GUI_PORT} &
+			socat TCP-LISTEN:${PORT},fork,reuseaddr,bind=\$(hostname -i) \
+				TCP:127.0.0.1:${PORT} &
 		fi
 		npx tsx source/test/stress/run.ts
 	"

--- a/source/scripts/stress.sh
+++ b/source/scripts/stress.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env sh
+
+# Ten years of a twenty-person board, generated and replayed in a container,
+# then served so it can be used rather than only measured.
+#
+# Opt-in, and deliberately in no pipeline: it takes minutes and wants gigabytes.
+#
+#   npm run stress                     # the default: ~960k events, serves the GUI
+#   STRESS_EVENTS=50000 npm run stress # something smaller, to see it work first
+#   STRESS_SERVE=false npm run stress  # numbers only, exits when done
+#
+# A container so it neither touches the real board nor depends on this machine
+# having the right node. The image is the e2e one, which already carries git and
+# the dependencies.
+
+set -eu
+
+# What the browser on this machine opens. Inside the container the GUI binds
+# 3710 on loopback — its own design — so socat bridges the two: it cannot
+# listen on 3710 itself, since 0.0.0.0 covers loopback and node would then find
+# the port taken and quietly move to another one.
+PORT="${STRESS_PORT:-3720}"
+GUI_PORT=3710
+
+SERVE="${STRESS_SERVE:-true}"
+MEMORY="${STRESS_MEMORY:-6g}"
+# Node's default heap is well under what a million events needs, and it dies
+# with a stack trace that looks like a bug in the board rather than a limit.
+NODE_HEAP="${STRESS_NODE_HEAP:-5120}"
+
+# The checkout goes in read-only, so anything the run needs built has to be
+# built out here.
+if [ ! -f dist/gui/index.html ]; then
+	echo "Building the GUI (the container mounts this read-only)..."
+	npm run build:gui
+fi
+
+if ! docker image inspect epiq-e2e >/dev/null 2>&1; then
+	echo "Building the epiq-e2e image (once)..."
+	npm run build:e2e:image
+fi
+
+echo "Stress board in a container — memory ${MEMORY}, GUI on http://127.0.0.1:${PORT}"
+
+# A terminal only when there is one to attach: run from a script or a pipe,
+# `-t` fails outright with "the input device is not a TTY".
+if [ -t 0 ]; then
+	TTY_FLAGS="-it"
+else
+	TTY_FLAGS=""
+fi
+
+# `--init` so ctrl-c reaches node rather than leaving it holding the port.
+# shellcheck disable=SC2086
+exec docker run --rm ${TTY_FLAGS} --init \
+	--memory "${MEMORY}" \
+	-p "${PORT}:${PORT}" \
+	-e STRESS_EVENTS="${STRESS_EVENTS:-}" \
+	-e STRESS_ACTORS="${STRESS_ACTORS:-}" \
+	-e STRESS_YEARS="${STRESS_YEARS:-}" \
+	-e STRESS_SERVE="${SERVE}" \
+	-e NODE_OPTIONS="--max-old-space-size=${NODE_HEAP}" \
+	-v "$PWD":/app:ro \
+	-v /app/node_modules \
+	-w /app \
+	epiq-e2e \
+	sh -c "
+		if [ '${SERVE}' = 'true' ]; then
+			apt-get update >/dev/null 2>&1
+			apt-get install -y socat >/dev/null 2>&1
+			socat TCP-LISTEN:${PORT},fork,reuseaddr TCP:127.0.0.1:${GUI_PORT} &
+		fi
+		npx tsx source/test/stress/run.ts
+	"

--- a/source/test/stress/generate-log.ts
+++ b/source/test/stress/generate-log.ts
@@ -2,9 +2,15 @@
 // stress run has something real to chew on.
 //
 // The lines are minted the way persist() mints them — `{[action]: payload, v,
-// id: [ulid, refId]}`, ULIDs that climb, a refId chain per actor — because a
-// log of plausible-looking lines that fails to materialize would be worse than
-// no test at all: it would look like it passed.
+// id: [ulid, refId]}`, ULIDs that climb, a refId chain per actor — and every
+// payload is checked against the schema the product parses with. A log of
+// plausible-looking lines that fails to apply would be worse than no test at
+// all: it would look like it passed.
+//
+// What it writes is a board being worked, not a board being filled. Tickets are
+// opened into the first lane, walked along the lanes as they are worked, and
+// closed — so the open board stays the size a real one is, and the decade of
+// history piles up where a decade of history actually goes: the closed board.
 //
 // Not a test file. Nothing runs this but `npm run stress`.
 
@@ -13,27 +19,30 @@ import path from 'node:path';
 import {ulid} from 'ulid';
 import {parseEventPayload} from '../../lib/event/event-payload.schema.js';
 import {EventAction} from '../../lib/event/event.model.js';
+import {CLOSED_SWIMLANE_ID} from '../../lib/event/static-ids.js';
 import {isFail} from '../../lib/model/result-types.js';
 
 export type GenerateInput = {
 	stateRoot: string;
-	boardId: string;
 	laneIds: string[];
 	actors: {userId: string; userName: string}[];
 	events: number;
 	years: number;
-	// Which actions the log is made of, when narrowing it to one is how you
-	// find out which handler is the slow one.
+	// Which actions the log is made of. Narrowing it to one or two is how a slow
+	// handler is found.
 	shape?: readonly string[];
 	// Created by the log itself, so replay has them before anything uses them.
 	tagNames: string[];
+	// How many tickets stay open. A board's open count is a steady state rather
+	// than a fraction of its age: a team closes work to keep the board readable,
+	// so ten years of history leaves about as many open tickets as one year.
+	openTickets?: number;
 };
 
-// Roughly what a person does to a ticket, in the proportions a board actually
-// sees: far more tagging and commenting than creating.
+// Roughly what a person does to a ticket, in the proportions a board sees: far
+// more tagging, commenting and moving than creating.
 const SHAPE = [
 	'add.issue',
-	'add.issue.tag',
 	'add.issue.tag',
 	'add.issue.comment',
 	'add.issue.comment',
@@ -42,15 +51,22 @@ const SHAPE = [
 	'edit.title',
 	'edit.description',
 	'add.issue.assignee',
+	'close.issue',
 ] as const;
+
+type Action = (typeof SHAPE)[number];
 
 const YEAR_MS = 365 * 24 * 60 * 60 * 1000;
 
+// Compared lexicographically, which is what the rank ordering does.
 const RANKS = ['aQ', 'aV', 'b0', 'b5', 'cB', 'cH'];
+
+// A ticket on the board, and how far along the lanes it has been worked.
+type OpenTicket = {id: string; lane: number};
 
 export const generateLog = async (
 	input: GenerateInput,
-): Promise<{lines: number}> => {
+): Promise<{lines: number; closed: number; open: number}> => {
 	const eventsDir = path.join(input.stateRoot, '.epiq', 'events');
 	fs.mkdirSync(eventsDir, {recursive: true});
 
@@ -65,25 +81,20 @@ export const generateLog = async (
 		buffer: [] as string[],
 	}));
 
-	const shape = (input.shape ?? SHAPE) as readonly (typeof SHAPE)[number][];
+	const shape = (input.shape ?? SHAPE) as readonly Action[];
+	const openTarget = input.openTickets ?? 250;
 
 	const start = Date.now() - input.years * YEAR_MS;
 	const step = Math.max(1, Math.floor((input.years * YEAR_MS) / input.events));
 
 	// The tail of the causal order, which is what an actor refs when it has
-	// synced. Advanced globally rather than per actor so the forest is mostly a
-	// chain, the way a team that syncs often really looks.
+	// synced. Advanced globally rather than per actor, the way a team that syncs
+	// often really looks.
 	let edge: string | null = null;
 
 	// A minority of events ref an older edge instead: concurrent work, which is
 	// what makes getSortedEvents do more than walk a list.
 	let staleEdge: string | null = null;
-
-	// Issues are referred to long after they are made, so keep a pool rather
-	// than only ever touching the newest.
-	const issues: string[] = [];
-
-	let written = 0;
 
 	// Checked against the schema the product parses with, not against what this
 	// file believes. A payload missing a field materializes anyway — nothing
@@ -106,19 +117,26 @@ export const generateLog = async (
 		}
 	};
 
-	const emit = (
+	let written = 0;
+	let closed = 0;
+
+	const write = (
 		action: string,
 		payload: Record<string, unknown>,
-		at: number,
+		id: string,
+		refId: string | null,
 	) => {
 		const stream = streams[written % streams.length]!;
-		const id = ulid(at);
 
 		validate(action, payload);
-
 		stream.buffer.push(
-			JSON.stringify({[action]: payload, v: 1, id: [id, edge]}),
+			JSON.stringify({[action]: payload, v: 1, id: [id, refId]}),
 		);
+
+		if (stream.buffer.length >= 4096) {
+			stream.out.write(stream.buffer.join('\n') + '\n');
+			stream.buffer.length = 0;
+		}
 
 		staleEdge = edge;
 		edge = id;
@@ -132,74 +150,132 @@ export const generateLog = async (
 	//
 	// Strictly before the first event that uses them, so no reordering of
 	// concurrent branches can put a tagging ahead of its tag.
-	const preambleCount = input.actors.length + input.tagNames.length;
-	let preambleAt = start - preambleCount;
+	let preambleAt = start - (input.actors.length + input.tagNames.length);
 
 	const tagIds = input.tagNames.map((_, index) =>
 		ulid(start - input.tagNames.length + index),
 	);
 
 	for (const actor of input.actors) {
-		emit(
+		write(
 			'create.contributor',
 			{id: actor.userId, name: actor.userName},
-			preambleAt++,
+			ulid(preambleAt++),
+			edge,
 		);
 	}
 
 	input.tagNames.forEach((name, index) => {
-		emit('create.tag', {id: tagIds[index]!, name}, preambleAt++);
+		write('create.tag', {id: tagIds[index]!, name}, ulid(preambleAt++), edge);
 	});
 
-	for (let i = 0; i < input.events; i++) {
-		const stream = streams[i % streams.length]!;
-		const action = shape[i % shape.length]!;
+	// The tickets on the board, oldest first.
+	const open: OpenTicket[] = [];
 
-		// Climbing, and never behind the parent it points at — the same rule
-		// persist() enforces when it seeds from the edge.
-		const id = ulid(start + i * step);
+	for (let i = 0; i < input.events; i++) {
+		const shaped = shape[i % shape.length]!;
+
+		// Closing is what holds the open board at its size. Below the target a
+		// team has nothing it would be closing, so the event becomes work on a
+		// ticket instead — which also stops the pool emptying and later events
+		// naming tickets that are not there.
+		// A comment rather than another tagging: the same ticket tagged with the
+		// same tag twice is a skip on replay, and standing in with one would
+		// manufacture thousands of them.
+		const action: Action =
+			shaped === 'close.issue' && open.length <= openTarget
+				? 'add.issue.comment'
+				: shaped;
 
 		// Some events ref an older edge: concurrent work, which is what makes
 		// getSortedEvents do more than walk a list. Never the first, though —
 		// branching off the preamble makes this event a sibling of the last
 		// create.tag, and siblings sort by ULID, so its whole subtree would be
-		// walked before the tags it goes on to use exist.
+		// walked before the tags it uses exist.
 		const refId = i > 0 && i % 17 === 0 && staleEdge ? staleEdge : edge;
 
-		const issueId =
-			action === 'add.issue'
-				? ulid(start + i * step)
-				: issues[i % Math.max(1, issues.length)] ?? ulid(start + i * step);
+		const id = ulid(start + i * step);
+		const actorId = streams[written % streams.length]!.actor.userId;
 
-		if (action === 'add.issue') issues.push(issueId);
+		if (action === 'add.issue') {
+			const ticket: OpenTicket = {id, lane: 0};
+			open.push(ticket);
 
-		const payload = buildPayload(action, {
-			id: issueId,
-			laneId: input.laneIds[i % input.laneIds.length]!,
-			tagId: tagIds[i % tagIds.length]!,
-			actorId: stream.actor.userId,
-			n: i,
-		});
+			write(
+				action,
+				{
+					id: ticket.id,
+					name: `Ticket ${i}: something a person actually wrote down`,
+					// Filed into the first lane, rather than dropped wherever.
+					parent: input.laneIds[0]!,
+					rank: RANKS[i % RANKS.length]!,
+				},
+				id,
+				refId,
+			);
 
-		validate(action, payload);
-
-		stream.buffer.push(
-			JSON.stringify({[action]: payload, v: 1, id: [id, refId]}),
-		);
-
-		if (stream.buffer.length >= 4096) {
-			stream.out.write(stream.buffer.join('\n') + '\n');
-			stream.buffer.length = 0;
+			continue;
 		}
 
-		staleEdge = edge;
-		edge = id;
-		written++;
+		if (open.length === 0) continue;
+
+		// Closing takes the oldest: a backlog drains from the far end.
+		const ticket = action === 'close.issue' ? open[0]! : open[i % open.length]!;
+
+		if (action === 'close.issue') {
+			open.shift();
+			closed++;
+
+			write(
+				action,
+				{
+					id: ticket.id,
+					// The handler refuses any parent but this one.
+					parent: CLOSED_SWIMLANE_ID,
+					rank: RANKS[i % RANKS.length]!,
+				},
+				id,
+				refId,
+			);
+
+			continue;
+		}
+
+		if (action === 'move.node') {
+			// Along the lanes, not between random ones: a ticket is worked from
+			// one column to the next, and now and then sent back one, which is
+			// what a review that failed looks like.
+			const back = i % 9 === 0 && ticket.lane > 0;
+
+			ticket.lane = back
+				? ticket.lane - 1
+				: Math.min(ticket.lane + 1, input.laneIds.length - 1);
+
+			write(
+				action,
+				{
+					id: ticket.id,
+					parent: input.laneIds[ticket.lane]!,
+					rank: RANKS[i % RANKS.length]!,
+				},
+				id,
+				refId,
+			);
+
+			continue;
+		}
+
+		write(
+			action,
+			workPayload(action, ticket.id, i, actorId, tagIds),
+			id,
+			refId,
+		);
 	}
 
-	// Awaited, not merely ended: `end()` returns before the bytes reach the
-	// disk, and reading the log a moment later then finds a file that is empty
-	// or half written — which measures an empty board and calls it a pass.
+	// Awaited, not merely ended: `end()` returns before the bytes reach the disk,
+	// and reading the log a moment later then finds a file that is empty or half
+	// written — which measures an empty board and calls it a pass.
 	await Promise.all(
 		streams.map(
 			stream =>
@@ -216,49 +292,42 @@ export const generateLog = async (
 		),
 	);
 
-	return {lines: written};
+	return {lines: written, closed, open: open.length};
 };
 
-const buildPayload = (
-	action: (typeof SHAPE)[number],
-	at: {id: string; laneId: string; tagId: string; actorId: string; n: number},
+// Everything that happens to a ticket without moving or closing it.
+const workPayload = (
+	action: Action,
+	issueId: string,
+	n: number,
+	actorId: string,
+	tagIds: string[],
 ): Record<string, unknown> => {
 	switch (action) {
-		case 'add.issue':
-			return {
-				id: at.id,
-				name: `Ticket ${at.n}: something a person actually wrote down`,
-				parent: at.laneId,
-				rank: RANKS[at.n % RANKS.length],
-			};
 		case 'add.issue.tag':
-			return {id: at.id, tag: at.tagId};
+			return {id: issueId, tag: tagIds[n % tagIds.length]!};
 		case 'add.issue.comment':
 			return {
 				id: ulid(),
-				issue: at.id,
+				issue: issueId,
 				// Required. Without it the event still materializes — nothing
-				// validates a payload on load — and then takes the GUI down on the
-				// first read, with a stack trace pointing at colour generation.
-				author: at.actorId,
+				// validates a payload on load — and takes the GUI down on the first
+				// read, inside colour generation, a long way from the mistake.
+				author: actorId,
 				md: `Had a look at this — the part to watch is the ${
-					at.n % 7 === 0 ? 'window derivation' : 'ordering'
+					n % 7 === 0 ? 'window derivation' : 'ordering'
 				}.`,
 			};
-		case 'move.node':
-			return {
-				id: at.id,
-				parent: at.laneId,
-				rank: RANKS[at.n % RANKS.length],
-			};
 		case 'edit.title':
-			return {id: at.id, name: `Ticket ${at.n}, renamed`};
+			return {id: issueId, name: `Ticket ${n}, renamed`};
 		case 'edit.description':
 			return {
-				id: at.id,
-				md: `Longer body for ticket ${at.n}.\n\nSecond paragraph.`,
+				id: issueId,
+				md: `Longer body for ticket ${n}.\n\nSecond paragraph.`,
 			};
 		case 'add.issue.assignee':
-			return {id: at.id, assignee: at.actorId};
+			return {id: issueId, assignee: actorId};
+		default:
+			throw new Error(`no payload for ${action}`);
 	}
 };

--- a/source/test/stress/generate-log.ts
+++ b/source/test/stress/generate-log.ts
@@ -1,0 +1,264 @@
+// Writes an event log the size a team actually reaches, so the rest of the
+// stress run has something real to chew on.
+//
+// The lines are minted the way persist() mints them — `{[action]: payload, v,
+// id: [ulid, refId]}`, ULIDs that climb, a refId chain per actor — because a
+// log of plausible-looking lines that fails to materialize would be worse than
+// no test at all: it would look like it passed.
+//
+// Not a test file. Nothing runs this but `npm run stress`.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import {ulid} from 'ulid';
+import {parseEventPayload} from '../../lib/event/event-payload.schema.js';
+import {EventAction} from '../../lib/event/event.model.js';
+import {isFail} from '../../lib/model/result-types.js';
+
+export type GenerateInput = {
+	stateRoot: string;
+	boardId: string;
+	laneIds: string[];
+	actors: {userId: string; userName: string}[];
+	events: number;
+	years: number;
+	// Which actions the log is made of, when narrowing it to one is how you
+	// find out which handler is the slow one.
+	shape?: readonly string[];
+	// Created by the log itself, so replay has them before anything uses them.
+	tagNames: string[];
+};
+
+// Roughly what a person does to a ticket, in the proportions a board actually
+// sees: far more tagging and commenting than creating.
+const SHAPE = [
+	'add.issue',
+	'add.issue.tag',
+	'add.issue.tag',
+	'add.issue.comment',
+	'add.issue.comment',
+	'move.node',
+	'move.node',
+	'edit.title',
+	'edit.description',
+	'add.issue.assignee',
+] as const;
+
+const YEAR_MS = 365 * 24 * 60 * 60 * 1000;
+
+const RANKS = ['aQ', 'aV', 'b0', 'b5', 'cB', 'cH'];
+
+export const generateLog = async (
+	input: GenerateInput,
+): Promise<{lines: number}> => {
+	const eventsDir = path.join(input.stateRoot, '.epiq', 'events');
+	fs.mkdirSync(eventsDir, {recursive: true});
+
+	// One open handle per actor: a million appends through writeFileSync would
+	// be a million opens.
+	const streams = input.actors.map(actor => ({
+		actor,
+		out: fs.createWriteStream(
+			path.join(eventsDir, `${actor.userId}.${actor.userName}.jsonl`),
+			{flags: 'a'},
+		),
+		buffer: [] as string[],
+	}));
+
+	const shape = (input.shape ?? SHAPE) as readonly (typeof SHAPE)[number][];
+
+	const start = Date.now() - input.years * YEAR_MS;
+	const step = Math.max(1, Math.floor((input.years * YEAR_MS) / input.events));
+
+	// The tail of the causal order, which is what an actor refs when it has
+	// synced. Advanced globally rather than per actor so the forest is mostly a
+	// chain, the way a team that syncs often really looks.
+	let edge: string | null = null;
+
+	// A minority of events ref an older edge instead: concurrent work, which is
+	// what makes getSortedEvents do more than walk a list.
+	let staleEdge: string | null = null;
+
+	// Issues are referred to long after they are made, so keep a pool rather
+	// than only ever touching the newest.
+	const issues: string[] = [];
+
+	let written = 0;
+
+	// Checked against the schema the product parses with, not against what this
+	// file believes. A payload missing a field materializes anyway — nothing
+	// validates one on load — and surfaces far later as a crash somewhere else
+	// entirely: a comment with no author took the GUI down inside colour
+	// generation, long after the mistake was written.
+	//
+	// Once per distinct action: the schema is the same for every event of a
+	// kind, and a million parses would cost more than the generation.
+	const validated = new Set<string>();
+
+	const validate = (action: string, payload: Record<string, unknown>) => {
+		if (validated.has(action)) return;
+		validated.add(action);
+
+		const result = parseEventPayload(action as EventAction, payload);
+
+		if (isFail(result)) {
+			throw new Error(`generated an invalid ${action}: ${result.message}`);
+		}
+	};
+
+	const emit = (
+		action: string,
+		payload: Record<string, unknown>,
+		at: number,
+	) => {
+		const stream = streams[written % streams.length]!;
+		const id = ulid(at);
+
+		validate(action, payload);
+
+		stream.buffer.push(
+			JSON.stringify({[action]: payload, v: 1, id: [id, edge]}),
+		);
+
+		staleEdge = edge;
+		edge = id;
+		written++;
+	};
+
+	// The log makes what it later refers to. Borrowing the seed project's ids
+	// left every tagging and every assignment skipped on replay — a third of the
+	// events silently not becoming board state, which measures a smaller board
+	// and calls it a pass.
+	//
+	// Strictly before the first event that uses them, so no reordering of
+	// concurrent branches can put a tagging ahead of its tag.
+	const preambleCount = input.actors.length + input.tagNames.length;
+	let preambleAt = start - preambleCount;
+
+	const tagIds = input.tagNames.map((_, index) =>
+		ulid(start - input.tagNames.length + index),
+	);
+
+	for (const actor of input.actors) {
+		emit(
+			'create.contributor',
+			{id: actor.userId, name: actor.userName},
+			preambleAt++,
+		);
+	}
+
+	input.tagNames.forEach((name, index) => {
+		emit('create.tag', {id: tagIds[index]!, name}, preambleAt++);
+	});
+
+	for (let i = 0; i < input.events; i++) {
+		const stream = streams[i % streams.length]!;
+		const action = shape[i % shape.length]!;
+
+		// Climbing, and never behind the parent it points at — the same rule
+		// persist() enforces when it seeds from the edge.
+		const id = ulid(start + i * step);
+
+		// Some events ref an older edge: concurrent work, which is what makes
+		// getSortedEvents do more than walk a list. Never the first, though —
+		// branching off the preamble makes this event a sibling of the last
+		// create.tag, and siblings sort by ULID, so its whole subtree would be
+		// walked before the tags it goes on to use exist.
+		const refId = i > 0 && i % 17 === 0 && staleEdge ? staleEdge : edge;
+
+		const issueId =
+			action === 'add.issue'
+				? ulid(start + i * step)
+				: issues[i % Math.max(1, issues.length)] ?? ulid(start + i * step);
+
+		if (action === 'add.issue') issues.push(issueId);
+
+		const payload = buildPayload(action, {
+			id: issueId,
+			laneId: input.laneIds[i % input.laneIds.length]!,
+			tagId: tagIds[i % tagIds.length]!,
+			actorId: stream.actor.userId,
+			n: i,
+		});
+
+		validate(action, payload);
+
+		stream.buffer.push(
+			JSON.stringify({[action]: payload, v: 1, id: [id, refId]}),
+		);
+
+		if (stream.buffer.length >= 4096) {
+			stream.out.write(stream.buffer.join('\n') + '\n');
+			stream.buffer.length = 0;
+		}
+
+		staleEdge = edge;
+		edge = id;
+		written++;
+	}
+
+	// Awaited, not merely ended: `end()` returns before the bytes reach the
+	// disk, and reading the log a moment later then finds a file that is empty
+	// or half written — which measures an empty board and calls it a pass.
+	await Promise.all(
+		streams.map(
+			stream =>
+				new Promise<void>((resolve, reject) => {
+					stream.out.once('finish', resolve);
+					stream.out.once('error', reject);
+
+					if (stream.buffer.length > 0) {
+						stream.out.write(stream.buffer.join('\n') + '\n');
+					}
+
+					stream.out.end();
+				}),
+		),
+	);
+
+	return {lines: written};
+};
+
+const buildPayload = (
+	action: (typeof SHAPE)[number],
+	at: {id: string; laneId: string; tagId: string; actorId: string; n: number},
+): Record<string, unknown> => {
+	switch (action) {
+		case 'add.issue':
+			return {
+				id: at.id,
+				name: `Ticket ${at.n}: something a person actually wrote down`,
+				parent: at.laneId,
+				rank: RANKS[at.n % RANKS.length],
+			};
+		case 'add.issue.tag':
+			return {id: at.id, tag: at.tagId};
+		case 'add.issue.comment':
+			return {
+				id: ulid(),
+				issue: at.id,
+				// Required. Without it the event still materializes — nothing
+				// validates a payload on load — and then takes the GUI down on the
+				// first read, with a stack trace pointing at colour generation.
+				author: at.actorId,
+				md: `Had a look at this — the part to watch is the ${
+					at.n % 7 === 0 ? 'window derivation' : 'ordering'
+				}.`,
+			};
+		case 'move.node':
+			return {
+				id: at.id,
+				parent: at.laneId,
+				rank: RANKS[at.n % RANKS.length],
+			};
+		case 'edit.title':
+			return {id: at.id, name: `Ticket ${at.n}, renamed`};
+		case 'edit.description':
+			return {
+				id: at.id,
+				md: `Longer body for ticket ${at.n}.\n\nSecond paragraph.`,
+			};
+		case 'add.issue.assignee':
+			return {id: at.id, assignee: at.actorId};
+	}
+};

--- a/source/test/stress/run.ts
+++ b/source/test/stress/run.ts
@@ -1,0 +1,298 @@
+// Ten years of a twenty-person board, replayed through the real loader and the
+// real materializer, then served so it can be used rather than only measured.
+//
+// Opt-in. Nothing runs this but `npm run stress`, and nothing depends on it.
+//
+//   npm run stress                      # in a container, the default
+//   npx tsx source/test/stress/run.ts  # on this machine, if you insist
+//
+// Env: STRESS_EVENTS, STRESS_ACTORS, STRESS_YEARS, STRESS_SERVE, STRESS_DIR.
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {execSync} from 'node:child_process';
+import {generateLog} from './generate-log.js';
+
+// Empty is unset, not zero: the container passes every variable through
+// whether or not it was given one, so `?? fallback` sees '' and Number('') is
+// 0 — which ran the whole thing over an empty board and reported it happily.
+const number = (name: string, fallback: number) => {
+	const raw = process.env[name];
+	const parsed = raw ? Number(raw) : Number.NaN;
+
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+// Twenty people for ten years, at the ~400 events per person-month this board
+// has actually seen.
+const ACTORS = number('STRESS_ACTORS', 20);
+const YEARS = number('STRESS_YEARS', 10);
+const EVENTS = number('STRESS_EVENTS', ACTORS * YEARS * 12 * 400);
+const SERVE = process.env['STRESS_SERVE'] !== 'false';
+
+const ROOT =
+	process.env['STRESS_DIR'] ??
+	fs.mkdtempSync(path.join(os.tmpdir(), 'epiq-stress-'));
+
+// The checkout, remembered before anything changes directory into the scratch
+// project: the GUI server resolves its assets against the working directory,
+// so serving from inside the project would look for dist/gui in there.
+const CHECKOUT = process.cwd();
+
+const REPO = path.join(ROOT, 'repo');
+const GLOBAL = path.join(ROOT, 'global');
+
+const mb = (bytes: number) => `${(bytes / 1024 / 1024).toFixed(0)} MB`;
+const secs = (ms: number) => `${(ms / 1000).toFixed(2)} s`;
+
+const step = async <T>(label: string, fn: () => T | Promise<T>): Promise<T> => {
+	const t0 = performance.now();
+	const value = await fn();
+	const took = performance.now() - t0;
+	const heap = process.memoryUsage();
+
+	console.log(
+		`  ${label.padEnd(38)} ${secs(took).padStart(9)}   ` +
+			`heap ${mb(heap.heapUsed).padStart(7)}   rss ${mb(heap.rss).padStart(7)}`,
+	);
+
+	return value;
+};
+
+console.log(
+	`\n  ${EVENTS.toLocaleString()} events — ${ACTORS} people, ${YEARS} years`,
+);
+
+fs.rmSync(REPO, {recursive: true, force: true});
+fs.mkdirSync(REPO, {recursive: true});
+fs.mkdirSync(GLOBAL, {recursive: true});
+
+process.env['EPIQ_GLOBAL_DIR'] = GLOBAL;
+process.env['IS_LOCAL'] = 'true';
+
+fs.writeFileSync(
+	path.join(GLOBAL, 'config.json'),
+	JSON.stringify({
+		logLevel: 'error',
+		userId: 'u-000',
+		userName: 'person000',
+		preferredEditor: 'vim',
+		autoSync: false,
+	}),
+);
+
+const git = (args: string) =>
+	execSync(`git ${args}`, {cwd: REPO, stdio: 'ignore'});
+
+git('init -b main');
+git('config user.email stress@example.com');
+git('config user.name Stress');
+fs.writeFileSync(path.join(REPO, 'readme.md'), '# stress\n');
+git('add -A');
+git('commit -m "stress"');
+
+process.chdir(REPO);
+
+// commands.ts first: the init command sits in an import cycle with it.
+await import('../../lib/command-line/commands.js');
+const {createDefaultEvents} = await import('../../lib/event/event-boot.js');
+const {materializeAll, partitionMaterializeResults} = await import(
+	'../../lib/event/event-materialize.js'
+);
+const {patchSettingsState} = await import('../../lib/state/settings.state.js');
+const {initCommand} = await import(
+	'../../lib/command-line/commands/init.cmd.js'
+);
+
+patchSettingsState({
+	userId: 'u-000',
+	userName: 'person000',
+	preferredEditor: 'vim',
+	autoSync: false,
+});
+
+const defaults = createDefaultEvents({userId: 'u-000', userName: 'person000'});
+if (defaults.status === 'fail') throw new Error(defaults.message);
+materializeAll(defaults.value ?? []);
+
+const init = await initCommand();
+if (init.status === 'fail') throw new Error(`init: ${init.message}`);
+
+// What the GUI and the MCP server both do before replaying anything: nothing
+// they send reads a ticket's virtual fields, and building them is most of the
+// cost of a replay. Left on, this measures a path neither of them takes — the
+// TUI's. STRESS_VIRTUAL=on measures that one instead.
+const {setVirtualNodesEnabled} = await import(
+	'../../lib/virtual-nodes/virtual-nodes.js'
+);
+
+const VIRTUAL = process.env['STRESS_VIRTUAL'] === 'on';
+setVirtualNodesEnabled(VIRTUAL);
+
+const api = await import('../../mcp/epiq-api.js');
+const {getStateBranchRoot} = await import('../../git/git-storage.js');
+
+const ok = <T>(result: {status: string; message: string; value?: T}): T => {
+	if (result.status === 'fail') throw new Error(result.message);
+	return result.value as T;
+};
+
+// A real board, real lanes and real tags, so the generated events hang off
+// nodes that exist rather than ids nothing resolves.
+const boards = ok(await api.listBoards({repoRoot: REPO})) as {id: string}[];
+const boardId = boards[0]!.id;
+
+for (const title of ['Review', 'Blocked']) {
+	ok(await api.createSwimlane({repoRoot: REPO, title, boardId}));
+}
+
+const lanes = ok(await api.listSwimlanes({repoRoot: REPO})) as {id: string}[];
+
+const stateRoot = ok(getStateBranchRoot({repoRoot: REPO}));
+if (!stateRoot) throw new Error('no state branch root');
+
+console.log(
+	`  virtual nodes ${
+		VIRTUAL ? 'on  (the TUI\u2019s replay)' : 'off (what the GUI and MCP do)'
+	}\n`,
+);
+
+await step('generate the log', () =>
+	generateLog({
+		stateRoot,
+		boardId,
+		laneIds: lanes.map(lane => lane.id),
+		actors: Array.from({length: ACTORS}, (_, i) => ({
+			userId: `u-${String(i).padStart(3, '0')}`,
+			userName: `person${String(i).padStart(3, '0')}`,
+		})),
+		events: EVENTS,
+		years: YEARS,
+		tagNames: ['gui', 'bug', 'feature', 'sync', 'crdt', 'testing'],
+		// STRESS_SHAPE=add.issue,move.node narrows the log to those actions, which
+		// is how a slow handler is found: time one kind at two sizes.
+		shape: process.env['STRESS_SHAPE']?.split(','),
+	}),
+);
+
+const eventsDir = path.join(stateRoot, '.epiq', 'events');
+const onDisk = fs
+	.readdirSync(eventsDir)
+	.filter(file => file.endsWith('.jsonl'))
+	.reduce((sum, file) => sum + fs.statSync(path.join(eventsDir, file)).size, 0);
+
+console.log(`  ${'log on disk'.padEnd(38)} ${mb(onDisk).padStart(9)}\n`);
+
+const {loadMergedEvents} = await import('../../lib/event/event-load.js');
+const {getEventTimeline} = await import('../../mcp/epiq-time-travel.js');
+
+const loaded = await step('load, parse and order the log', () => {
+	const result = loadMergedEvents(stateRoot);
+	if (result.status === 'fail' || !result.value) {
+		throw new Error(result.message);
+	}
+	return result.value;
+});
+
+console.log(
+	`  ${'events loaded'.padEnd(38)} ${loaded.length
+		.toLocaleString()
+		.padStart(9)}`,
+);
+
+const materialized = await step('replay it (materializeAll)', () =>
+	materializeAll(loaded),
+);
+
+// The number that decides whether any of this counts. An event the replay
+// skipped never became board state, so a run that reports a fast timeline over
+// a log it could not apply has measured nothing.
+const {fatal, skipped} = partitionMaterializeResults(materialized ?? []);
+
+console.log(
+	`  ${'events skipped on replay'.padEnd(38)} ${String(skipped.length).padStart(
+		9,
+	)}` + (skipped.length > 0 ? '   <-- these never became board state' : ''),
+);
+console.log(
+	`  ${'events fatal on replay'.padEnd(38)} ${String(fatal.length).padStart(
+		9,
+	)}` + (fatal.length > 0 ? '   <-- the log is not valid' : ''),
+);
+
+if (fatal.length > 0) {
+	console.log(`\n  first fatal: ${fatal[0]?.message}\n`);
+}
+
+// Grouped, because "600 skipped" says something is wrong and nothing about
+// what: a skip is a precondition the log did not meet, and they come in kinds.
+const reasons = new Map<string, number>();
+
+for (const failure of [...skipped, ...fatal]) {
+	const kind = (failure.message ?? '')
+		.replace(/[0-9A-HJKMNP-TV-Z]{26}/g, '<id>')
+		.slice(0, 70);
+
+	reasons.set(kind, (reasons.get(kind) ?? 0) + 1);
+}
+
+for (const [reason, count] of [...reasons].sort((a, b) => b[1] - a[1])) {
+	console.log(`      ${String(count).padStart(7)}  ${reason}`);
+}
+
+console.log('');
+
+// Cold: the index does not exist yet, so this pays for the whole derivation.
+const cold = await step('timeline, cold (builds the index)', () =>
+	getEventTimeline({repoRoot: REPO, boardId}),
+);
+
+if (cold.status === 'fail' || !cold.value) throw new Error(cold.message);
+
+console.log(
+	`  ${'events in the window'.padEnd(38)} ` +
+		`${cold.value.events.length.toLocaleString().padStart(9)}` +
+		(cold.value.events.length === 0 ? '   <-- past the 20k payload cap' : ''),
+);
+
+// Warm: what a drag of the needle actually costs, which is the thing under
+// test. Ten of them, since one is too small to read.
+const t0 = performance.now();
+for (let i = 0; i < 10; i++) {
+	const end = Date.now() - i * 24 * 60 * 60 * 1000;
+	await getEventTimeline({
+		repoRoot: REPO,
+		boardId,
+		start: end - 30 * 24 * 60 * 60 * 1000,
+		end,
+	});
+}
+const perRequest = (performance.now() - t0) / 10;
+
+console.log(
+	`  ${'timeline, warm (per request)'.padEnd(38)} ` +
+		`${perRequest.toFixed(1).padStart(6)} ms`,
+);
+
+console.log(
+	`\n  peak rss ${mb(process.memoryUsage().rss)}   ` + `project at ${REPO}\n`,
+);
+
+if (!SERVE) process.exit(0);
+
+// Back to the checkout before the import, not after: the server resolves its
+// asset root once, in a top-level const, as the module is evaluated. Changing
+// directory afterwards leaves it looking for dist/gui inside the scratch
+// project, where it answers every request with a 404.
+process.chdir(CHECKOUT);
+
+const {startGuiServer} = await import('../../gui/api/api-server.js');
+
+// Binds 127.0.0.1 by design; `npm run stress` forwards it out of the
+// container rather than the server learning about containers.
+const served = await startGuiServer({repoRoot: REPO, boardId: ''});
+if (served.status === 'fail' || !served.value) throw new Error(served.message);
+
+const address = served.value.server.address() as {port: number};
+console.log(`  the board, at this size:  http://127.0.0.1:${address.port}\n`);

--- a/source/test/stress/run.ts
+++ b/source/test/stress/run.ts
@@ -158,10 +158,9 @@ console.log(
 	}\n`,
 );
 
-await step('generate the log', () =>
+const generated = await step('generate the log', () =>
 	generateLog({
 		stateRoot,
-		boardId,
 		laneIds: lanes.map(lane => lane.id),
 		actors: Array.from({length: ACTORS}, (_, i) => ({
 			userId: `u-${String(i).padStart(3, '0')}`,
@@ -173,6 +172,7 @@ await step('generate the log', () =>
 		// STRESS_SHAPE=add.issue,move.node narrows the log to those actions, which
 		// is how a slow handler is found: time one kind at two sizes.
 		shape: process.env['STRESS_SHAPE']?.split(','),
+		openTickets: Number(process.env['STRESS_OPEN'] ?? '') || undefined,
 	}),
 );
 
@@ -182,7 +182,11 @@ const onDisk = fs
 	.filter(file => file.endsWith('.jsonl'))
 	.reduce((sum, file) => sum + fs.statSync(path.join(eventsDir, file)).size, 0);
 
-console.log(`  ${'log on disk'.padEnd(38)} ${mb(onDisk).padStart(9)}\n`);
+console.log(`  ${'log on disk'.padEnd(38)} ${mb(onDisk).padStart(9)}`);
+console.log(
+	`  ${'tickets closed / left open'.padEnd(38)} ` +
+		`${generated.closed.toLocaleString()} / ${generated.open.toLocaleString()}\n`,
+);
 
 const {loadMergedEvents} = await import('../../lib/event/event-load.js');
 const {getEventTimeline} = await import('../../mcp/epiq-time-travel.js');


### PR DESCRIPTION
An opt-in stress test that builds a twenty-person, ten-year board and serves it — and the five defects it found, none of which the existing suites could see, because they only appear at a size no fixture had.

## The harness

`npm run stress` generates a valid event log the size a team reaches (~960,000 events, 169 MB), replays it through the real loader and materializer, and serves the GUI on it, in a container. Opt-in and in no pipeline: it takes minutes and wants gigabytes.

It writes **a board being worked**, not a board being filled — tickets are filed into the first lane, walked along the lanes, and closed, so the open board stays the size a real one is (250) and the decade accumulates on the closed board (95,750). Every payload is checked against the schema the product parses with: a log that looks plausible and fails to apply is worse than no test, because it looks like it passed.

## What it found

| ref | defect | before | after |
| --- | --- | --- | --- |
| `JWB5G08` | every node and comment write rebuilt its whole map — replay was O(N²) | 96 s at 40k, ~15 h extrapolated | 1.9 s at 960k |
| `EA8A36B` | a comment with no author crashed the GUI, on data the schema is written to accept | server exits | falls back |
| `832GVFH` | the board shipped every ticket ever closed, with every comment body — and asked for comments once per issue, O(issues × comments) | 88.7 MB | 8.8 MB |
| `KKK5ZR4` | every board-state read re-read and re-replayed the whole log | 8–20 s per request | 0.75 s |
| `REE7VPK` | the GUI port was fixed, so nothing forwarding to it could satisfy the websocket origin guard | — | settable |

`JWB5G08` is **not** the quadratic `materializeAll` already guards against: deferring the derive stopped the child index being rebuilt per event, and this sat underneath it, untouched by that.

## On the state change

`setStateEntry` writes one entry in place while a replay batch is open, and copies outside one — a reader holding the previous state must not see it change. In place is safe because nothing reads derived state mid-batch, which is the invariant `withDeferredDerive` already establishes. `replay-equivalence` is the test that matters and passes: a batched replay lands where a per-event replay does.

## Gate

1150 unit, 127 browser, 17 TUI e2e (container), 15 collaboration (container). The collaboration suite is the one that exercises several actors converging against the state layer.

## Not done

- Paging back into the closed board. The year window makes it boot; it does not let a reader dig.
- A local write still grows the log, so the next request after an edit pays a full reload. Reads are what `KKK5ZR4` fixes.
- `8CYH2TC`: past 20,000 events the log still shows commits only.