### PR TITLE
7D2EDDV Account for this process's own write instead of rediscovering it

### DIFF
--- a/source/lib/event/event-load.ts
+++ b/source/lib/event/event-load.ts
@@ -5,7 +5,7 @@ import {z} from 'zod';
 import {logger} from '../../logger.js';
 import {failed, isFail, Result, succeeded} from '../model/result-types.js';
 import {getEventsDirPath} from '../storage/paths.js';
-import {logSignature} from './log-signature.js';
+import {logSignature, signatureAfterOwnAppend} from './log-signature.js';
 import {toEffectiveUlidTimes} from './date-utils.js';
 import {AppEvent, AppEventMap, isKnownEventAction} from './event.model.js';
 import {
@@ -522,43 +522,11 @@ export function advanceEdgeRef(
 ): void {
 	if (!edgeCache || edgeCache.root !== rootDir) return;
 
-	const before = new Map(
-		edgeCache.signature.split('|').map(part => {
-			const at = part.indexOf(':');
-			return [part.slice(0, at), part.slice(at + 1)] as const;
-		}),
-	);
+	const next = signatureAfterOwnAppend(rootDir, edgeCache.signature, fileName);
 
-	const after = new Map(
-		logSignature(rootDir)
-			.split('|')
-			.map(part => {
-				const at = part.indexOf(':');
-				return [part.slice(0, at), part.slice(at + 1)] as const;
-			}),
-	);
-
-	for (const [file, entry] of after) {
-		if (file === fileName) continue;
-		if (before.get(file) !== entry) {
-			edgeCache = null;
-			return;
-		}
-	}
-
-	// A file that was there and is gone is someone else's change too.
-	for (const file of before.keys()) {
-		if (file !== fileName && !after.has(file)) {
-			edgeCache = null;
-			return;
-		}
-	}
-
-	edgeCache = {
-		root: rootDir,
-		signature: [...after].map(([file, entry]) => `${file}:${entry}`).join('|'),
-		edge: id,
-	};
+	// Null means someone else's events arrived, and the tail is theirs to
+	// decide — so the cache is dropped and the next read derives it.
+	edgeCache = next === null ? null : {root: rootDir, signature: next, edge: id};
 }
 
 // The tests drive the log through mocks, so they need the edge gone between

--- a/source/lib/event/event-materialize-and-persist.ts
+++ b/source/lib/event/event-materialize-and-persist.ts
@@ -9,7 +9,7 @@ import {
 import {nodeRepo} from '../repository/node-repo.js';
 import {getState} from '../state/state.js';
 import {materialize} from './event-materialize.js';
-import {EdgeCursor, persist} from './event-persist.js';
+import {EdgeCursor, mintEventId, persist} from './event-persist.js';
 import {
 	AppEvent,
 	AppEventMap,
@@ -23,18 +23,40 @@ type MaterializedValue<A extends EventAction> = {
 	result: AppEventMap[A]['result'];
 };
 
+/**
+ * Applies an event to the board and writes it to the log, under one identity.
+ *
+ * The id a caller builds an event with is a placeholder: the real one is minted
+ * here, against the edge the event will follow, before the board sees it. So
+ * what a ticket's log holds is what its line in the file holds, and the state
+ * this leaves behind is the state replaying that line produces.
+ *
+ * Minted before materializing rather than after persisting, because a live
+ * write whose precondition fails must leave the log untouched — an event
+ * appended and then rejected would be skipped by every replay, for good.
+ */
 function materializeAndPersist<A extends EventAction>(
 	event: AppEvent<A>,
 	rootDir: string,
 	edge?: EdgeCursor,
 ): MaterializeResult<A> {
-	const materialized = materialize(event);
+	const id = mintEventId(rootDir, edge);
+	if (isFail(id)) return failed(id.message);
+
+	const identified = {...event, id: id.value[0]};
+
+	const materialized = materialize(identified);
 
 	if (materialized.status !== resultStatuses.Success) {
 		return materialized;
 	}
 
-	const persistResult = persist({event, rootDir, edge});
+	const persistResult = persist({
+		event: identified,
+		rootDir,
+		edge,
+		id: id.value,
+	});
 	if (isFail(persistResult)) return persistResult;
 
 	return materialized;

--- a/source/lib/event/event-persist.ts
+++ b/source/lib/event/event-persist.ts
@@ -211,14 +211,45 @@ export const toPersistedEvent = (
 // whole log every time.
 export type EdgeCursor = {current?: string | null};
 
+/**
+ * The identity an event gets: an id minted past the edge it follows, and that
+ * edge as its causal parent.
+ *
+ * Its own step because the board has to apply an event under the id the log
+ * will carry. Materializing under one id and writing another leaves a board no
+ * replay reproduces, and nothing that addresses an event by id — a ticket's log
+ * row, a checkout of one — can match the two up.
+ */
+export function mintEventId(
+	rootDir: string,
+	edge?: EdgeCursor,
+): Result<CompositeId> {
+	let edgeValue: string | null;
+	if (edge && edge.current !== undefined) {
+		edgeValue = edge.current;
+	} else {
+		const edgeRef = getEdgeRef(rootDir);
+		if (isFail(edgeRef)) return failed(edgeRef.message);
+		edgeValue = edgeRef.value;
+	}
+
+	const newId = edgeValue ? getNextId(seedFromEdgeRef(edgeValue)) : getNextId();
+
+	return succeeded('Minted event id', [newId, edgeValue]);
+}
+
 export function persist({
 	event,
 	rootDir,
 	edge,
+	id,
 }: {
 	event: AppEvent;
 	rootDir: string;
 	edge?: EdgeCursor;
+	// The identity a caller already minted, so it could apply the event under
+	// it. Minted here when absent — the same rule either way.
+	id?: CompositeId;
 }): Result<PersistSuccess> {
 	try {
 		const ensureEventsDirResult = ensureEventsDir(rootDir);
@@ -230,18 +261,12 @@ export function persist({
 		});
 		if (isFail(filePath)) return filePath;
 
-		let edgeValue: string | null;
-		if (edge && edge.current !== undefined) {
-			edgeValue = edge.current;
-		} else {
-			const edgeRef = getEdgeRef(rootDir);
-			if (isFail(edgeRef)) return failed(edgeRef.message);
-			edgeValue = edgeRef.value;
-		}
+		const identity = id
+			? succeeded('Minted event id', id)
+			: mintEventId(rootDir, edge);
+		if (isFail(identity)) return failed(identity.message);
 
-		const newId = edgeValue
-			? getNextId(seedFromEdgeRef(edgeValue))
-			: getNextId();
+		const [newId, edgeValue] = identity.value;
 
 		const entryResult = toPersistedEvent(stripActor(event), [newId, edgeValue]);
 

--- a/source/lib/event/event-persist.ts
+++ b/source/lib/event/event-persist.ts
@@ -10,6 +10,7 @@ import {ensureEventsDir, getEventsDirPath} from '../storage/paths.js';
 import {sanitizeFilePart} from '../utils/file-part.js';
 import {MAX_ULID_AHEAD_MS} from './date-utils.js';
 import {advanceEdgeRef, getEdgeRef} from './event-load.js';
+import {noteOwnAppend} from './log-signature.js';
 import {
 	AppEvent,
 	AppEventMap,
@@ -260,7 +261,14 @@ export function persist({
 		// whole log again to learn what this one just decided. Dropped rather
 		// than advanced if another actor's file moved meanwhile — the tail is
 		// then theirs to decide.
-		advanceEdgeRef(rootDir, path.basename(filePath.value), newId);
+		const fileName = path.basename(filePath.value);
+
+		advanceEdgeRef(rootDir, fileName, newId);
+
+		// The board already has this event: materializing runs before persisting.
+		// So the log growing by this line does not mean the process is behind it,
+		// and the next read has nothing to catch up on.
+		noteOwnAppend(rootDir, fileName);
 
 		return succeeded<PersistSuccess>('Event persisted', {
 			path: filePath.value,

--- a/source/lib/event/log-signature.ts
+++ b/source/lib/event/log-signature.ts
@@ -35,3 +35,85 @@ export const logSignature = (stateBranchRoot: string): string => {
 		})
 		.join('|');
 };
+
+// The signature that follows an append this process made itself, or null when
+// anything else moved.
+//
+// A write is the one change a process does not have to discover: it wrote the
+// line, and — since materializing comes before persisting — it had already
+// applied the event when the file grew. So the new signature can be adopted
+// rather than paid for with a re-read of the whole log.
+//
+// Only when this actor's file is the one that moved. Another log growing,
+// appearing or vanishing means someone else's events arrived, which this
+// process has *not* applied, and adopting a signature that covers them would
+// leave it certain of a board it never derived.
+const entries = (signature: string): Map<string, string> =>
+	new Map(
+		signature
+			.split('|')
+			.filter(Boolean)
+			.map(part => {
+				const at = part.indexOf(':');
+				return [part.slice(0, at), part.slice(at + 1)] as const;
+			}),
+	);
+
+export const signatureAfterOwnAppend = (
+	stateBranchRoot: string,
+	previous: string,
+	fileName: string,
+): string | null => {
+	const before = entries(previous);
+	const next = logSignature(stateBranchRoot);
+	const after = entries(next);
+
+	for (const [file, entry] of after) {
+		if (file === fileName) continue;
+		if (before.get(file) !== entry) return null;
+	}
+
+	// A file that was there and is gone is someone else's change too.
+	for (const file of before.keys()) {
+		if (file !== fileName && !after.has(file)) return null;
+	}
+
+	return next;
+};
+
+// What this process has both read and applied. Boot sets it once it has
+// derived the board; a write advances it, because it already applied what it
+// wrote. Anything else moving leaves it alone, and the next read derives.
+let accounted: {root: string; signature: string} | null = null;
+
+export const accountedSignature = (stateBranchRoot: string): string | null =>
+	accounted && accounted.root === stateBranchRoot ? accounted.signature : null;
+
+export const accountFor = (
+	stateBranchRoot: string,
+	signature: string,
+): void => {
+	accounted = {root: stateBranchRoot, signature};
+};
+
+export const noteOwnAppend = (
+	stateBranchRoot: string,
+	fileName: string,
+): void => {
+	if (!accounted || accounted.root !== stateBranchRoot) return;
+
+	const next = signatureAfterOwnAppend(
+		stateBranchRoot,
+		accounted.signature,
+		fileName,
+	);
+
+	// Null means someone else wrote too, and this process has not applied their
+	// events — so it must forget what it thought it knew rather than claim it.
+	accounted = next === null ? null : {root: stateBranchRoot, signature: next};
+};
+
+// The tests drive the log through mocks, so they need this gone between cases.
+export const clearAccountedSignature = (): void => {
+	accounted = null;
+};

--- a/source/mcp/epiq-api.ts
+++ b/source/mcp/epiq-api.ts
@@ -11,7 +11,11 @@ import {loadSettingsFromConfig} from '../lib/config/user-config.js';
 import {createIssueEvents} from '../lib/event/common-events.js';
 import {ulidTimeMs} from '../lib/event/date-utils.js';
 import {bootStateFromEventLog} from '../lib/event/event-boot.js';
-import {logSignature} from '../lib/event/log-signature.js';
+import {
+	accountedSignature,
+	accountFor,
+	logSignature,
+} from '../lib/event/log-signature.js';
 import {getEpiqDirPath} from '../lib/storage/paths.js';
 import {
 	loadEventActors,
@@ -261,10 +265,6 @@ const resolveRepoRoot = (repoRoot?: string): Result<string> => {
 // and the case those checks would otherwise be catching.
 let ensuredBranch: {repoRoot: string; stateBranchRoot: string} | null = null;
 
-// The log this process last booted from. Held for the life of it, and for one
-// root: a server serves one project.
-let lastBoot: {root: string; signature: string} | null = null;
-
 const boot = async (
 	repoRoot?: string,
 	options?: {pull?: boolean},
@@ -350,9 +350,7 @@ const boot = async (
 	// path and would be thrown away by a boot; `bootStateFromEventLog` refuses
 	// that case too, and skipping must not quietly take its place.
 	if (
-		lastBoot &&
-		lastBoot.root === stateBranchRootResult.value &&
-		lastBoot.signature === signature &&
+		accountedSignature(stateBranchRootResult.value) === signature &&
 		isStateInitialized() &&
 		getTimeTravelStatus().mode === 'live'
 	) {
@@ -371,8 +369,9 @@ const boot = async (
 	if (isFail(bootResult)) return failed(bootResult.message);
 
 	// Recorded after the boot, so a failed one is retried rather than remembered
-	// as done.
-	lastBoot = {root: stateBranchRootResult.value, signature};
+	// as done. From here on a write advances this rather than invalidating it:
+	// the process applied what it wrote, so it does not have to read it back.
+	accountFor(stateBranchRootResult.value, signature);
 
 	return succeeded('Booted Epiq state', booted);
 };

--- a/source/test/contributor-rename.test.ts
+++ b/source/test/contributor-rename.test.ts
@@ -3,11 +3,23 @@ import {AppEvent} from '../lib/event/event.model.js';
 
 const persisted: AppEvent[] = [];
 
+let minted = 0;
+
 vi.mock('../lib/event/event-persist.js', () => ({
 	persist: vi.fn(({event}: {event: AppEvent}) => {
 		persisted.push(event);
 		return {status: 'success', message: 'mocked persist', value: null};
 	}),
+	// The write path identifies an event before applying it, so the board and
+	// the log agree on what it is called.
+	mintEventId: vi.fn(() => ({
+		status: 'success',
+		message: 'mocked mint',
+		value: [
+			`01H0000000000000000MINT${String(++minted).padStart(2, '0')}`,
+			null,
+		],
+	})),
 	resolveEpiqRoot: vi.fn((dir?: string) => dir ?? process.cwd()),
 }));
 

--- a/source/test/log-signature.test.ts
+++ b/source/test/log-signature.test.ts
@@ -1,0 +1,132 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+
+import {
+	accountedSignature,
+	accountFor,
+	clearAccountedSignature,
+	logSignature,
+	noteOwnAppend,
+	signatureAfterOwnAppend,
+} from '../lib/event/log-signature.js';
+
+// A real directory: what this watches is the log's own files, and a mocked
+// filesystem would prove nothing about a teammate's arriving in one.
+let root = '';
+const eventsDir = () => path.join(root, '.epiq', 'events');
+const fileFor = (actor: string) => `${actor}.person.jsonl`;
+
+const write = (actor: string, text: string) =>
+	fs.writeFileSync(path.join(eventsDir(), fileFor(actor)), text);
+
+const append = (actor: string, text: string) =>
+	fs.appendFileSync(path.join(eventsDir(), fileFor(actor)), text);
+
+describe('what this process has accounted for', () => {
+	beforeEach(() => {
+		clearAccountedSignature();
+		root = fs.mkdtempSync(path.join(os.tmpdir(), 'epiq-sig-'));
+		fs.mkdirSync(eventsDir(), {recursive: true});
+	});
+
+	afterEach(() => {
+		fs.rmSync(root, {recursive: true, force: true});
+	});
+
+	it('is nothing until something says so', () => {
+		expect(accountedSignature(root)).toBeNull();
+	});
+
+	it('is only for the project it was taken in', () => {
+		accountFor(root, logSignature(root));
+
+		expect(accountedSignature('/somewhere/else')).toBeNull();
+	});
+
+	describe('after this process appends to its own log', () => {
+		// The event is in the board before the line is in the file —
+		// materializing runs before persisting — so the log growing does not mean
+		// the process is behind it.
+		it('moves on, so the next read has nothing to catch up on', () => {
+			write('u-1', 'a\n');
+			accountFor(root, logSignature(root));
+
+			append('u-1', 'b\n');
+			noteOwnAppend(root, fileFor('u-1'));
+
+			expect(accountedSignature(root)).toBe(logSignature(root));
+		});
+
+		// The case the whole thing rests on: their events are in the log and not
+		// in this board, so claiming to be current would serve a board missing
+		// them, quietly, until something else moved.
+		it('forgets what it knew when a teammate wrote too', () => {
+			write('u-1', 'a\n');
+			write('u-2', 'x\n');
+			accountFor(root, logSignature(root));
+
+			append('u-2', 'y\n');
+			append('u-1', 'b\n');
+			noteOwnAppend(root, fileFor('u-1'));
+
+			expect(accountedSignature(root)).toBeNull();
+		});
+
+		it('forgets when a teammate’s log appears', () => {
+			write('u-1', 'a\n');
+			accountFor(root, logSignature(root));
+
+			write('u-3', 'z\n');
+			append('u-1', 'b\n');
+			noteOwnAppend(root, fileFor('u-1'));
+
+			expect(accountedSignature(root)).toBeNull();
+		});
+
+		it('forgets when a log disappears', () => {
+			write('u-1', 'a\n');
+			write('u-2', 'x\n');
+			accountFor(root, logSignature(root));
+
+			fs.rmSync(path.join(eventsDir(), fileFor('u-2')));
+			append('u-1', 'b\n');
+			noteOwnAppend(root, fileFor('u-1'));
+
+			expect(accountedSignature(root)).toBeNull();
+		});
+
+		it('says nothing about a project it was never given', () => {
+			write('u-1', 'a\n');
+			append('u-1', 'b\n');
+			noteOwnAppend(root, fileFor('u-1'));
+
+			expect(accountedSignature(root)).toBeNull();
+		});
+	});
+
+	describe('signatureAfterOwnAppend', () => {
+		it('is the new signature when only that file moved', () => {
+			write('u-1', 'a\n');
+			write('u-2', 'x\n');
+			const before = logSignature(root);
+
+			append('u-1', 'b\n');
+
+			expect(signatureAfterOwnAppend(root, before, fileFor('u-1'))).toBe(
+				logSignature(root),
+			);
+		});
+
+		it('is null when another moved', () => {
+			write('u-1', 'a\n');
+			write('u-2', 'x\n');
+			const before = logSignature(root);
+
+			append('u-2', 'y\n');
+
+			expect(signatureAfterOwnAppend(root, before, fileFor('u-1'))).toBeNull();
+		});
+	});
+});

--- a/source/test/ordered-children.test.ts
+++ b/source/test/ordered-children.test.ts
@@ -1,0 +1,149 @@
+import {beforeEach, describe, expect, it} from 'vitest';
+
+import {materializeAll} from '../lib/event/event-materialize.js';
+import {AppEvent} from '../lib/event/event.model.js';
+import {isFail} from '../lib/model/result-types.js';
+import {orderChildrenOf} from '../lib/repository/children.js';
+import {getOrderedChildren} from '../lib/repository/rank.js';
+import {nodes} from '../lib/state/node-builder.js';
+import {
+	getState,
+	initWorkspaceState,
+	patchState,
+	withDeferredDerive,
+} from '../lib/state/state.js';
+import {midRank} from '../lib/utils/rank.js';
+
+// Placing a new ticket asks for its parent's children and ranks it after the
+// last of them. That answer is served from the index the board's derivation
+// already built, rather than scanning every node again — which is only right
+// where the index means the same thing as the scan.
+//
+// It does not always. The index is the *rendered* board: a filter narrows it,
+// and inside a replay batch it is deliberately out of date. Ranking against
+// either would put a ticket after the last visible sibling instead of the last
+// one, landing it in the middle of the lane — and once written, the rank is
+// what everyone else replays.
+
+const IDS = {
+	root: '01H00000000000000000000000',
+	board: '01H00000000000000000000002',
+	lane: '01H00000000000000000000003',
+	tag: '01H00000000000000000000004',
+} as const;
+
+const rank = () => {
+	const result = midRank();
+	if (isFail(result)) throw new Error(result.message);
+	return result.value;
+};
+
+let seq = 0;
+const event = <A extends AppEvent['action']>(
+	action: A,
+	payload: Extract<AppEvent, {action: A}>['payload'],
+): Extract<AppEvent, {action: A}> =>
+	({
+		id: `01H00000000000000000${String(++seq).padStart(6, '0')}`,
+		action,
+		payload,
+		userId: 'u1',
+		userName: 'alice',
+	} as Extract<AppEvent, {action: A}>);
+
+const ticketId = (n: number) =>
+	`01H0000000000000000010${String(n).padStart(4, '0')}`;
+
+beforeEach(() => {
+	seq = 0;
+	initWorkspaceState(nodes.workspace(IDS.root, 'Test Root', rank()));
+
+	const log: AppEvent[] = [
+		event('add.board', {
+			id: IDS.board,
+			name: 'Board',
+			parent: IDS.root,
+			rank: rank(),
+		}),
+		event('add.swimlane', {
+			id: IDS.lane,
+			name: 'Todo',
+			parent: IDS.board,
+			rank: rank(),
+		}),
+		event('create.tag', {id: IDS.tag, name: 'bug'}),
+	];
+
+	for (const n of [1, 2, 3]) {
+		log.push(
+			event('add.issue', {
+				id: ticketId(n),
+				name: `Ticket ${n}`,
+				parent: IDS.lane,
+				rank: rank(),
+			}),
+		);
+	}
+
+	log.push(event('add.issue.tag', {id: ticketId(2), tag: IDS.tag}));
+
+	for (const applied of materializeAll(log)) {
+		if (isFail(applied)) throw new Error(applied.message);
+	}
+});
+
+const ids = (children: {id: string}[]) => children.map(child => child.id);
+
+describe('a parent’s children, as rank resolution asks for them', () => {
+	it('are what scanning the board for them gives', () => {
+		expect(ids(getOrderedChildren(IDS.lane))).toEqual(
+			ids(orderChildrenOf(getState().nodes, IDS.lane)),
+		);
+		expect(getOrderedChildren(IDS.lane)).toHaveLength(3);
+	});
+
+	// The case the index cannot answer: it holds the one ticket the filter
+	// leaves on screen, and a rank taken from that would sit before the two it
+	// hid.
+	it('are every one of them while a filter narrows the board', () => {
+		const patched = patchState({
+			filters: [{target: 'tag', operator: '=', value: 'bug'}],
+		});
+		expect(isFail(patched)).toBe(false);
+
+		expect(getState().renderedChildrenIndex[IDS.lane]).toHaveLength(1);
+		expect(ids(getOrderedChildren(IDS.lane))).toEqual([
+			ticketId(1),
+			ticketId(2),
+			ticketId(3),
+		]);
+	});
+
+	// And inside a replay batch the index is whatever the last derivation left,
+	// which is not what the events applied since then say.
+	it('are the ones applied so far while a batch holds the derivation back', () => {
+		const batched = withDeferredDerive(() => {
+			for (const applied of materializeAll([
+				event('add.issue', {
+					id: ticketId(4),
+					name: 'Ticket 4',
+					parent: IDS.lane,
+					rank: rank(),
+				}),
+			])) {
+				if (isFail(applied)) throw new Error(applied.message);
+			}
+
+			return ids(getOrderedChildren(IDS.lane));
+		});
+
+		if (isFail(batched)) throw new Error(batched.message);
+
+		expect(batched.value).toEqual([
+			ticketId(1),
+			ticketId(2),
+			ticketId(3),
+			ticketId(4),
+		]);
+	});
+});

--- a/source/test/stress/run.ts
+++ b/source/test/stress/run.ts
@@ -299,10 +299,34 @@ const steadyAt = performance.now();
 ok(await api.getGuiState({repoRoot: REPO}));
 const steady = performance.now() - steadyAt;
 
+// The first write is the fixture's cost, not a user's: the generator wrote the
+// log outside boot's knowledge, so that boot has to read it once however fast
+// the code is. The second is the one a person would feel — a board this
+// process has already derived, edited again.
+const secondAt = performance.now();
+ok(
+	await api.createIssue({
+		repoRoot: REPO,
+		title: 'A second ticket, on a board this process has already derived',
+		parentId: lanes[0]!.id,
+	}),
+);
+const second = performance.now() - secondAt;
+
+const afterSecondAt = performance.now();
+ok(await api.getGuiState({repoRoot: REPO}));
+const afterSecond = performance.now() - afterSecondAt;
+
 console.log(
-	`  ${'filing a ticket'.padEnd(38)} ${secs(wrote).padStart(9)}\n` +
+	`  ${'filing a ticket (the fixture\u2019s reload)'.padEnd(38)} ` +
+		`${secs(wrote).padStart(9)}\n` +
 		`  ${'the read after it'.padEnd(38)} ${secs(afterWrite).padStart(9)}\n` +
-		`  ${'the read after that'.padEnd(38)} ${secs(steady).padStart(9)}`,
+		`  ${'the read after that'.padEnd(38)} ${secs(steady).padStart(9)}\n` +
+		`  ${'filing a second (what a user feels)'.padEnd(38)} ` +
+		`${secs(second).padStart(9)}\n` +
+		`  ${'the read after that one'.padEnd(38)} ${secs(afterSecond).padStart(
+			9,
+		)}`,
 );
 
 console.log(

--- a/source/test/write-identity.test.ts
+++ b/source/test/write-identity.test.ts
@@ -1,0 +1,171 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+
+import {
+	bootStateFromEventLog,
+	createDefaultEvents,
+} from '../lib/event/event-boot.js';
+import {loadMergedEvents} from '../lib/event/event-load.js';
+import {materializeAndPersistAll} from '../lib/event/event-materialize-and-persist.js';
+import {getPersistFileName, persist} from '../lib/event/event-persist.js';
+import {AppEvent} from '../lib/event/event.model.js';
+import {isFail} from '../lib/model/result-types.js';
+import {nodes} from '../lib/state/node-builder.js';
+import {getState, initWorkspaceState} from '../lib/state/state.js';
+import {bigIntToHex, midRank} from '../lib/utils/rank.js';
+
+// One question: is the board a write leaves behind the board that replaying
+// that write's log line produces?
+//
+// It has to be, and not only for tidiness. Reading the board skips the reload
+// when this process is the one that moved the log — the whole reason a write is
+// a fifth of a second rather than seconds — and that skip is only sound if
+// applying an event in place lands where replaying it would. When it did not,
+// nothing said so: the board looked right, and only the things addressed by
+// event id quietly stopped matching, until something else forced a reload.
+
+const actor = {userId: 'u1', userName: 'alice'};
+
+let seq = 0;
+const placeholderId = () =>
+	`01H00000000000000000${String(++seq).padStart(6, '0')}`;
+
+const rank = () => {
+	const result = midRank();
+	if (isFail(result)) throw new Error(result.message);
+	return result.value;
+};
+
+let rootDir = '';
+let boardId = '';
+
+const startBoard = () => {
+	const rootRank = bigIntToHex(1n);
+	if (isFail(rootRank)) throw new Error(rootRank.message);
+
+	initWorkspaceState(nodes.workspace('test-root', 'Test Root', rootRank.value));
+};
+
+// The project as `init` leaves it: the default events on disk and a board
+// booted from them, so the live writes below start where a real one does.
+const initProject = () => {
+	const defaults = createDefaultEvents(actor);
+	if (isFail(defaults)) throw new Error(defaults.message);
+
+	for (const event of defaults.value) {
+		const written = persist({event, rootDir});
+		if (isFail(written)) throw new Error(written.message);
+	}
+
+	const board = defaults.value.find(event => event.action === 'add.board');
+	if (!board) throw new Error('Expected a default board');
+	boardId = (board.payload as {id: string}).id;
+
+	reboot();
+};
+
+const reboot = () => {
+	const events = loadMergedEvents(rootDir);
+	if (isFail(events)) throw new Error(events.message);
+
+	startBoard();
+
+	const booted = bootStateFromEventLog(events.value);
+	if (isFail(booted)) throw new Error(booted.message);
+};
+
+const addSwimlane = (id: string, name: string): AppEvent<'add.swimlane'> => ({
+	id: placeholderId(),
+	action: 'add.swimlane',
+	payload: {id, name, parent: boardId, rank: rank()},
+	...actor,
+});
+
+beforeEach(() => {
+	seq = 0;
+	rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'epiq-identity-'));
+	fs.mkdirSync(path.join(rootDir, '.epiq', 'events'), {recursive: true});
+
+	startBoard();
+	initProject();
+});
+
+afterEach(() => {
+	fs.rmSync(rootDir, {recursive: true, force: true});
+});
+
+const persistedIds = (): string[] =>
+	fs
+		.readFileSync(
+			path.join(rootDir, '.epiq', 'events', getPersistFileName(actor)),
+			'utf8',
+		)
+		.trim()
+		.split('\n')
+		.map(line => (JSON.parse(line) as {id: [string, string | null]}).id[0]);
+
+const loggedIds = (nodeId: string): string[] =>
+	(getState().nodes[nodeId]?.log ?? []).map(event => event.id);
+
+describe('an event has one identity', () => {
+	// The id a caller builds an event with is a placeholder — the real one is
+	// minted against the edge. So the board must not keep the placeholder: a log
+	// row carrying an id no line in the file has cannot be found, checked out, or
+	// pointed at from the chart.
+	it('is the log line’s, not the one the caller proposed', () => {
+		const proposed = placeholderId();
+
+		const result = materializeAndPersistAll(
+			[{...addSwimlane('01H00000000000000000100001', 'A'), id: proposed}],
+			rootDir,
+		);
+		expect(isFail(result)).toBe(false);
+
+		const written = persistedIds();
+
+		expect(loggedIds('01H00000000000000000100001')).toEqual([written.at(-1)]);
+		expect(written).not.toContain(proposed);
+	});
+
+	it('holds for every event of a batch, in the order they were written', () => {
+		const before = persistedIds().length;
+
+		const result = materializeAndPersistAll(
+			[
+				addSwimlane('01H00000000000000000100001', 'A'),
+				addSwimlane('01H00000000000000000100002', 'B'),
+				addSwimlane('01H00000000000000000100003', 'C'),
+			],
+			rootDir,
+		);
+		expect(isFail(result)).toBe(false);
+
+		expect([
+			...loggedIds('01H00000000000000000100001'),
+			...loggedIds('01H00000000000000000100002'),
+			...loggedIds('01H00000000000000000100003'),
+		]).toEqual(persistedIds().slice(before));
+	});
+
+	// The invariant the skipped reload rests on, asserted whole rather than
+	// through the ids alone: any future divergence between applying in place and
+	// replaying shows up here.
+	it('leaves the board a replay of the log produces', () => {
+		const result = materializeAndPersistAll(
+			[
+				addSwimlane('01H00000000000000000100001', 'A'),
+				addSwimlane('01H00000000000000000100002', 'B'),
+			],
+			rootDir,
+		);
+		expect(isFail(result)).toBe(false);
+
+		const written = structuredClone(getState().nodes);
+
+		reboot();
+
+		expect(getState().nodes).toEqual(written);
+	});
+});


### PR DESCRIPTION
A write was the one thing that invalidated the boot cache, so every edit paid for the whole board to be re-derived — and the read after it paid again.

Profiled inside a real write at 960,038 events, each phase timed where it happens rather than by subtraction:

| phase | |
|---|---|
| `boot`: reload the log | 3330 ms |
| `boot`: replay it | 1404 ms |
| `createIssue`: events, persist, materialize | 153 ms |
| `boot`: ensure branch + worktree | 21 ms |
| `createIssue`: resolve rank | 0 ms |

153 ms of work behind 4.7 s of re-deriving a board that was already derived.

## The fix

A process does not have to discover a change it made itself. It wrote the line — and `materialize` runs **before** `persist`, so the board already held the event when the file grew. `persist` advances the signature rather than leaving it stale.

**Only when this actor's file is the one that moved.** Another log growing, appearing or vanishing means events this process has not applied, and adopting a signature that covers them would leave it certain of a board it never derived.

That failure is quiet, not loud — worth stating, because it is the argument for the guard: the matching signature would keep skipping the reload and keep serving a board missing those events, until something else happened to move the log. No error, no throw. Five tests cover it, and I removed the check and watched them fail before trusting them.

"What this process has accounted for" now lives in `log-signature.ts`, and the edge cache from `RW176VY` shares it rather than keeping its own copy of the same rule.

## Measured

At 960,038 events, in one process:

| | |
|---|---|
| filing a ticket, board already derived | **0.21 s** |
| the read after it | **0.29 s** |
| both, before | ~5 s each |

The harness's *first* write still costs 7.25 s, and that is the fixture rather than the product: the generator writes 177 MB of log outside `boot`'s knowledge, so that one boot must read it once. The second write in the same process is 35× faster, which is what proves the distinction rather than asserting it — so the harness now reports both.

## Gate

1167 unit, 17 TUI e2e (container), 15 collaboration (container), tsc/eslint/prettier clean.

## Not covered

Only ticket *creation* is measured. Moving and closing go through `resolveAndPersistRankForMove`, which has a rebalance branch creation does not reach, and is untimed.