### PR TITLE
v1.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "epiq",
-	"version": "1.7.2",
+	"version": "1.8.0",
 	"license": "MIT",
 	"type": "module",
 	"description": "EPIQ - ergonomic, distributed CLI-first issue tracker TUI ready for the agentic era",

--- a/source/version.ts
+++ b/source/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated. Do not edit.
-export const EPIQ_VERSION = '1.7.2';
+export const EPIQ_VERSION = '1.8.0';


### PR DESCRIPTION
- Event log panel — the board's history as a readable feed, docked beside it behind a Log checkbox, folded by day, with commits carried inline and every line marked by kind.
- History playback — the board's past plays as a movie, the player docked as a drawer, with the scrubber standing down while it runs.
- Timeline narrowing — Ticket only scopes the chart to one ticket and the stretch it has lived; Scope only and Ticket only now named alike, and a dragged-out window survives opening a ticket.
- Scope row folds into a select where the bar has no room for it.
- Filter the board by actor, not just assignee.
- Agents take a provider/name identity, announce it, and can assume a board name mid-session.
- Commit diffs — a file's header pins while you scroll, files open the way you left the last one, and diff code sits at the app's own text size.
- Built for scale — a 20-person decade (960k events) now replays in ~1.8s instead of hours; filing a ticket is 0.21s and the read after it 0.29s
- Boards send the tickets a reader is looking at rather than every ticket ever closed — an 88.7 MB payload down to 8.8 MB.
- Timeline derived once per state of the log instead of once per request.
- Fixed: a comment with no author could take the whole board down.
- Fixed: an event was applied to the board under one id and written to the log under another, so log rows could not be matched to the chart or checked out.
- Fixed: TUI descriptions overflowing their box, and line numbers drifting.
- Opt-in stress harness — generates and replays a team's decade of history in a container; never part of any pipeline.
- The GUI can be told which port to bind.