### PR TITLE
DP4KEMF N8GXRCF 4Y91XAX cheaper MCP reads and writes for agents

### DIFF
--- a/source/mcp/api-state.model.ts
+++ b/source/mcp/api-state.model.ts
@@ -40,6 +40,17 @@ export type ApiIssue = {
 
 export type ApiIssueDetail = ApiIssue & {comments: ApiIssueComment[]};
 
+// What a list is scanned for: enough to pick a ticket out and take its ref,
+// and nothing that runs to paragraphs.
+export type ApiIssueBrief = {
+	id: string;
+	ref: string;
+	title: string;
+	swimlane: string;
+	tags: string[];
+	assignees: string[];
+};
+
 export type ApiSwimlane = {
 	id: string;
 	title: string;

--- a/source/mcp/api-state.model.ts
+++ b/source/mcp/api-state.model.ts
@@ -14,6 +14,15 @@ export type ApiComment = {
 	createdAt: number;
 };
 
+// A comment as epiq_issue_get carries it: what a thread is read for, and
+// nothing the GUI needs to draw one.
+export type ApiIssueComment = {
+	id: string;
+	author: string;
+	createdAt: number;
+	body: string;
+};
+
 export type ApiIssue = {
 	id: string;
 	ref: string;
@@ -28,6 +37,8 @@ export type ApiIssue = {
 	parentNodeId: string;
 	isClosed: boolean;
 };
+
+export type ApiIssueDetail = ApiIssue & {comments: ApiIssueComment[]};
 
 export type ApiSwimlane = {
 	id: string;

--- a/source/mcp/api-state.model.ts
+++ b/source/mcp/api-state.model.ts
@@ -40,6 +40,13 @@ export type ApiIssue = {
 
 export type ApiIssueDetail = ApiIssue & {comments: ApiIssueComment[]};
 
+// One write over many tickets: which went through and which did not, and
+// why. A failure is per ticket, not per call.
+export type ApiBatchOutcome = {
+	done: {id: string; ref: string}[];
+	failed: {id: string; ref: string; reason: string}[];
+};
+
 // What a list is scanned for: enough to pick a ticket out and take its ref,
 // and nothing that runs to paragraphs.
 export type ApiIssueBrief = {

--- a/source/mcp/epiq-api.ts
+++ b/source/mcp/epiq-api.ts
@@ -74,6 +74,8 @@ import {logger} from '../logger.js';
 import {
 	ApiAssignee,
 	ApiIssue,
+	ApiIssueComment,
+	ApiIssueDetail,
 	ApiState,
 	ApiIssueHistoryEntry,
 	ApiSwimlane,
@@ -440,6 +442,21 @@ const mergeRegistryNames = (
 	return byId;
 };
 
+// A comment's id is its ULID, so sorting the ids is log order.
+const getIssueComments = (issueId: string): ApiIssueComment[] =>
+	nodeRepo
+		.getCommentsByIssue(issueId)
+		.sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
+		.map(comment => ({
+			id: comment.id,
+			author:
+				nodeRepo.getContributor(comment.authorId)?.name ??
+				comment.authorName ??
+				'Unknown',
+			createdAt: ulidTimeMs(comment.id),
+			body: comment.md,
+		}));
+
 const getIssueAssignees = (ticket: Ticket) =>
 	(ticket.props.assignees ?? [])
 		.map(assignee => nodeRepo.getContributor(assignee))
@@ -552,7 +569,8 @@ export const getIssue = async (input: GetIssueInput) => {
 		readonly: Boolean(issue.readonly),
 		tags: getIssueTags(issue),
 		assignees: getIssueAssignees(issue),
-	} satisfies ApiIssue);
+		comments: getIssueComments(issue.id),
+	} satisfies ApiIssueDetail);
 };
 
 export const listIssues = async (input: ListIssuesInput) => {

--- a/source/mcp/epiq-api.ts
+++ b/source/mcp/epiq-api.ts
@@ -73,6 +73,7 @@ import {
 import {logger} from '../logger.js';
 import {
 	ApiAssignee,
+	ApiBatchOutcome,
 	ApiIssue,
 	ApiIssueBrief,
 	ApiIssueComment,
@@ -89,11 +90,18 @@ type ToolInput = {
 
 type SyncInput = ToolInput;
 
-type MoveIssueInput = ToolInput & {
-	issueId: string;
-	parentId: string;
-	position?: MovePosition;
+// One ticket or many. issueIds asks for a per-ticket outcome; issueId alone
+// keeps the single answer.
+type IssueTargets = {
+	issueId?: string;
+	issueIds?: string[];
 };
+
+type MoveIssueInput = ToolInput &
+	IssueTargets & {
+		parentId: string;
+		position?: MovePosition;
+	};
 
 type ListIssuesInput = ToolInput & {
 	includeClosed?: boolean;
@@ -137,9 +145,7 @@ type CreateIssueInput = ToolInput & {
 	assigneeNames?: string[];
 };
 
-type CloseIssueInput = ToolInput & {
-	issueId: string;
-};
+type CloseIssueInput = ToolInput & IssueTargets;
 
 type BootResult = {
 	repoRoot: string;
@@ -161,10 +167,10 @@ type EditIssueTitleInput = ToolInput & {
 	title: string;
 };
 
-type AddIssueTagInput = ToolInput & {
-	issueId: string;
-	tagName: string;
-};
+type AddIssueTagInput = ToolInput &
+	IssueTargets & {
+		tagName: string;
+	};
 
 type RemoveIssueTagInput = ToolInput & {
 	issueId: string;
@@ -475,6 +481,71 @@ const getIssueAssignees = (ticket: Ticket) =>
 					color: getStringColor(name),
 				} satisfies ApiIssue['assignees'][number]),
 		);
+
+const targetIds = (input: IssueTargets): Result<string[]> => {
+	const ids = [
+		...new Set([
+			...(input.issueIds ?? []),
+			...(input.issueId ? [input.issueId] : []),
+		]),
+	];
+
+	return ids.length
+		? succeeded('Resolved targets', ids)
+		: failed('Provide issueId or issueIds');
+};
+
+const batchResult = (
+	verb: string,
+	outcome: ApiBatchOutcome,
+): Result<ApiBatchOutcome> => {
+	const done = outcome.done.length;
+	const summary =
+		`${verb} ${done} issue${done === 1 ? '' : 's'}` +
+		(outcome.failed.length ? `, ${outcome.failed.length} failed` : '');
+
+	return done
+		? succeeded(summary, outcome)
+		: failed(
+				`${summary}: ${outcome.failed
+					.map(f => `${f.ref} ${f.reason}`)
+					.join('; ')}`,
+		  );
+};
+
+// Runs one write per target and sorts the outcomes. Each write persists on
+// its own: a rank is resolved against the state the write before it left, so
+// the saving is the round trip and the result in the caller's context, not
+// the persist.
+const forEachTarget = (
+	ids: string[],
+	write: (id: string) => Result<unknown>,
+): ApiBatchOutcome => {
+	const outcome: ApiBatchOutcome = {done: [], failed: []};
+
+	for (const id of ids) {
+		const result = write(id);
+		if (isFail(result)) {
+			outcome.failed.push({id, ref: nodeRef(id), reason: result.message});
+		} else {
+			outcome.done.push({id, ref: nodeRef(id)});
+		}
+	}
+
+	return outcome;
+};
+
+const findWritableIssue = (id: string): Result<Ticket> => {
+	const stateResult = getStateResult();
+	if (isFail(stateResult)) return stateResult;
+
+	const issue = stateResult.value.nodes[id];
+	if (!issue || issue.isDeleted) return failed('Issue not found');
+	if (!isTicketNode(issue)) return failed('Target must be an issue');
+	if (issue.readonly) return failed('Issue is readonly');
+
+	return succeeded('Found issue', issue);
+};
 
 export const listBoards = async (input: ToolInput = {}) => {
 	const bootResult = await boot(input.repoRoot, {pull: false});
@@ -815,46 +886,63 @@ export const createIssue = async (input: CreateIssueInput) => {
 	});
 };
 
-export const closeIssue = async (input: CloseIssueInput) => {
+const closeOne = (id: string, actor: Actor, stateBranchRoot: string) => {
+	const issueResult = findWritableIssue(id);
+	if (isFail(issueResult)) return issueResult;
+
+	const rankResult = resolveAndPersistRankForMove(
+		CLOSED_SWIMLANE_ID,
+		id,
+		{at: 'end'},
+		actor,
+		stateBranchRoot,
+	);
+	if (isFail(rankResult)) return rankResult;
+
+	const event = {
+		id: ulid(),
+		...actor,
+		action: 'close.issue',
+		payload: {
+			id,
+			parent: CLOSED_SWIMLANE_ID,
+			rank: rankResult.value,
+		},
+	} satisfies AppEvent<'close.issue'>;
+
+	const results = materializeAndPersistAll([event], stateBranchRoot);
+	if (isFail(results)) return failed(results.message);
+
+	return succeeded('Closed issue', {id, ref: nodeRef(id)});
+};
+
+type IssueRef = {id: string; ref: string};
+
+export function closeIssue(
+	input: CloseIssueInput & {issueIds: string[]},
+): Promise<Result<ApiBatchOutcome>>;
+export function closeIssue(input: CloseIssueInput): Promise<Result<IssueRef>>;
+export async function closeIssue(
+	input: CloseIssueInput,
+): Promise<Result<ApiBatchOutcome | IssueRef>> {
 	const bootResult = await boot(input.repoRoot, {pull: false});
 	if (isFail(bootResult)) return bootResult;
 
 	const actorResult = getActor();
 	if (isFail(actorResult)) return actorResult;
 
-	const rankResult = resolveAndPersistRankForMove(
-		CLOSED_SWIMLANE_ID,
-		input.issueId,
-		{at: 'end'},
-		actorResult.value,
-		bootResult.value.stateBranchRoot,
-	);
-	if (isFail(rankResult)) return rankResult;
+	const idsResult = targetIds(input);
+	if (isFail(idsResult)) return idsResult;
 
-	const event = {
-		id: ulid(),
-		...actorResult.value,
-		action: 'close.issue',
-		payload: {
-			id: input.issueId,
-			parent: CLOSED_SWIMLANE_ID,
-			rank: rankResult.value,
-		},
-	} satisfies AppEvent<'close.issue'>;
+	const close = (id: string) =>
+		closeOne(id, actorResult.value, bootResult.value.stateBranchRoot);
 
-	const results = materializeAndPersistAll(
-		[event],
-		bootResult.value.stateBranchRoot,
-	);
-	if (isFail(results)) return failed(results.message);
+	if (!input.issueIds) return close(idsResult.value[0]!);
 
-	return succeeded('Closed issue', {
-		id: input.issueId,
-		ref: nodeRef(input.issueId),
-	});
-};
+	return batchResult('Closed', forEachTarget(idsResult.value, close));
+}
 
-export const reopenIssue = async (input: CloseIssueInput) => {
+export const reopenIssue = async (input: ToolInput & {issueId: string}) => {
 	const bootResult = await boot(input.repoRoot, {pull: false});
 	if (isFail(bootResult)) return bootResult;
 
@@ -924,9 +1012,54 @@ export const reopenIssue = async (input: CloseIssueInput) => {
 	});
 };
 
-export const moveIssue = async (
+const moveOne = (
+	id: string,
 	input: MoveIssueInput,
-): Promise<Result<{id: string; parentId: string}>> => {
+	actor: Actor,
+	stateBranchRoot: string,
+) => {
+	const issueResult = findWritableIssue(id);
+	if (isFail(issueResult)) return issueResult;
+
+	const rankResult = resolveAndPersistRankForMove(
+		input.parentId,
+		id,
+		input.position ?? {at: 'end'},
+		actor,
+		stateBranchRoot,
+	);
+	if (isFail(rankResult)) return rankResult;
+
+	const event = {
+		id: ulid(),
+		...actor,
+		action: 'move.node',
+		payload: {
+			id,
+			parent: input.parentId,
+			rank: rankResult.value,
+		},
+	} satisfies AppEvent<'move.node'>;
+
+	const results = materializeAndPersistAll([event], stateBranchRoot);
+	if (isFail(results)) return failed(results.message);
+
+	return succeeded('Moved issue', {
+		id,
+		ref: nodeRef(id),
+		parentId: input.parentId,
+	});
+};
+
+export function moveIssue(
+	input: MoveIssueInput & {issueIds: string[]},
+): Promise<Result<ApiBatchOutcome>>;
+export function moveIssue(
+	input: MoveIssueInput,
+): Promise<Result<IssueRef & {parentId: string}>>;
+export async function moveIssue(
+	input: MoveIssueInput,
+): Promise<Result<ApiBatchOutcome | (IssueRef & {parentId: string})>> {
 	const repoRootResult = resolveRepoRoot(input.repoRoot);
 	if (isFail(repoRootResult)) return repoRootResult;
 
@@ -950,39 +1083,16 @@ export const moveIssue = async (
 	);
 	if (isFail(bootStateResult)) return bootStateResult;
 
-	const rankResult = resolveAndPersistRankForMove(
-		input.parentId,
-		input.issueId,
-		input.position ?? {at: 'end'},
-		actorResult.value,
-		stateBranchRootResult.value,
-	);
+	const idsResult = targetIds(input);
+	if (isFail(idsResult)) return idsResult;
 
-	if (isFail(rankResult)) return rankResult;
+	const move = (id: string) =>
+		moveOne(id, input, actorResult.value, stateBranchRootResult.value);
 
-	const event = {
-		id: ulid(),
-		...actorResult.value,
-		action: 'move.node',
-		payload: {
-			id: input.issueId,
-			parent: input.parentId,
-			rank: rankResult.value,
-		},
-	} satisfies AppEvent<'move.node'>;
+	if (!input.issueIds) return move(idsResult.value[0]!);
 
-	const results = materializeAndPersistAll(
-		[event],
-		stateBranchRootResult.value,
-	);
-	if (isFail(results)) return failed(results.message);
-
-	return succeeded('Moved issue', {
-		id: input.issueId,
-		ref: nodeRef(input.issueId),
-		parentId: input.parentId,
-	});
-};
+	return batchResult('Moved', forEachTarget(idsResult.value, move));
+}
 
 export const createSwimlane = async (input: CreateSwimlaneInput) => {
 	const bootResult = await boot(input.repoRoot, {pull: false});
@@ -1604,27 +1714,52 @@ export const editIssueTitle = async (input: EditIssueTitleInput) => {
 	});
 };
 
-export const addIssueTag = async (input: AddIssueTagInput) => {
+type TagRef = {tag: {id: string; name: string}};
+
+export function addIssueTag(
+	input: AddIssueTagInput & {issueIds: string[]},
+): Promise<Result<ApiBatchOutcome & TagRef>>;
+export function addIssueTag(
+	input: AddIssueTagInput,
+): Promise<Result<IssueRef & TagRef>>;
+export async function addIssueTag(
+	input: AddIssueTagInput,
+): Promise<Result<(ApiBatchOutcome & TagRef) | (IssueRef & TagRef)>> {
 	const bootResult = await boot(input.repoRoot, {pull: false});
 	if (isFail(bootResult)) return bootResult;
 
 	const actorResult = getActor();
 	if (isFail(actorResult)) return actorResult;
 
-	const stateResult = getStateResult();
-	if (isFail(stateResult)) return stateResult;
-
-	const issue = stateResult.value.nodes[input.issueId];
-
-	if (!issue) return failed('Issue not found');
-	if (!isTicketNode(issue)) return failed('Tag target must be an issue');
-	if (issue.readonly) return failed('Cannot tag readonly issue');
+	const idsResult = targetIds(input);
+	if (isFail(idsResult)) return idsResult;
 
 	const tagName = sanitizeInlineText(input.tagName).trim();
 	if (!tagName) return failed('Tag name cannot be empty');
 
 	const overLongTag = tooLong('Tag name', tagName, MAX_TAG_NAME_LENGTH);
 	if (overLongTag) return failed(overLongTag);
+
+	// Tagging needs no rank, so every target that checks out goes into one
+	// persist, behind the tag's creation if it is new.
+	const outcome: ApiBatchOutcome = {done: [], failed: []};
+
+	for (const id of idsResult.value) {
+		const issueResult = findWritableIssue(id);
+		if (isFail(issueResult)) {
+			outcome.failed.push({id, ref: nodeRef(id), reason: issueResult.message});
+		} else {
+			outcome.done.push({id, ref: nodeRef(id)});
+		}
+	}
+
+	if (!input.issueIds && outcome.failed[0]) {
+		return failed(outcome.failed[0].reason);
+	}
+
+	if (outcome.done.length === 0) {
+		return failed(batchResult('Tagged', outcome).message);
+	}
 
 	const existingTag = nodeRepo.findTagByName(tagName);
 
@@ -1644,15 +1779,18 @@ export const addIssueTag = async (input: AddIssueTagInput) => {
 						},
 					} satisfies AppEvent<'create.tag'>,
 			  ]),
-		{
-			id: ulid(),
-			...actorResult.value,
-			action: 'add.issue.tag',
-			payload: {
-				id: input.issueId,
-				tag: tagId,
-			},
-		} satisfies AppEvent<'add.issue.tag'>,
+		...outcome.done.map(
+			({id}) =>
+				({
+					id: ulid(),
+					...actorResult.value,
+					action: 'add.issue.tag',
+					payload: {
+						id,
+						tag: tagId,
+					},
+				} satisfies AppEvent<'add.issue.tag'>),
+		),
 	];
 
 	const results = materializeAndPersistAll(
@@ -1662,12 +1800,17 @@ export const addIssueTag = async (input: AddIssueTagInput) => {
 
 	if (isFail(results)) return failed(results.message);
 
-	return succeeded('Added issue tag', {
-		id: input.issueId,
-		ref: nodeRef(input.issueId),
-		tag: {id: tagId, name: tagName},
-	});
-};
+	const tag = {id: tagId, name: tagName};
+
+	if (!input.issueIds) {
+		return succeeded('Added issue tag', {...outcome.done[0]!, tag});
+	}
+
+	const batch = batchResult('Tagged', outcome);
+	return isFail(batch)
+		? batch
+		: succeeded(batch.message, {...batch.value, tag});
+}
 
 // Tombstone, not deletion: the id and every ticket reference survive in the
 // log; the tag just stops rendering anywhere, and its name is free again.

--- a/source/mcp/epiq-api.ts
+++ b/source/mcp/epiq-api.ts
@@ -74,6 +74,7 @@ import {logger} from '../logger.js';
 import {
 	ApiAssignee,
 	ApiIssue,
+	ApiIssueBrief,
 	ApiIssueComment,
 	ApiIssueDetail,
 	ApiState,
@@ -97,6 +98,11 @@ type MoveIssueInput = ToolInput & {
 type ListIssuesInput = ToolInput & {
 	includeClosed?: boolean;
 	boardId?: string;
+	swimlaneId?: string;
+	tag?: string;
+	assignee?: string;
+	query?: string;
+	brief?: boolean;
 };
 
 type ListSwimlanesInput = ToolInput & {
@@ -573,7 +579,16 @@ export const getIssue = async (input: GetIssueInput) => {
 	} satisfies ApiIssueDetail);
 };
 
-export const listIssues = async (input: ListIssuesInput) => {
+const sameName = (a: string, b: string) =>
+	a.trim().toLowerCase() === b.trim().toLowerCase();
+
+export function listIssues(
+	input: ListIssuesInput & {brief: true},
+): Promise<Result<ApiIssueBrief[]>>;
+export function listIssues(input: ListIssuesInput): Promise<Result<ApiIssue[]>>;
+export async function listIssues(
+	input: ListIssuesInput,
+): Promise<Result<ApiIssue[] | ApiIssueBrief[]>> {
 	const bootResult = await boot(input.repoRoot, {pull: false});
 	if (isFail(bootResult)) return bootResult;
 
@@ -581,8 +596,9 @@ export const listIssues = async (input: ListIssuesInput) => {
 	if (isFail(stateResult)) return stateResult;
 
 	const nodes = stateResult.value.nodes;
+	const query = input.query?.trim().toLowerCase();
 
-	const issues: ApiIssue[] = Object.values(nodes)
+	const tickets = Object.values(nodes)
 		.filter(isTicketNode)
 		.filter(n => !n.isDeleted)
 		.filter(n => input.includeClosed || n.parentNodeId !== CLOSED_SWIMLANE_ID)
@@ -591,7 +607,49 @@ export const listIssues = async (input: ListIssuesInput) => {
 			const swimlane = n.parentNodeId ? nodes[n.parentNodeId] : undefined;
 			return swimlane?.parentNodeId === input.boardId;
 		})
-		.map(
+		.filter(n => !input.swimlaneId || n.parentNodeId === input.swimlaneId)
+		.filter(
+			n =>
+				!input.tag ||
+				getIssueTags(n).some(tag => sameName(tag.name, input.tag!)),
+		)
+		.filter(
+			n =>
+				!input.assignee ||
+				getIssueAssignees(n).some(a => sameName(a.name, input.assignee!)),
+		)
+		.filter(
+			n =>
+				!query ||
+				n.title.toLowerCase().includes(query) ||
+				(n.props.description ?? '').toLowerCase().includes(query),
+		);
+
+	const swimlaneTitle = (n: Ticket) =>
+		sanitizeInlineText(
+			(n.parentNodeId ? nodes[n.parentNodeId]?.title : undefined) ?? '',
+		);
+
+	if (input.brief) {
+		return succeeded(
+			'Listed issues',
+			tickets.map(
+				n =>
+					({
+						id: n.id,
+						ref: nodeRef(n.id),
+						title: sanitizeInlineText(n.title),
+						swimlane: swimlaneTitle(n),
+						tags: getIssueTags(n).map(tag => tag.name),
+						assignees: getIssueAssignees(n).map(a => a.name),
+					} satisfies ApiIssueBrief),
+			),
+		);
+	}
+
+	return succeeded(
+		'Listed issues',
+		tickets.map(
 			n =>
 				({
 					id: n.id,
@@ -605,10 +663,9 @@ export const listIssues = async (input: ListIssuesInput) => {
 					tags: getIssueTags(n),
 					assignees: getIssueAssignees(n),
 				} satisfies ApiIssue),
-		);
-
-	return succeeded('Listed issues', issues);
-};
+		),
+	);
+}
 
 export const createIssue = async (input: CreateIssueInput) => {
 	const bootResult = await boot(input.repoRoot, {pull: false});

--- a/source/mcp/server.ts
+++ b/source/mcp/server.ts
@@ -103,7 +103,7 @@ export const createMcpServer = () => {
 		'epiq_issue_get',
 		{
 			description:
-				'Get one Epiq issue by its full id or its 7-character ref. Use this rather than listing the whole board when you already know which issue you want.',
+				'Get one Epiq issue by its full id or its 7-character ref, with its comments in log order. Use this rather than listing the whole board when you already know which issue you want, and rather than epiq_state_get to read a thread.',
 			inputSchema: z.object({
 				idOrRef: z.string().min(1),
 				repoRoot: z.string().optional(),

--- a/source/mcp/server.ts
+++ b/source/mcp/server.ts
@@ -259,9 +259,10 @@ export const createMcpServer = () => {
 		'epiq_issue_tag_add',
 		{
 			description:
-				'Add a tag to an Epiq issue, creating the tag if it does not exist',
+				'Add a tag to an Epiq issue, or to many at once with issueIds, creating the tag if it does not exist',
 			inputSchema: z.object({
-				issueId: z.string().min(1),
+				issueId: z.string().min(1).optional(),
+				issueIds: z.array(z.string().min(1)).min(1).max(200).optional(),
 				tagName: z.string().min(1).max(MAX_TAG_NAME_LENGTH),
 				repoRoot: z.string().optional(),
 			}),
@@ -451,9 +452,11 @@ export const createMcpServer = () => {
 	server.registerTool(
 		'epiq_issue_close',
 		{
-			description: 'Close an Epiq issue',
+			description:
+				'Close an Epiq issue, or many at once with issueIds — one call, an outcome per ticket',
 			inputSchema: z.object({
-				issueId: z.string().min(1),
+				issueId: z.string().min(1).optional(),
+				issueIds: z.array(z.string().min(1)).min(1).max(200).optional(),
 				repoRoot: z.string().optional(),
 			}),
 		},
@@ -463,9 +466,11 @@ export const createMcpServer = () => {
 	server.registerTool(
 		'epiq_issue_move',
 		{
-			description: 'Move an Epiq issue to another swimlane',
+			description:
+				'Move an Epiq issue to another swimlane, or many at once with issueIds — one call, an outcome per ticket',
 			inputSchema: z.object({
-				issueId: z.string().min(1),
+				issueId: z.string().min(1).optional(),
+				issueIds: z.array(z.string().min(1)).min(1).max(200).optional(),
 				parentId: z.string().min(1),
 				position: z
 					.discriminatedUnion('at', [

--- a/source/mcp/server.ts
+++ b/source/mcp/server.ts
@@ -89,11 +89,16 @@ export const createMcpServer = () => {
 		'epiq_issue_list',
 		{
 			description:
-				'List Epiq issues. Pass boardId to scope results to a single board and reduce response size.',
+				'List Epiq issues. Narrow with boardId, swimlaneId, tag, assignee or query (matched against title and description), and pass brief to get id, ref, title, swimlane, tag names and assignee names only — descriptions are the bulk of a board. Read one ticket with epiq_issue_get.',
 			inputSchema: z.object({
 				repoRoot: z.string().optional(),
 				includeClosed: z.boolean().optional(),
 				boardId: z.string().optional(),
+				swimlaneId: z.string().optional(),
+				tag: z.string().optional(),
+				assignee: z.string().optional(),
+				query: z.string().optional(),
+				brief: z.boolean().optional(),
 			}),
 		},
 		exclusiveTool(listIssues),

--- a/source/mcp/test/epiq-api.test.ts
+++ b/source/mcp/test/epiq-api.test.ts
@@ -823,6 +823,65 @@ describe('mcp tools', () => {
 		}
 	});
 
+	describe('listIssues narrowing', () => {
+		const ids = async (input: Parameters<typeof tools.listIssues>[0]) => {
+			const result = await tools.listIssues(input);
+			expect(isFail(result)).toBe(false);
+			if (isFail(result)) return [];
+			return result.value.map(issue => issue.id).sort();
+		};
+
+		it('narrows to one swimlane', async () => {
+			expect(await ids({repoRoot: '/repo', swimlaneId: 'swimlane-1'})).toEqual([
+				'01H0000000000000000ABCDEFG',
+				fixtureId('issue-1'),
+			]);
+		});
+
+		it('narrows by tag name, whatever its case', async () => {
+			expect(await ids({repoRoot: '/repo', tag: 'BUG'})).toEqual([
+				fixtureId('issue-1'),
+			]);
+		});
+
+		it('narrows by assignee name', async () => {
+			expect(await ids({repoRoot: '/repo', assignee: 'alice'})).toEqual([
+				fixtureId('issue-1'),
+			]);
+		});
+
+		it('matches a query against the title and the description', async () => {
+			expect(await ids({repoRoot: '/repo', query: 'distinct'})).toEqual([
+				'01H0000000000000000ABCDEFG',
+			]);
+			expect(await ids({repoRoot: '/repo', query: 'bug description'})).toEqual([
+				fixtureId('issue-1'),
+			]);
+		});
+
+		// A list is scanned, not read: the descriptions are most of a board's
+		// bytes and rarely what the caller came for.
+		it('brief drops the description and names tags, assignees and the lane', async () => {
+			const result = await tools.listIssues({
+				repoRoot: '/repo',
+				swimlaneId: 'swimlane-1',
+				brief: true,
+			});
+
+			expect(isFail(result)).toBe(false);
+			if (isFail(result)) return;
+			expect(result.value).toContainEqual({
+				id: fixtureId('issue-1'),
+				ref: nodeRef(fixtureId('issue-1')),
+				title: 'Fix bug',
+				swimlane: 'Todo',
+				tags: ['bug'],
+				assignees: ['Alice'],
+			});
+			expect(result.value.every(issue => !('description' in issue))).toBe(true);
+		});
+	});
+
 	it('excludes deleted (tombstoned) nodes from boards, swimlanes, and issues', async () => {
 		const boards = await tools.listBoards({repoRoot: '/repo'});
 		const swimlanes = await tools.listSwimlanes({repoRoot: '/repo'});

--- a/source/mcp/test/epiq-api.test.ts
+++ b/source/mcp/test/epiq-api.test.ts
@@ -1151,6 +1151,106 @@ describe('mcp tools', () => {
 		);
 	});
 
+	// A release sweep is dozens of closes; one call for them, and a miss in the
+	// middle does not stop the rest.
+	describe('many tickets in one call', () => {
+		it('closes each target on its own and reports the ones it could not', async () => {
+			const result = await tools.closeIssue({
+				repoRoot: '/repo',
+				issueIds: [
+					fixtureId('issue-1'),
+					fixtureId('nope'),
+					fixtureId('issue-2'),
+				],
+			});
+
+			expect(isFail(result)).toBe(false);
+			if (isFail(result)) return;
+			expect(result.message).toBe('Closed 2 issues, 1 failed');
+			expect(result.value.done.map(d => d.id)).toEqual([
+				fixtureId('issue-1'),
+				fixtureId('issue-2'),
+			]);
+			expect(result.value.failed).toEqual([
+				{
+					id: fixtureId('nope'),
+					ref: nodeRef(fixtureId('nope')),
+					reason: 'Issue not found',
+				},
+			]);
+			expect(persistModule.materializeAndPersistAll).toHaveBeenCalledTimes(2);
+		});
+
+		it('fails outright when no target went through', async () => {
+			const result = await tools.closeIssue({
+				repoRoot: '/repo',
+				issueIds: [fixtureId('nope')],
+			});
+
+			expect(isFail(result)).toBe(true);
+			if (!isFail(result)) return;
+			expect(result.message).toContain('Closed 0 issues, 1 failed');
+			expect(persistModule.materializeAndPersistAll).not.toHaveBeenCalled();
+		});
+
+		it('moves each target', async () => {
+			const result = await tools.moveIssue({
+				repoRoot: '/repo',
+				issueIds: [fixtureId('issue-1'), '01H0000000000000000ABCDEFG'],
+				parentId: 'swimlane-2',
+			});
+
+			expect(isFail(result)).toBe(false);
+			if (isFail(result)) return;
+			expect(result.value.done).toHaveLength(2);
+			expect(result.value.failed).toEqual([]);
+			expect(persistModule.materializeAndPersistAll).toHaveBeenCalledTimes(2);
+		});
+
+		it('tags every target in one persist, behind the tag it creates', async () => {
+			const result = await tools.addIssueTag({
+				repoRoot: '/repo',
+				issueIds: [
+					fixtureId('issue-1'),
+					fixtureId('nope'),
+					'01H0000000000000000ABCDEFG',
+				],
+				tagName: 'urgent',
+			});
+
+			expect(isFail(result)).toBe(false);
+			if (isFail(result)) return;
+			expect(result.value.done).toHaveLength(2);
+			expect(result.value.failed.map(f => f.id)).toEqual([fixtureId('nope')]);
+			expect(result.value.tag.name).toBe('urgent');
+			expect(persistModule.materializeAndPersistAll).toHaveBeenCalledTimes(1);
+			expect(persistModule.materializeAndPersistAll).toHaveBeenCalledWith(
+				[
+					expect.objectContaining({action: 'create.tag'}),
+					expect.objectContaining({
+						action: 'add.issue.tag',
+						payload: expect.objectContaining({id: fixtureId('issue-1')}),
+					}),
+					expect.objectContaining({
+						action: 'add.issue.tag',
+						payload: expect.objectContaining({
+							id: '01H0000000000000000ABCDEFG',
+						}),
+					}),
+				],
+				'/state',
+			);
+		});
+
+		it('asks for a target when given none', async () => {
+			const result = await tools.closeIssue({repoRoot: '/repo'});
+
+			expect(isFail(result)).toBe(true);
+			if (!isFail(result)) return;
+			expect(result.message).toBe('Provide issueId or issueIds');
+		});
+	});
+
 	it('moves an issue', async () => {
 		const result = await tools.moveIssue({
 			repoRoot: '/repo',

--- a/source/mcp/test/epiq-api.test.ts
+++ b/source/mcp/test/epiq-api.test.ts
@@ -431,6 +431,7 @@ let tools: typeof import('../epiq-api.js');
 let persistModule: typeof import('../../lib/event/event-materialize-and-persist.js');
 let timeTravelModule: typeof import('../epiq-time-travel.js');
 let gitUtilsModule: typeof import('../../git/git-utils.js');
+let nodeRepoModule: typeof import('../../lib/repository/node-repo.js');
 
 beforeAll(async () => {
 	tools = await import('../epiq-api.js');
@@ -439,6 +440,7 @@ beforeAll(async () => {
 	);
 	timeTravelModule = await import('../epiq-time-travel.js');
 	gitUtilsModule = await import('../../git/git-utils.js');
+	nodeRepoModule = await import('../../lib/repository/node-repo.js');
 });
 
 describe('mcp tools', () => {
@@ -530,6 +532,51 @@ describe('mcp tools', () => {
 			if (isFail(result)) return;
 			expect(result.value.id).toBe(fixtureId('issue-1'));
 			expect(result.value.ref).toBe(nodeRef(fixtureId('issue-1')));
+		});
+
+		// The skill tells an agent to read a thread before starting; without this
+		// the only tool that carried a comment was the whole state.
+		it('carries the comments in log order, named by their author', async () => {
+			vi.mocked(nodeRepoModule.nodeRepo.getCommentsByIssue).mockReturnValueOnce(
+				[
+					{
+						id: fixtureId('comment-2'),
+						issue: fixtureId('issue-1'),
+						authorId: 'nobody',
+						authorName: 'Bob',
+						md: 'Second',
+					},
+					{
+						id: fixtureId('comment-1'),
+						issue: fixtureId('issue-1'),
+						authorId: 'contributor-1',
+						authorName: 'Alice',
+						md: 'First',
+					},
+				],
+			);
+
+			const result = await tools.getIssue({
+				repoRoot: '/repo',
+				idOrRef: fixtureId('issue-1'),
+			});
+
+			expect(isFail(result)).toBe(false);
+			if (isFail(result)) return;
+			expect(result.value.comments).toEqual([
+				{
+					id: fixtureId('comment-1'),
+					author: 'Alice',
+					createdAt: expect.any(Number),
+					body: 'First',
+				},
+				{
+					id: fixtureId('comment-2'),
+					author: 'Bob',
+					createdAt: expect.any(Number),
+					body: 'Second',
+				},
+			]);
 		});
 
 		// The inverse of the commit-prefix convention: ref in, ticket out.


### PR DESCRIPTION
Three tickets, one commit each, from a session that spent most of its board tokens working around the MCP layer:

- **DP4KEMF** `epiq_issue_get` carries the ticket's comments in log order. The skill tells an agent to read a thread before starting, and the only tool that carried a comment was `epiq_state_get`.
- **N8GXRCF** `epiq_issue_list` narrows by `swimlaneId`, `tag`, `assignee` or `query` on the server, and `brief: true` returns id, ref, title, lane, tag names and assignee names without the descriptions.
- **4Y91XAX** `epiq_issue_close`, `epiq_issue_move` and `epiq_issue_tag_add` take `issueIds` and return an outcome per ticket. Close and move persist per ticket because each rank is resolved against the state the previous write left; tagging persists once.

Single-id calls keep their existing response shapes.