### PR TITLE
C2ENVN0 take the log to its foot whenever the timeline moves

### DIFF
--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -1039,7 +1039,7 @@ export const App = () => {
 		return () => window.clearTimeout(timer);
 	}, [state, theatre, selection.windowOnly, logOpen]);
 
-	const logEntries = useEventLog({
+	const {entries: logEntries, moment: logMoment} = useEventLog({
 		open: logOpen,
 		timeline: history.timeline,
 		commits: history.commits,
@@ -1633,6 +1633,7 @@ export const App = () => {
 						{logOpen && (
 							<EventLog
 								entries={logEntries}
+								moment={logMoment}
 								bottomClearance={theatre ? THEATRE_PLAYER_CLEARANCE : 0}
 								onOpen={openLogDestination}
 							/>

--- a/source/gui/client/components/EventLog.tsx
+++ b/source/gui/client/components/EventLog.tsx
@@ -139,10 +139,14 @@ const EventRow = ({entry}: {entry: LogEntry}) => (
 
 const EventLogPanel = ({
 	entries,
+	moment,
 	bottomClearance,
 	onOpen,
 }: {
 	entries: readonly LogEntry[];
+	// The moment the lines were sliced against. Moving it is moving the
+	// timeline, and the pane snaps to its foot for that — see below.
+	moment: number;
 	// Following a line. One handler on the pane rather than one per row: the
 	// rows carry where they go, and hundreds of closures would be the expensive
 	// half of a feature whose whole point is that it costs nothing until used.
@@ -222,6 +226,20 @@ const EventLogPanel = ({
 
 		pane.scrollTop = pane.scrollHeight;
 	}, [newestId, days.length, foldOverrides, openCount]);
+
+	// Moving the timeline is different from a line arriving: reading back
+	// through the log is reading the moment the board stands at, and once that
+	// moment changes the place being read is gone with it. So the pane goes to
+	// the foot whether or not it was there — and is pinned again, so what lands
+	// next follows. Without this a scrub that shortens the log by hundreds of
+	// lines left the pane scrolled to where they used to be, showing nothing.
+	useLayoutEffect(() => {
+		const pane = scrollRef.current;
+		if (!pane) return;
+
+		pinnedRef.current = true;
+		pane.scrollTop = pane.scrollHeight;
+	}, [moment]);
 
 	// The keys on screen before this render. The column slides by however many
 	// rows joined the bottom, which is not always one: an event that crosses

--- a/source/gui/client/lib/use-event-log.ts
+++ b/source/gui/client/lib/use-event-log.ts
@@ -61,6 +61,13 @@ export const momentOnScreen = (
 	return Infinity;
 };
 
+export type EventLogView = {
+	entries: LogEntry[];
+	// The moment the lines were sliced against, handed out with them: the panel
+	// snaps to its foot when this moves, and not when a line merely arrives.
+	moment: number;
+};
+
 export const useEventLog = ({
 	open,
 	timeline,
@@ -72,7 +79,7 @@ export const useEventLog = ({
 	playing,
 	playheadTime,
 	timeTravel,
-}: EventLogSources): LogEntry[] => {
+}: EventLogSources): EventLogView => {
 	const {view, only, ticketOnly} = selection;
 
 	// The board is down to one ticket only while one is actually open — the box
@@ -105,5 +112,7 @@ export const useEventLog = ({
 	// Sliced when the moment moves rather than on every render: a movie renders
 	// the board on every animation frame but reaches a new event a few times a
 	// second, and the panel only wants a new list for the latter.
-	return useMemo(() => logEntriesUpTo(rows, moment), [rows, moment]);
+	const entries = useMemo(() => logEntriesUpTo(rows, moment), [rows, moment]);
+
+	return useMemo(() => ({entries, moment}), [entries, moment]);
 };

--- a/source/test/e2e-gui/event-log.pw.ts
+++ b/source/test/e2e-gui/event-log.pw.ts
@@ -322,3 +322,88 @@ test('a line that leads somewhere says so under the pointer', async ({
 	await page.getByTestId('log-toggle').click();
 	expect(pageErrors).toEqual([]);
 });
+
+// Reading back through the log is reading the moment the board stands at.
+// Moving the timeline changes that moment, so the pane goes to the foot — a
+// scrub that shortened the log by hundreds of lines used to leave it scrolled
+// to where they had been, showing nothing.
+test('moving the timeline takes the log to its foot, wherever it was', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	// Short, so a dozen lines is more than the pane can show.
+	await page.setViewportSize({width: 1280, height: 420});
+	await openBoard(page, appUrl);
+	const boardUrl = page.url();
+
+	// Filed from the board behind the panel each one opens, so there is no
+	// round trip per ticket; one line in the log apiece.
+	const stamp = Date.now();
+	for (let index = 0; index < 10; index++) {
+		await page.getByTitle('Add issue').first().click();
+		await page.getByPlaceholder('issue name').fill(`Foot ${stamp}-${index}`);
+		await page.getByPlaceholder('issue name').press('Enter');
+		await expect(page.locator('aside')).toContainText(`Foot ${stamp}-${index}`);
+	}
+	await page.goto(boardUrl);
+
+	await page.getByTestId('log-toggle').click();
+	const pane = page.getByTestId('event-log-scroll');
+	await expect(pane).toBeVisible();
+	await expect
+		.poll(async () => await page.getByTestId('log-line').count())
+		.toBeGreaterThan(10);
+
+	const scrolled = () =>
+		page.evaluate(`
+(() => {
+	const pane = document.querySelector('[data-testid="event-log-scroll"]');
+	return {
+		overflow: pane.scrollHeight - pane.clientHeight,
+		fromFoot: pane.scrollHeight - pane.scrollTop - pane.clientHeight,
+		top: pane.scrollTop,
+	};
+})()
+`) as Promise<{overflow: number; fromFoot: number; top: number}>;
+
+	// The premise: there is somewhere to scroll to. A pane that does not
+	// overflow is at its foot whatever happens, and would prove nothing.
+	await expect.poll(async () => (await scrolled()).overflow).toBeGreaterThan(0);
+
+	// Read back to the top, which is the position a scrub used to keep.
+	await page.evaluate(
+		`document.querySelector('[data-testid="event-log-scroll"]').scrollTop = 0`,
+	);
+	await expect.poll(async () => (await scrolled()).top).toBe(0);
+
+	// Into the past, but only just: the board stands at an earlier moment while
+	// the log stays longer than the pane. A scrub that shortened it to fit would
+	// leave the pane at its foot with nothing to prove — so that is asserted.
+	const track = page.getByTestId('scrubber-track');
+	const box = await track.boundingBox();
+	if (!box) throw new Error('scrubber track is not on screen');
+	await page.mouse.click(box.x + box.width * 0.97, box.y + box.height / 2);
+	await expect(
+		page.getByRole('button', {name: 'Resume', exact: true}),
+	).toBeVisible();
+
+	await expect.poll(async () => (await scrolled()).overflow).toBeGreaterThan(0);
+	await expect
+		.poll(async () => (await scrolled()).fromFoot)
+		.toBeLessThanOrEqual(1);
+
+	// And back to the present is a move of the timeline too.
+	await page.evaluate(
+		`document.querySelector('[data-testid="event-log-scroll"]').scrollTop = 0`,
+	);
+	await expect.poll(async () => (await scrolled()).top).toBe(0);
+	await page.getByRole('button', {name: 'Resume', exact: true}).click();
+	await expect
+		.poll(async () => (await scrolled()).fromFoot)
+		.toBeLessThanOrEqual(1);
+
+	await page.getByTestId('log-toggle').click();
+	await returnToLive(page);
+	expect(pageErrors).toEqual([]);
+});


### PR DESCRIPTION
Move the needle so the log is re-sliced to far fewer lines and the pane kept its old scroll position: empty space on screen, the lines somewhere above it.

Decided with the reporter: whenever the timeline is moved, the pane snaps to its foot — always, whether or not the reader had scrolled up. Reading back through the log is reading the moment the board stands at; once that moment changes, the place being read is gone with it. A live line arriving is a different case and keeps today's rule: only a pane already at the foot follows it down.

`useEventLog` already computed that moment (`momentOnScreen`: the playhead while a movie runs, the checkout while the needle is parked, the present while live) to slice the lines against. It now hands it out with them, and the panel has one layout effect keyed on it that pins and scrolls to the foot. Nothing keys on the lines themselves, so a live log being read is not yanked.

The test needed care to mean anything. Its first version passed without the fix: a scrub to mid-track dropped enough lines that the pane stopped overflowing, and a pane with nowhere to scroll is at its foot for free. It now scrubs to 97% so the log stays longer than the pane, asserts that premise outright, and reads 90px from the foot without the fix against 0 with it. Resume — back to the present — is covered as a timeline move too.