### PR TITLE
9541X2N Notice the state branch once, not on every call

### DIFF
--- a/source/mcp/epiq-api.ts
+++ b/source/mcp/epiq-api.ts
@@ -12,6 +12,7 @@ import {createIssueEvents} from '../lib/event/common-events.js';
 import {ulidTimeMs} from '../lib/event/date-utils.js';
 import {bootStateFromEventLog} from '../lib/event/event-boot.js';
 import {logSignature} from '../lib/event/log-signature.js';
+import {getEpiqDirPath} from '../lib/storage/paths.js';
 import {
 	loadEventActors,
 	loadMergedEvents,
@@ -248,6 +249,18 @@ const resolveRepoRoot = (repoRoot?: string): Result<string> => {
 	return succeeded('Resolved Epiq repo root', result.value);
 };
 
+// The state branch and its worktree, once this process has seen them in place.
+//
+// Both checks spawn a subprocess, about 160ms for the pair, and every read and
+// every write runs them before doing anything. What they guard against is a
+// first call: a clone that never synced has no local branch for the worktree to
+// attach to. Neither comes and goes under a running server.
+//
+// Revalidated by looking for the worktree's own directory, which is what
+// disappears when another process relocates it — cheap enough to do every time,
+// and the case those checks would otherwise be catching.
+let ensuredBranch: {repoRoot: string; stateBranchRoot: string} | null = null;
+
 // The log this process last booted from. Held for the life of it, and for one
 // root: a server serves one project.
 let lastBoot: {root: string; signature: string} | null = null;
@@ -273,25 +286,37 @@ const boot = async (
 	const stateBranchResult = getStateBranch(repoRootResult.value);
 	if (isFail(stateBranchResult)) return failed(stateBranchResult.message);
 
-	// A clone that has never synced has no local state branch for the worktree
-	// to attach to. Deliberately not the full bootstrap the sync path runs:
-	// that also repairs the branch's contents with a commit, and this is on
-	// every API call.
-	const localBranchResult = await ensureLocalStateBranch({
-		repoRoot: repoRootResult.value,
-		stateBranchName: stateBranchResult.value,
-	});
+	const inPlace =
+		ensuredBranch !== null &&
+		ensuredBranch.repoRoot === repoRootResult.value &&
+		ensuredBranch.stateBranchRoot === stateBranchRootResult.value &&
+		fs.existsSync(getEpiqDirPath(stateBranchRootResult.value));
 
-	if (isFail(localBranchResult)) return failed(localBranchResult.message);
+	if (!inPlace) {
+		// A clone that has never synced has no local state branch for the
+		// worktree to attach to. Deliberately not the full bootstrap the sync
+		// path runs: that also repairs the branch's contents with a commit.
+		const localBranchResult = await ensureLocalStateBranch({
+			repoRoot: repoRootResult.value,
+			stateBranchName: stateBranchResult.value,
+		});
 
-	const ensureWorktreeResult = await ensureStateBranchWorktree({
-		repoRoot: repoRootResult.value,
-		stateBranchRoot: stateBranchRootResult.value,
-		stateBranchName: stateBranchResult.value,
-	});
+		if (isFail(localBranchResult)) return failed(localBranchResult.message);
 
-	if (isFail(ensureWorktreeResult)) {
-		return failed(ensureWorktreeResult.message);
+		const ensureWorktreeResult = await ensureStateBranchWorktree({
+			repoRoot: repoRootResult.value,
+			stateBranchRoot: stateBranchRootResult.value,
+			stateBranchName: stateBranchResult.value,
+		});
+
+		if (isFail(ensureWorktreeResult)) {
+			return failed(ensureWorktreeResult.message);
+		}
+
+		ensuredBranch = {
+			repoRoot: repoRootResult.value,
+			stateBranchRoot: stateBranchRootResult.value,
+		};
 	}
 
 	// MCP tools are local-only by default; fetching remote state is explicit.


### PR DESCRIPTION
`boot()` ran two git subprocesses before doing anything — one checking the local state branch exists, one checking its worktree is where it should be — and every read and every write goes through `boot()`.

What they guard against is a **first** call: a clone that has never synced has no local state branch for the worktree to attach to. Neither the branch nor the worktree comes and goes under a running server.

## What it costs

| | |
|---|---|
| `rev-parse --verify` (the branch) | 84 ms |
| `worktree list --porcelain` (the worktree) | 80 ms |

Measured in this repository, which has forty-odd worktrees for `worktree list` to walk. On a fresh one the pair is cheaper — filing a ticket on the stress board went 0.88 s → 0.84 s, so about 40 ms there. The saving scales with what the check has to look through, which is itself the argument for not doing it on every call.

## Why the shortcut is safe

It is remembered once this process has seen them in place, and **revalidated every call** by looking for the worktree's own `.epiq` directory. That is what disappears when another process relocates the worktree — the case those git calls would otherwise be catching — so the shortcut stops the moment the thing it assumed stops being true. `fs.existsSync` against two subprocess spawns.

[[KKK5ZR4]] made `boot()` skip the load and the replay when the log has not moved; these two ran *before* that check and were not covered by it.

## Gate

1158 unit, tsc/eslint/prettier clean.

## Not claimed

The remaining time in a write is not attributed. I measured this pair specifically rather than subtracting it from a total, having got that wrong more than once tonight.