### PR TITLE
VPR4FJ5 park a stray hover arrow before the log snaps to its foot

### DIFF
--- a/source/gui/client/components/EventLog.tsx
+++ b/source/gui/client/components/EventLog.tsx
@@ -217,6 +217,29 @@ const EventLogPanel = ({
 		return () => observer.disconnect();
 	}, [bottomClearance]);
 
+	// The arrow that marks the row under the pointer is one node for the whole
+	// panel, carried to whichever row that is. Moved through its ref rather
+	// than by state: hovering sweeps across rows, and re-rendering the column
+	// at every one of them is the cost this panel is built to avoid.
+	const arrowRef = useRef<HTMLSpanElement>(null);
+
+	// An absolutely positioned child extends the pane's scrollable overflow,
+	// hidden or not. So an arrow left on a row the column has since lost is a
+	// stretch of empty pane below the last line, and a snap to the foot lands in
+	// it — showing nothing until the log grows back down to where the row was.
+	// Called before either snap above: past the end of the column the arrow
+	// marks nothing, and goes back to the top where it takes no room.
+	const parkStrayArrow = () => {
+		const arrow = arrowRef.current;
+		const column = columnRef.current;
+		if (!arrow || !column) return;
+
+		if (arrow.offsetTop < column.offsetTop + column.offsetHeight) return;
+
+		arrow.style.top = '0px';
+		arrow.style.opacity = '0';
+	};
+
 	// Before paint, so a line arriving never shows the pane a frame out of place.
 	// Only while the reader is at the foot: scrolled back, the log is something
 	// being read, and pulling it to the bottom would take that away.
@@ -224,6 +247,7 @@ const EventLogPanel = ({
 		const pane = scrollRef.current;
 		if (!pane || !pinnedRef.current) return;
 
+		parkStrayArrow();
 		pane.scrollTop = pane.scrollHeight;
 	}, [newestId, days.length, foldOverrides, openCount]);
 
@@ -238,6 +262,7 @@ const EventLogPanel = ({
 		if (!pane) return;
 
 		pinnedRef.current = true;
+		parkStrayArrow();
 		pane.scrollTop = pane.scrollHeight;
 	}, [moment]);
 
@@ -276,12 +301,6 @@ const EventLogPanel = ({
 		// rebuilt every render: the crawl moves when the log does, not when the
 		// board beside it repaints.
 	}, [newestId, animate]);
-
-	// The arrow that marks the row under the pointer is one node for the whole
-	// panel, carried to whichever row that is. Moved through its ref rather
-	// than by state: hovering sweeps across rows, and re-rendering the column
-	// at every one of them is the cost this panel is built to avoid.
-	const arrowRef = useRef<HTMLSpanElement>(null);
 
 	const markRow = (target: EventTarget | null) => {
 		const arrow = arrowRef.current;

--- a/source/test/e2e-gui/event-log.pw.ts
+++ b/source/test/e2e-gui/event-log.pw.ts
@@ -407,3 +407,65 @@ test('moving the timeline takes the log to its foot, wherever it was', async ({
 	await returnToLive(page);
 	expect(pageErrors).toEqual([]);
 });
+
+// The hover arrow is positioned inside the scroll pane, and a positioned child
+// holds the pane's overflow open wherever it is left. Hovered onto a row deep
+// in a tall log and then orphaned by a movie emptying the column, it used to
+// leave the foot snap scrolled into a stretch of nothing until the log grew
+// back down to it.
+test('an arrow left below the fold does not hold the pane open when the log empties', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await page.setViewportSize({width: 1280, height: 420});
+	await openBoard(page, appUrl);
+	const boardUrl = page.url();
+
+	const stamp = Date.now();
+	for (let index = 0; index < 10; index++) {
+		await page.getByTitle('Add issue').first().click();
+		await page.getByPlaceholder('issue name').fill(`Arrow ${stamp}-${index}`);
+		await page.getByPlaceholder('issue name').press('Enter');
+		await expect(page.locator('aside')).toContainText(
+			`Arrow ${stamp}-${index}`,
+		);
+	}
+	await page.goto(boardUrl);
+
+	await page.getByTestId('log-toggle').click();
+	const lines = page.getByTestId('log-line');
+	await expect.poll(async () => await lines.count()).toBeGreaterThan(10);
+
+	const overflow = () =>
+		page.evaluate(`
+(() => {
+	const pane = document.querySelector('[data-testid="event-log-scroll"]');
+	return pane.scrollHeight - pane.clientHeight;
+})()
+`) as Promise<number>;
+
+	// The premise: the log is taller than the pane, so the newest row sits
+	// below where the pane's foot will be once the column is empty.
+	await expect.poll(overflow).toBeGreaterThan(0);
+	await lines.last().hover();
+	await expect(page.getByTestId('log-row-arrow')).toHaveCSS('opacity', '1');
+	await page.mouse.move(900, 300);
+
+	// A movie opens on the board before any of its events, with an empty log.
+	// The pane has nothing to overflow with then — unless the arrow is holding
+	// it open from where the last row used to be.
+	await page.getByTestId('theatre-play').click();
+	await expect(page.getByTestId('theatre-player')).toBeVisible();
+	await page.getByTestId('theatre-toggle').click();
+	await expect(page.getByTestId('theatre-toggle')).toHaveAttribute(
+		'aria-label',
+		'Play',
+	);
+
+	await expect.poll(overflow).toBe(0);
+
+	await returnToLive(page);
+	await page.getByTestId('log-toggle').click();
+	expect(pageErrors).toEqual([]);
+});


### PR DESCRIPTION
Ticket VPR4FJ5: with the log panel open, a movie played over an empty pane until the log had grown halfway back.

The one-node hover arrow is absolutely positioned inside the scroll pane at the hovered row's offset, and an absolutely positioned child holds the pane's scrollable overflow open even at opacity 0. Hover a row deep in a tall log, start a movie: the rows go, the arrow stays thousands of pixels down, and the foot snap scrolls into that empty overflow. Folding a day after hovering below the fold did the same at a smaller scale.

Before either snap, an arrow past the end of the column is parked back at the top, where it takes no room. Regression test in event-log.pw.ts, red without the fix (overflow 54 px on an empty log), green with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)