### PR TITLE
MBB6WY5 1E41HXN bound the log in bytes and keep the SEA bundle out of stack frames

### DIFF
--- a/source/logger.ts
+++ b/source/logger.ts
@@ -5,7 +5,14 @@ import {isFail} from './lib/model/result-types.js';
 import {EPIQ_DIR_NAME, resolveClosestEpiqRoot} from './lib/storage/paths.js';
 import {LogLevel} from './lib/state/settings.state.js';
 
-const MAX_LINES = 1000;
+export const MAX_LINES = 1000;
+// One message may span many lines (a stack trace does), so the file is bounded
+// in bytes as well: a log past V8's string cap cannot be read back to trim it,
+// and a trim that throws inside the logger takes the whole app down with it.
+export const MAX_BYTES = 4 * 1024 * 1024;
+// Caps a single message, so one dump of a large object or a deep stack cannot
+// eat the whole horizon on its own.
+export const MAX_MESSAGE_CHARS = 16 * 1024;
 const TRIM_EVERY_N_WRITES = 50;
 
 let writesSinceTrim = 0;
@@ -27,45 +34,83 @@ const getLogPath = () => {
 	return path.join(epiqRootDirResult.value, EPIQ_DIR_NAME, 'log', 'epiq.log');
 };
 
-function enforceLogHorizon() {
-	const logPath = getLogPath();
+// The last `maxBytes` of the file, starting at a line boundary, without
+// decoding what comes before them.
+const readTail = (filePath: string, maxBytes: number): string => {
+	const size = fs.statSync(filePath).size;
 
-	if (!logPath) return;
+	if (size <= maxBytes) {
+		return fs.readFileSync(filePath, 'utf8');
+	}
+
+	const fd = fs.openSync(filePath, 'r');
+	try {
+		const buffer = Buffer.alloc(maxBytes);
+		fs.readSync(fd, buffer, 0, maxBytes, size - maxBytes);
+		const text = buffer.toString('utf8');
+		const firstNewline = text.indexOf('\n');
+
+		return firstNewline === -1 ? '' : text.slice(firstNewline + 1);
+	} finally {
+		fs.closeSync(fd);
+	}
+};
+
+export function enforceLogHorizon(logPath: string) {
 	if (!fs.existsSync(logPath)) return;
 
-	const content = fs.readFileSync(logPath, 'utf8');
-	const lines = content.split('\n');
+	const size = fs.statSync(logPath).size;
+	const lines = readTail(logPath, MAX_BYTES).split('\n');
 
 	if (lines[lines.length - 1] === '') {
 		lines.pop();
 	}
 
-	if (lines.length <= MAX_LINES) return;
+	if (size <= MAX_BYTES && lines.length <= MAX_LINES) return;
 
 	const trimmed = lines.slice(-MAX_LINES).join('\n') + '\n';
 
 	fs.writeFileSync(logPath, trimmed, 'utf8');
 }
 
+const clip = (message: string): string => {
+	if (message.length <= MAX_MESSAGE_CHARS) return message;
+
+	const dropped = message.length - MAX_MESSAGE_CHARS;
+
+	return `${message.slice(0, MAX_MESSAGE_CHARS)} … [${dropped} more chars]`;
+};
+
 function write(prefix: string, args: unknown[], short = false) {
 	const logPath = getLogPath();
 	if (!logPath) return;
 
-	const message = util.format(...args);
+	const message = clip(util.format(...args));
 	const now = new Date();
 
 	const timestamp = short ? now.toISOString().slice(11, 19) : now.toISOString();
 
 	const line = `[${timestamp}] ${prefix} ${message}\n`;
 
-	fs.mkdirSync(path.dirname(logPath), {recursive: true});
-	fs.appendFileSync(logPath, line, 'utf8');
+	// A log that cannot be written or trimmed is not a reason to take the app
+	// down: the callers are already on an error path or in a render.
+	try {
+		fs.mkdirSync(path.dirname(logPath), {recursive: true});
+		fs.appendFileSync(logPath, line, 'utf8');
 
-	writesSinceTrim++;
+		writesSinceTrim++;
 
-	if (writesSinceTrim >= TRIM_EVERY_N_WRITES) {
-		writesSinceTrim = 0;
-		enforceLogHorizon();
+		// The byte cap is checked on every write, not every fiftieth: a log
+		// inherited from an older build may already be far past it.
+		if (
+			writesSinceTrim >= TRIM_EVERY_N_WRITES ||
+			fs.statSync(logPath).size > MAX_BYTES
+		) {
+			writesSinceTrim = 0;
+			enforceLogHorizon(logPath);
+		}
+	} catch {
+		// Dropped on purpose.
 	}
 }
 
@@ -107,5 +152,3 @@ export const logger = {
 };
 
 (globalThis as {logger?: typeof logger}).logger = logger;
-
-export {};

--- a/source/scripts/build-sea.mjs
+++ b/source/scripts/build-sea.mjs
@@ -97,7 +97,14 @@ writeFileSync(resolve(root, 'dist/sea-inner.js'), inner);
 console.log('\n[3/7] Creating CJS bootstrap...');
 const esmCode = readFileSync(resolve(root, 'dist/sea-inner.js'), 'utf8');
 const b64 = Buffer.from(esmCode).toString('base64');
+// Installed before the import so that no stack ever names the data: URL.
+const stackTrace = readFileSync(
+	resolve(root, 'source/scripts/sea-stack-trace.cjs'),
+	'utf8',
+).replace(/^'use strict';\n/, '');
 const cjsWrapper = `'use strict';
+${stackTrace}
+Error.prepareStackTrace = prepareStackTrace;
 const {pathToFileURL} = require('node:url');
 process.env.__EPIQ_SEA_URL__ = pathToFileURL(process.execPath).href;
 (async () => {

--- a/source/scripts/sea-stack-trace.cjs
+++ b/source/scripts/sea-stack-trace.cjs
@@ -1,0 +1,32 @@
+'use strict';
+// The SEA bootstrap (build-sea.mjs) loads the app from a data: URL, so V8
+// names the script by that URL and every stack frame would carry the whole
+// base64 bundle: one logged error is tens of megabytes, and a crash pasted
+// into a terminal is unreadable. This formats stacks the way Node does and
+// swaps the bundle URL for a short name.
+//
+// Inlined into the bootstrap as plain script, so it must not depend on
+// `module` or `require`.
+/* global module */
+const SEA_BUNDLE_URL = /data:application\/javascript;base64,[A-Za-z0-9+/=]+/g;
+const SEA_BUNDLE_NAME = 'epiq-sea';
+
+function prepareStackTrace(error, callSites) {
+	let header;
+	try {
+		header = Error.prototype.toString.call(error);
+	} catch {
+		header = 'Error';
+	}
+
+	const lines = [header];
+	for (const site of callSites) {
+		lines.push(`    at ${site}`);
+	}
+
+	return lines.join('\n').replace(SEA_BUNDLE_URL, SEA_BUNDLE_NAME);
+}
+
+if (typeof module === 'object' && module.exports) {
+	module.exports = {prepareStackTrace, SEA_BUNDLE_NAME};
+}

--- a/source/test/logger.test.ts
+++ b/source/test/logger.test.ts
@@ -1,0 +1,98 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {
+	enforceLogHorizon,
+	logger,
+	MAX_BYTES,
+	MAX_LINES,
+	MAX_MESSAGE_CHARS,
+} from '../logger.js';
+
+const originalCwd = process.cwd();
+let root: string;
+let logPath: string;
+
+beforeEach(() => {
+	root = fs.mkdtempSync(path.join(os.tmpdir(), 'epiq-logger-'));
+	fs.mkdirSync(path.join(root, '.epiq'));
+	logPath = path.join(root, '.epiq', 'log', 'epiq.log');
+	process.chdir(root);
+});
+
+afterEach(() => {
+	process.chdir(originalCwd);
+	fs.rmSync(root, {recursive: true, force: true});
+});
+
+const lineOf = (chars: number, fill = 'x') => fill.repeat(chars) + '\n';
+
+describe('enforceLogHorizon', () => {
+	it('keeps a log under both caps as it is', () => {
+		const content = lineOf(10).repeat(MAX_LINES);
+		fs.mkdirSync(path.dirname(logPath), {recursive: true});
+		fs.writeFileSync(logPath, content);
+
+		enforceLogHorizon(logPath);
+
+		expect(fs.readFileSync(logPath, 'utf8')).toBe(content);
+	});
+
+	it('trims to the last lines when the line cap is passed', () => {
+		fs.mkdirSync(path.dirname(logPath), {recursive: true});
+		fs.writeFileSync(
+			logPath,
+			lineOf(3, 'a').repeat(20) + lineOf(3, 'b').repeat(MAX_LINES),
+		);
+
+		enforceLogHorizon(logPath);
+
+		const lines = fs.readFileSync(logPath, 'utf8').split('\n');
+		expect(lines.pop()).toBe('');
+		expect(lines).toHaveLength(MAX_LINES);
+		expect(lines.every(line => line === 'bbb')).toBe(true);
+	});
+
+	it('trims by bytes when a few long lines pass the byte cap', () => {
+		// Well under the line cap, well over the byte cap: what a handful of
+		// multi-megabyte stack traces did to a real log.
+		const longLine = lineOf(MAX_BYTES / 2);
+		fs.mkdirSync(path.dirname(logPath), {recursive: true});
+		fs.writeFileSync(logPath, longLine.repeat(5) + lineOf(5, 'y'));
+
+		enforceLogHorizon(logPath);
+
+		const kept = fs.readFileSync(logPath, 'utf8');
+		expect(Buffer.byteLength(kept)).toBeLessThanOrEqual(MAX_BYTES);
+		// The cut lands on a line boundary, so a partial line is dropped.
+		expect(kept).toBe(longLine + lineOf(5, 'y'));
+	});
+});
+
+describe('logger', () => {
+	it('clips a single oversized message', () => {
+		logger.info('x'.repeat(MAX_MESSAGE_CHARS * 3));
+
+		const written = fs.readFileSync(logPath, 'utf8');
+		expect(written.length).toBeLessThan(MAX_MESSAGE_CHARS + 200);
+		expect(written).toContain(`[${MAX_MESSAGE_CHARS * 2} more chars]`);
+	});
+
+	it('trims an inherited oversized log on the next write', () => {
+		fs.mkdirSync(path.dirname(logPath), {recursive: true});
+		fs.writeFileSync(logPath, lineOf(MAX_BYTES / 2).repeat(3));
+
+		logger.info('hello');
+
+		expect(fs.statSync(logPath).size).toBeLessThanOrEqual(MAX_BYTES);
+		expect(fs.readFileSync(logPath, 'utf8')).toContain('[Info] hello');
+	});
+
+	it('never throws when the log cannot be written', () => {
+		// A file where the log directory should be: mkdir and append both fail.
+		fs.writeFileSync(path.join(root, '.epiq', 'log'), '');
+
+		expect(() => logger.error('boom')).not.toThrow();
+	});
+});

--- a/source/test/sea-stack-trace.test.ts
+++ b/source/test/sea-stack-trace.test.ts
@@ -1,0 +1,66 @@
+import fs from 'node:fs';
+import {createRequire} from 'node:module';
+import path from 'node:path';
+import vm from 'node:vm';
+import {afterEach, describe, expect, it} from 'vitest';
+
+const require = createRequire(import.meta.url);
+const sourcePath = path.resolve(
+	import.meta.dirname,
+	'../scripts/sea-stack-trace.cjs',
+);
+const {prepareStackTrace, SEA_BUNDLE_NAME} = require(sourcePath) as {
+	prepareStackTrace: NonNullable<typeof Error.prepareStackTrace>;
+	SEA_BUNDLE_NAME: string;
+};
+
+// What the SEA bootstrap imports: the whole app, base64-encoded.
+const bundleUrl = `data:application/javascript;base64,${Buffer.from(
+	'x'.repeat(4096),
+).toString('base64')}`;
+
+const throwFromBundle = () =>
+	vm.runInThisContext('(function boom() { throw new Error("nope"); })', {
+		filename: bundleUrl,
+	}) as () => never;
+
+const previous = Error.prepareStackTrace;
+
+afterEach(() => {
+	Error.prepareStackTrace = previous;
+});
+
+describe('sea-stack-trace', () => {
+	it('names the bundle instead of repeating its data: URL in every frame', () => {
+		Error.prepareStackTrace = prepareStackTrace;
+
+		let stack = '';
+		try {
+			throwFromBundle()();
+		} catch (error) {
+			stack = (error as Error).stack ?? '';
+		}
+
+		expect(stack.startsWith('Error: nope\n    at boom (')).toBe(true);
+		expect(stack).toContain(`${SEA_BUNDLE_NAME}:1:`);
+		expect(stack).not.toContain('base64');
+		expect(stack.length).toBeLessThan(4096);
+	});
+
+	it('installs as the plain script the bootstrap inlines it as', () => {
+		const source = fs.readFileSync(sourcePath, 'utf8');
+
+		// Module scope, as in the CJS bootstrap: no `module`, no `require`.
+		vm.runInThisContext(
+			`(() => {\n${source}\nError.prepareStackTrace = prepareStackTrace;\n})()`,
+			{filename: 'sea.cjs'},
+		);
+
+		expect(Error.prepareStackTrace).not.toBe(previous);
+		expect(() => throwFromBundle()()).toThrow(
+			expect.objectContaining({
+				stack: expect.stringContaining(`${SEA_BUNDLE_NAME}:1:`),
+			}),
+		);
+	});
+});


### PR DESCRIPTION
Two tickets, one commit each.

**MBB6WY5** — TUI crashes with `ERR_STRING_TOO_LONG` once `.epiq/log/epiq.log` passes 512 MB. The horizon was 1000 lines, so multi-megabyte lines let the log reach a gigabyte; `enforceLogHorizon` then re-read it as one string, threw inside `logger.error`, and took the app down. Now the log is capped in bytes as well (4 MB, trimmed from the tail without decoding the whole file), each message is clipped at 16 KB, the byte cap is checked on every write so an inherited oversized log is trimmed on the next one, and a log write can never throw.

**1E41HXN** — the SEA bootstrap imports the app from a `data:` URL, so V8 named the script by that URL and every stack frame carried the whole 1.9 MB base64 bundle. A `prepareStackTrace` hook, inlined into the bootstrap, formats stacks as Node does and names the bundle `epiq-sea`. Verified with a rebuilt binary: frames read `at Ic (epiq-sea:390:271)` and the longest log line is a few hundred characters.

Tests: `source/test/logger.test.ts`, `source/test/sea-stack-trace.test.ts`; `npm test` green. The local gate's one failure was a scrubber drag test that passes alone; the machine was at load 15 with other Playwright runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CoXCuo1BiXNR5g4NnxGN15