### PR TITLE
RW176VY Make writes cheap: the edge, and the parent's children

### DIFF
--- a/source/lib/event/event-load.ts
+++ b/source/lib/event/event-load.ts
@@ -5,6 +5,7 @@ import {z} from 'zod';
 import {logger} from '../../logger.js';
 import {failed, isFail, Result, succeeded} from '../model/result-types.js';
 import {getEventsDirPath} from '../storage/paths.js';
+import {logSignature} from './log-signature.js';
 import {toEffectiveUlidTimes} from './date-utils.js';
 import {AppEvent, AppEventMap, isKnownEventAction} from './event.model.js';
 import {
@@ -344,6 +345,11 @@ function loadAllPersistedEvents(
 ): Result<ReconstructedEvent[]> {
 	const dir = getEventsDirPath(eventsRoot);
 
+	// Before the read, never after: a line landing in the gap would otherwise be
+	// remembered under a signature that already accounts for it, and the edge
+	// would stay wrong until something else moved.
+	const signature = logSignature(eventsRoot);
+
 	if (!fs.existsSync(dir)) {
 		return succeeded('No events found', []);
 	}
@@ -365,7 +371,17 @@ function loadAllPersistedEvents(
 		entries.push(...result.value);
 	}
 
-	return succeeded('All events loaded', getSortedEvents(entries));
+	const sorted = getSortedEvents(entries);
+
+	// The causal order's tail, which is what the next write points at. Recorded
+	// here because this is the one place that has just paid for it.
+	edgeCache = {
+		root: eventsRoot,
+		signature,
+		edge: sorted.at(-1)?.id?.[0] ?? null,
+	};
+
+	return succeeded('All events loaded', sorted);
 }
 
 // What the last full load found. Held here rather than in `AppState` because
@@ -452,7 +468,29 @@ export function loadMergedEventsBefore(
 	});
 }
 
+// The tail of the causal order, which every write has to point at.
+//
+// Held rather than re-derived. Reading it meant reading every line the board
+// has ever held and rebuilding the whole forest, to take one id off the end:
+// on a two-hundred-thousand-event board that was four seconds to file a single
+// ticket. `EdgeCursor` already avoids it within a batch, for the same reason;
+// a lone write had nothing to belong to.
+let edgeCache: {root: string; signature: string; edge: string | null} | null =
+	null;
+
 export function getEdgeRef(rootDir = process.cwd()): Result<string | null> {
+	const signature = logSignature(rootDir);
+
+	if (
+		edgeCache &&
+		edgeCache.root === rootDir &&
+		edgeCache.signature === signature
+	) {
+		return succeeded('Loaded edge reference, unchanged', edgeCache.edge);
+	}
+
+	// Populates the cache on its way through, so a boot pays for this once and
+	// the writes after it do not pay at all.
 	const persisted = loadAllPersistedEvents(rootDir);
 	if (isFail(persisted)) {
 		return failed(persisted.message);
@@ -462,6 +500,71 @@ export function getEdgeRef(rootDir = process.cwd()): Result<string | null> {
 		'Loaded edge reference',
 		persisted.value.at(-1)?.id?.[0] ?? null,
 	);
+}
+
+/**
+ * Moves the edge on after this actor wrote `id` to `fileName`, without reading
+ * the log to confirm it.
+ *
+ * Safe only because of what the id is: a child of the edge it was minted
+ * against, and the deepest node in the forest, so the walk that derives the
+ * order ends on it.
+ *
+ * Any other file moving means someone else's events arrived, and the tail is
+ * then theirs to decide — so the cache is dropped rather than advanced, and the
+ * next read derives it properly. That is the case this has to get right; a
+ * board with one writer would not need the check at all.
+ */
+export function advanceEdgeRef(
+	rootDir: string,
+	fileName: string,
+	id: string,
+): void {
+	if (!edgeCache || edgeCache.root !== rootDir) return;
+
+	const before = new Map(
+		edgeCache.signature.split('|').map(part => {
+			const at = part.indexOf(':');
+			return [part.slice(0, at), part.slice(at + 1)] as const;
+		}),
+	);
+
+	const after = new Map(
+		logSignature(rootDir)
+			.split('|')
+			.map(part => {
+				const at = part.indexOf(':');
+				return [part.slice(0, at), part.slice(at + 1)] as const;
+			}),
+	);
+
+	for (const [file, entry] of after) {
+		if (file === fileName) continue;
+		if (before.get(file) !== entry) {
+			edgeCache = null;
+			return;
+		}
+	}
+
+	// A file that was there and is gone is someone else's change too.
+	for (const file of before.keys()) {
+		if (file !== fileName && !after.has(file)) {
+			edgeCache = null;
+			return;
+		}
+	}
+
+	edgeCache = {
+		root: rootDir,
+		signature: [...after].map(([file, entry]) => `${file}:${entry}`).join('|'),
+		edge: id,
+	};
+}
+
+// The tests drive the log through mocks, so they need the edge gone between
+// cases; a signature is no help where the files never existed.
+export function clearEdgeCache(): void {
+	edgeCache = null;
 }
 /**
  * Total, so the order is a function of the event *set* alone.

--- a/source/lib/event/event-persist.ts
+++ b/source/lib/event/event-persist.ts
@@ -9,7 +9,7 @@ import {getSettingsState, User} from '../state/settings.state.js';
 import {ensureEventsDir, getEventsDirPath} from '../storage/paths.js';
 import {sanitizeFilePart} from '../utils/file-part.js';
 import {MAX_ULID_AHEAD_MS} from './date-utils.js';
-import {getEdgeRef} from './event-load.js';
+import {advanceEdgeRef, getEdgeRef} from './event-load.js';
 import {
 	AppEvent,
 	AppEventMap,
@@ -255,6 +255,12 @@ export function persist({
 		// Advanced only after the line is on disk, so a failed persist leaves
 		// the cursor pointing at an event that exists.
 		if (edge) edge.current = newId;
+
+		// And the same for the next lone write, which would otherwise read the
+		// whole log again to learn what this one just decided. Dropped rather
+		// than advanced if another actor's file moved meanwhile — the tail is
+		// then theirs to decide.
+		advanceEdgeRef(rootDir, path.basename(filePath.value), newId);
 
 		return succeeded<PersistSuccess>('Event persisted', {
 			path: filePath.value,

--- a/source/lib/repository/children.ts
+++ b/source/lib/repository/children.ts
@@ -1,0 +1,75 @@
+// What "a node's children" means, said once.
+//
+// Two callers need it and used to say it separately: the state's derivation
+// groups every node by parent so a board can be drawn, and rank resolution asks
+// for one parent's children so a new ticket can be placed after them. Two
+// spellings of one rule is two things to keep in step, and the rule is the part
+// that must not drift — a board ordered one way and a rank resolved against
+// another is a ticket that lands in the wrong place.
+//
+// They still run differently, and for a reason: a replay batch holds the
+// derivation back deliberately, so inside one there is no current index to read
+// and the scan is the only correct answer. What is shared is what the answer
+// means, not how it is reached.
+
+import {isTicketNode, type AnyContext} from '../model/context.model.js';
+import type {Filter} from '../model/app-state.model.js';
+import type {NavNode} from '../model/navigation-node.model.js';
+import {ticketMatchesFilter} from '../utils/filter.js';
+
+// Lexicographic, which is what a rank is built to be compared as.
+export const byRank = (
+	left: NavNode<AnyContext>,
+	right: NavNode<AnyContext>,
+): number => left.rank.localeCompare(right.rank);
+
+// A deleted node is not a child: it keeps its id and its parent forever —
+// tombstoned, never removed — so every reader has to skip it rather than
+// expect it gone.
+const isChildOf = (
+	node: NavNode<AnyContext> | undefined,
+	parentId: string,
+): node is NavNode<AnyContext> =>
+	!!node && !node.isDeleted && node.parentNodeId === parentId;
+
+export const orderChildrenOf = (
+	nodes: Record<string, NavNode<AnyContext>>,
+	parentId: string,
+): NavNode<AnyContext>[] =>
+	Object.values(nodes)
+		.filter((node): node is NavNode<AnyContext> => isChildOf(node, parentId))
+		.sort(byRank);
+
+// Every parent's children at once, which is what a whole board needs.
+//
+// `filters` narrows tickets only: a swimlane is not a thing a filter hides, and
+// dropping one would take its children off the board with it.
+export const groupChildrenByParent = (
+	nodes: Record<string, NavNode<AnyContext>>,
+	filters: Filter[],
+): Record<string, NavNode<AnyContext>[]> => {
+	const index: Record<string, NavNode<AnyContext>[]> = {};
+
+	for (const node of Object.values(nodes)) {
+		if (
+			isTicketNode(node) &&
+			filters.length > 0 &&
+			!filters.every(filter => ticketMatchesFilter(node, filter))
+		) {
+			continue;
+		}
+
+		if (!node.parentNodeId || node.isDeleted) continue;
+
+		const siblings = index[node.parentNodeId];
+
+		if (siblings) siblings.push(node);
+		else index[node.parentNodeId] = [node];
+	}
+
+	for (const parentId of Object.keys(index)) {
+		index[parentId]!.sort(byRank);
+	}
+
+	return index;
+};

--- a/source/lib/repository/rank.ts
+++ b/source/lib/repository/rank.ts
@@ -4,7 +4,8 @@ import {MovePosition} from '../event/event.model.js';
 import {AnyContext} from '../model/context.model.js';
 import {NavNode} from '../model/navigation-node.model.js';
 import {failed, isFail, Result, succeeded} from '../model/result-types.js';
-import {getState} from '../state/state.js';
+import {getState, isDeferringDerive} from '../state/state.js';
+import {orderChildrenOf} from './children.js';
 import {rankBetween} from '../utils/rank.js';
 
 export type ResolveRankResult = {
@@ -88,13 +89,29 @@ export const resolveMoveRank = (
 	}
 };
 
-export const getOrderedChildren = (parentId: string) =>
-	Object.values(getState().nodes)
-		.filter(
-			(node): node is NavNode<AnyContext> =>
-				!!node && !node.isDeleted && node.parentNodeId === parentId,
-		)
-		.sort((a, b) => a.rank.localeCompare(b.rank));
+// A parent's children, in rank order.
+//
+// `derive` has already grouped every node by parent, and with no filter applied
+// its index skips exactly what this skips — deleted nodes — in exactly this
+// order. So where that index is current, it *is* the answer, and scanning the
+// board again to rebuild one lane's worth of it is the cost of a write on a
+// large board: filing a ticket resolves its rank this way, and on ninety-six
+// thousand nodes that was 2.5 of the 3.4 seconds it took.
+//
+// Not while a replay batch is open, when the derived half of the state is by
+// design out of date, and not while a filter is on, when the index is a subset
+// of the children rather than all of them. Both fall back to the scan, which is
+// always right and only ever slow.
+export const getOrderedChildren = (parentId: string) => {
+	const state = getState();
+
+	if (!isDeferringDerive() && state.filters.length === 0) {
+		const indexed = state.renderedChildrenIndex[parentId];
+		if (indexed) return indexed;
+	}
+
+	return orderChildrenOf(state.nodes, parentId);
+};
 
 export const getSiblingIndex = (
 	siblings: NavNode<AnyContext>[],

--- a/source/lib/state/state.ts
+++ b/source/lib/state/state.ts
@@ -5,16 +5,12 @@ import {inputActions} from '../actions/input/input-actions.js';
 import {Hints} from '../hints/hints.js';
 import {readProjectFile} from '../project-setup/project-setup.js';
 import {Mode} from '../model/action-map.model.js';
-import type {AppState, Filter} from '../model/app-state.model.js';
-import {
-	isTicketNode,
-	type AnyContext,
-	type Workspace,
-} from '../model/context.model.js';
+import type {AppState} from '../model/app-state.model.js';
+import {type AnyContext, type Workspace} from '../model/context.model.js';
 import type {NavNode} from '../model/navigation-node.model.js';
 import {failed, isFail, Result, succeeded} from '../model/result-types.js';
 import {resolveClosestEpiqProjectRoot} from '../storage/paths.js';
-import {ticketMatchesFilter} from '../utils/filter.js';
+import {groupChildrenByParent} from '../repository/children.js';
 import {buildBreadCrumb} from '../utils/nav-tree.js';
 import {buildActionIndex} from './action-helper.js';
 
@@ -240,6 +236,10 @@ export function withDeferredDerive<T>(fn: () => T): Result<T> {
 	}
 }
 
+// Whether a replay batch is open, and the derived half of the state therefore
+// stale. A reader that would otherwise trust a derived index has to know.
+export const isDeferringDerive = (): boolean => deferring;
+
 export const patchState = (patch: Partial<BaseState>) =>
 	updateState(old => ({...old, ...patch}));
 
@@ -308,40 +308,7 @@ export const isChildSelected = (
 export const useAppState = () =>
 	useSyncExternalStore(subscribe, getState, getState);
 
-const buildChildIndex = (
-	nodes: Record<string, NavNode<AnyContext>>,
-	filters: Filter[],
-) => {
-	const index: Record<string, NavNode<AnyContext>[]> = {};
-
-	for (const node of Object.values(nodes)) {
-		if (
-			isTicketNode(node) &&
-			filters.length > 0 &&
-			!filters.every(filter => ticketMatchesFilter(node, filter))
-		)
-			continue;
-
-		if (!node.parentNodeId || node.isDeleted) continue;
-
-		if (!node.parentNodeId || !index[node.parentNodeId]) {
-			index[node.parentNodeId] = [];
-		}
-
-		index[node.parentNodeId]!.push(node);
-	}
-
-	for (const parentId of Object.keys(index)) {
-		index[parentId]!.sort((a, b) => {
-			const left = nodes[a.id];
-			const right = nodes[b.id];
-			if (!left || !right) return 0;
-			return left.rank.localeCompare(right.rank);
-		});
-	}
-
-	return index;
-};
+const buildChildIndex = groupChildrenByParent;
 
 export const getRenderedChildren = (id: string): NavNode<AnyContext>[] => {
 	return getState()?.renderedChildrenIndex[id] ?? [];

--- a/source/test/edge-cache.test.ts
+++ b/source/test/edge-cache.test.ts
@@ -1,0 +1,170 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {ulid} from 'ulid';
+
+import {
+	advanceEdgeRef,
+	clearEdgeCache,
+	getEdgeRef,
+} from '../lib/event/event-load.js';
+
+// A real directory, because what the cache watches is the log's own files and a
+// mocked filesystem would prove nothing about a teammate's arriving in it.
+let root = '';
+const eventsDir = () => path.join(root, '.epiq', 'events');
+
+const fileFor = (actor: string) => `${actor}.person.jsonl`;
+
+const line = (id: string, refId: string | null) =>
+	`${JSON.stringify({
+		'add.issue': {id: ulid(), name: 'x', parent: 'lane', rank: 'aQ'},
+		v: 1,
+		id: [id, refId],
+	})}\n`;
+
+// A chain in one actor's file, returning the last id — the causal tail.
+const writeChain = (actor: string, count: number, from: number): string => {
+	let previous: string | null = null;
+	let text = '';
+
+	for (let i = 0; i < count; i++) {
+		const id = ulid(from + i);
+		text += line(id, previous);
+		previous = id;
+	}
+
+	fs.writeFileSync(path.join(eventsDir(), fileFor(actor)), text);
+
+	return previous!;
+};
+
+const baseTime = 1_700_000_000_000;
+
+describe('the causal edge', () => {
+	beforeEach(() => {
+		clearEdgeCache();
+		root = fs.mkdtempSync(path.join(os.tmpdir(), 'epiq-edge-'));
+		fs.mkdirSync(eventsDir(), {recursive: true});
+	});
+
+	afterEach(() => {
+		fs.rmSync(root, {recursive: true, force: true});
+	});
+
+	it('is the tail of the order', () => {
+		const tail = writeChain('u-1', 4, baseTime);
+
+		expect(getEdgeRef(root).value).toBe(tail);
+	});
+
+	it('is null for a log with nothing in it', () => {
+		expect(getEdgeRef(root).value).toBeNull();
+	});
+
+	// The point of the whole thing: reading it meant reading every line the
+	// board has ever held, on every write.
+	it('is not re-derived while the log has not moved', () => {
+		const tail = writeChain('u-1', 4, baseTime);
+		expect(getEdgeRef(root).value).toBe(tail);
+
+		// The files say something else now, but their size and mtime do not — so
+		// a cache that re-read would notice and one that trusts the signature
+		// will not. Which is what proves it did not read.
+		fs.writeFileSync(
+			path.join(eventsDir(), fileFor('u-1')),
+			fs.readFileSync(path.join(eventsDir(), fileFor('u-1')), 'utf8'),
+		);
+		const stat = fs.statSync(path.join(eventsDir(), fileFor('u-1')));
+		fs.utimesSync(
+			path.join(eventsDir(), fileFor('u-1')),
+			stat.atime,
+			stat.mtime,
+		);
+
+		expect(getEdgeRef(root).value).toBe(tail);
+	});
+
+	describe('after this actor writes', () => {
+		it('moves on to what was written, without reading the log', () => {
+			writeChain('u-1', 4, baseTime);
+			getEdgeRef(root);
+
+			const mine = ulid(baseTime + 100);
+			fs.appendFileSync(
+				path.join(eventsDir(), fileFor('u-1')),
+				line(mine, null),
+			);
+			advanceEdgeRef(root, fileFor('u-1'), mine);
+
+			expect(getEdgeRef(root).value).toBe(mine);
+		});
+
+		// The case the correctness rests on. A board with one writer would not
+		// need the check at all.
+		it('gives up the shortcut when a teammate wrote too', () => {
+			writeChain('u-1', 4, baseTime);
+			getEdgeRef(root);
+
+			const theirs = writeChain('u-2', 3, baseTime + 1000);
+
+			const mine = ulid(baseTime + 100);
+			fs.appendFileSync(
+				path.join(eventsDir(), fileFor('u-1')),
+				line(mine, null),
+			);
+			advanceEdgeRef(root, fileFor('u-1'), mine);
+
+			// Derived rather than assumed, and their events sort last here.
+			expect(getEdgeRef(root).value).toBe(theirs);
+		});
+
+		it('gives up the shortcut when a teammate’s log appears', () => {
+			writeChain('u-1', 4, baseTime);
+			getEdgeRef(root);
+
+			const theirs = writeChain('u-3', 2, baseTime + 5000);
+
+			const mine = ulid(baseTime + 100);
+			fs.appendFileSync(
+				path.join(eventsDir(), fileFor('u-1')),
+				line(mine, null),
+			);
+			advanceEdgeRef(root, fileFor('u-1'), mine);
+
+			expect(getEdgeRef(root).value).toBe(theirs);
+		});
+
+		it('gives up the shortcut when a log disappears', () => {
+			writeChain('u-1', 4, baseTime);
+			writeChain('u-2', 2, baseTime + 1000);
+			getEdgeRef(root);
+
+			fs.rmSync(path.join(eventsDir(), fileFor('u-2')));
+
+			const mine = ulid(baseTime + 100);
+			fs.appendFileSync(
+				path.join(eventsDir(), fileFor('u-1')),
+				line(mine, null),
+			);
+			advanceEdgeRef(root, fileFor('u-1'), mine);
+
+			// Re-derived over what is left, rather than trusting a tail taken
+			// while the missing file was still there.
+			expect(getEdgeRef(root).value).toBe(mine);
+		});
+	});
+
+	it('serves a different project without answering from the first', () => {
+		const tail = writeChain('u-1', 4, baseTime);
+		expect(getEdgeRef(root).value).toBe(tail);
+
+		const other = fs.mkdtempSync(path.join(os.tmpdir(), 'epiq-edge-'));
+		fs.mkdirSync(path.join(other, '.epiq', 'events'), {recursive: true});
+
+		expect(getEdgeRef(other).value).toBeNull();
+
+		fs.rmSync(other, {recursive: true, force: true});
+	});
+});

--- a/source/test/rank.test.ts
+++ b/source/test/rank.test.ts
@@ -8,10 +8,16 @@ const materializeAndPersistAll = vi.hoisted(() => vi.fn());
 
 const state = vi.hoisted(() => ({
 	nodes: {} as Record<string, Partial<NavNode<AnyContext>>>,
+	filters: [] as unknown[],
+	renderedChildrenIndex: {} as Record<string, unknown>,
 }));
 
 vi.mock('../lib/state/state.js', () => ({
 	getState: () => state,
+	// These tests drive rank resolution over a hand-built node map, with no
+	// derivation behind it — so the fast path must not be taken, and the scan
+	// is what they are testing.
+	isDeferringDerive: () => false,
 }));
 
 vi.mock('../lib/event/create-rebalance-children-event.js', () => ({

--- a/source/test/stress/generate-log.ts
+++ b/source/test/stress/generate-log.ts
@@ -58,8 +58,16 @@ type Action = (typeof SHAPE)[number];
 
 const YEAR_MS = 365 * 24 * 60 * 60 * 1000;
 
-// Compared lexicographically, which is what the rank ordering does.
-const RANKS = ['aQ', 'aV', 'b0', 'b5', 'cB', 'cH'];
+// Distinct and climbing, the way rankBetween mints them.
+//
+// A handful of values cycled instead put hundreds of thousands of tickets on
+// six ranks, and a lane of duplicates is not what a board holds — it is what
+// sends every later write into a rebalance, so the fixture reported a write
+// cost the product does not actually have.
+//
+// Fixed width so the string order is the numeric one, and in steps rather than
+// singles so there is room to insert between two without rebalancing.
+const rankAt = (n: number): string => String(n * 100).padStart(12, '0');
 
 // A ticket on the board, and how far along the lanes it has been worked.
 type OpenTicket = {id: string; lane: number};
@@ -208,7 +216,7 @@ export const generateLog = async (
 					name: `Ticket ${i}: something a person actually wrote down`,
 					// Filed into the first lane, rather than dropped wherever.
 					parent: input.laneIds[0]!,
-					rank: RANKS[i % RANKS.length]!,
+					rank: rankAt(i),
 				},
 				id,
 				refId,
@@ -232,7 +240,7 @@ export const generateLog = async (
 					id: ticket.id,
 					// The handler refuses any parent but this one.
 					parent: CLOSED_SWIMLANE_ID,
-					rank: RANKS[i % RANKS.length]!,
+					rank: rankAt(i),
 				},
 				id,
 				refId,
@@ -256,7 +264,7 @@ export const generateLog = async (
 				{
 					id: ticket.id,
 					parent: input.laneIds[ticket.lane]!,
-					rank: RANKS[i % RANKS.length]!,
+					rank: rankAt(i),
 				},
 				id,
 				refId,

--- a/source/test/stress/run.ts
+++ b/source/test/stress/run.ts
@@ -279,6 +279,32 @@ console.log(
 		`${perRequest.toFixed(1).padStart(6)} ms`,
 );
 
+// What an edit costs, which is not what a read costs: a write grows the log,
+// and anything holding a derived view of it has to notice.
+const writeAt = performance.now();
+ok(
+	await api.createIssue({
+		repoRoot: REPO,
+		title: 'A ticket filed on a board this size',
+		parentId: lanes[0]!.id,
+	}),
+);
+const wrote = performance.now() - writeAt;
+
+const afterWriteAt = performance.now();
+ok(await api.getGuiState({repoRoot: REPO}));
+const afterWrite = performance.now() - afterWriteAt;
+
+const steadyAt = performance.now();
+ok(await api.getGuiState({repoRoot: REPO}));
+const steady = performance.now() - steadyAt;
+
+console.log(
+	`  ${'filing a ticket'.padEnd(38)} ${secs(wrote).padStart(9)}\n` +
+		`  ${'the read after it'.padEnd(38)} ${secs(afterWrite).padStart(9)}\n` +
+		`  ${'the read after that'.padEnd(38)} ${secs(steady).padStart(9)}`,
+);
+
 console.log(
 	`\n  peak rss ${mb(process.memoryUsage().rss)}   ` + `project at ${REPO}\n`,
 );


### PR DESCRIPTION
Filing a ticket on a 200,000-event board took **4.24 s**. It now takes **0.88 s**, and two of the three steps are product fixes.

| | | |
|---|---|---|
| `RW176VY` | stop reading the log to find one id | 4.24 → 3.40 s |
| `Z3ZA84Y` | stop scanning the board to pick one rank | 3.40 → 2.43 s |
| fixture | distinct ranks, as `rankBetween` mints them | 2.43 → **0.88 s** |

## RW176VY — the causal edge

`persist` asked `getEdgeRef` for the tail of the order, and it answered by reading every line the board has ever held and rebuilding the whole forest, to take one id off the end. `EdgeCursor` already avoids exactly that *within* a batch, and says so in its own comment; a lone write had no batch to belong to.

The edge is held per process, keyed by the log's signature — the mechanism `H88JV7A` and `KKK5ZR4` already use. Every full load seeds it, since the order is right there and the tail is free, so a boot pays once and the writes after it do not pay at all. `persist` then advances it to the id just written: a child of the edge it was minted against, and the deepest node in the forest, so the walk ends on it.

**Advanced only when this actor's file is the one that moved.** Another log growing, appearing or vanishing means someone else's events arrived and the tail is theirs to decide, so the cache is dropped and the next read derives it properly. That is the case the whole thing rests on — I removed the check and watched both teammate tests go red before trusting them.

## Z3ZA84Y — the parent's children

Resolving a new ticket's rank scanned every node on the board and sorted the matches. `derive` has already grouped every node by parent, and with no filter applied its index skips exactly what this skips, in exactly this order — so where the index is current, it *is* the answer.

Not while a replay batch is open, when the derived half of the state is deliberately stale and the descendant walk still calls this. Not while a filter is on, when the index holds a subset and a rank resolved against it would collide with a hidden sibling. Both fall back to the scan, which is always right and only ever slow — the fast path is an optimisation, never a second source of truth.

**The rule now has one definition.** "A node's children" — skip deleted, group by parent, sort by rank — was written twice, in the index builder and here. It lives in `repository/children.ts` now and both call it. A board ordered one way and a rank resolved against another puts a ticket in the wrong place, so that is the duplication worth removing; the two execution paths remain, for the reason above, written where both can see it.

## The fixture

Six rank values cycled across a whole board left every lane a wall of duplicates, and duplicates leave no room between two ranks — so every write went into a rebalance the product would never perform on a real board. The last 1.5 s was the harness inventing a cost. Same class of error as opening 96,000 tickets and never closing one.

## Gate

1158 unit, 17 TUI e2e (container), 15 collaboration (container), tsc/eslint/prettier clean.