### PR TITLE
7J7HKSA drop the :coffee command from the TUI

### DIFF
--- a/source/lib/command-line/cmd-keywords.ts
+++ b/source/lib/command-line/cmd-keywords.ts
@@ -32,8 +32,6 @@ export const CmdKeywords = {
 
 	EXPORT: 'export',
 
-	COFFEE: 'coffee',
-
 	NONE: '',
 } as const;
 export type CmdKeyword = (typeof CmdKeywords)[keyof typeof CmdKeywords];

--- a/source/lib/command-line/command-intent.ts
+++ b/source/lib/command-line/command-intent.ts
@@ -14,9 +14,6 @@ export const getCommandIntent = (command: string): CommandIntent => {
 		case CmdKeywords.EXPORT:
 			return CmdIntent.Export;
 
-		case CmdKeywords.COFFEE:
-			return CmdIntent.Coffee;
-
 		case CmdKeywords.INIT:
 			return CmdIntent.Init;
 
@@ -117,5 +114,4 @@ export const CmdIntent = {
 	Sync: 'sync',
 
 	Export: 'export',
-	Coffee: 'coffee',
 } as const;

--- a/source/lib/command-line/command-modifiers.ts
+++ b/source/lib/command-line/command-modifiers.ts
@@ -106,7 +106,6 @@ export type CommandMap = {
 };
 
 const GLOBAL_COMMANDS = [
-	CmdKeywords.COFFEE,
 	CmdKeywords.EXIT,
 	CmdKeywords.SYNC,
 	CmdKeywords.HELP,
@@ -387,7 +386,6 @@ export const getCmdModifiers = (
 		[CmdKeywords.NEW]: getNewModifiers(currentContext),
 
 		[CmdKeywords.CONFIG]: [...CONFIG_MODIFIERS],
-		[CmdKeywords.COFFEE]: ['1', '3', '5', '20', 'custom'],
 	};
 
 	return modifiers[keyword] ?? [];

--- a/source/lib/command-line/command-validation.ts
+++ b/source/lib/command-line/command-validation.ts
@@ -771,31 +771,6 @@ const validators: Record<CmdKeyword, Validator> = {
 	},
 
 	[CmdKeywords.SYNC]: () => valid(CONFIRM_MSG),
-	[CmdKeywords.COFFEE]: args => {
-		const {modifier} = args;
-		const modifiers = getCmdModifiers(CmdKeywords.COFFEE);
-
-		if (
-			modifier.length &&
-			modifier.length <= 1 &&
-			!modifiers.includes(modifier)
-		) {
-			return invalid({
-				message: hintDefault('enter an amount ... '),
-				completionWordList: modifiers.filter(x => x.startsWith(modifier)),
-			});
-		}
-
-		return requireModifierOrInputStr({
-			hint: buildOptionsHint({
-				prefix: 'fuel continued development with ... $ ',
-				wordList: ['1', ' 3 ', '5', '20', 'custom'],
-				inputString: '',
-				minLengthForHints: 0,
-			}),
-			onOk: 'Thank you for your support! 🫡',
-		})(args);
-	},
 };
 
 type CmdValidator = {

--- a/source/lib/command-line/commands.ts
+++ b/source/lib/command-line/commands.ts
@@ -18,7 +18,7 @@ import {isTicketNode} from '../model/context.model.js';
 import {failed, isFail, succeeded} from '../model/result-types.js';
 import {findAncestor} from '../repository/node-repo.js';
 import {resolveAndPersistRankForMove} from '../repository/rank.js';
-import {getCmdArg, getCmdState, replaceCmdInput} from '../state/cmd.state.js';
+import {getCmdArg, getCmdState} from '../state/cmd.state.js';
 import {patchSettingsState} from '../state/settings.state.js';
 import {
 	getRenderedChildren,
@@ -28,7 +28,6 @@ import {
 } from '../state/state.js';
 import {patchUiState} from '../state/ux-state.js';
 import {getPersistRoot} from '../storage/paths.js';
-import {openUrl} from '../utils/open-in-browser.js';
 import {CmdKeywords} from './cmd-keywords.js';
 import {CmdIntent} from './command-intent.js';
 import {ConfigModifiers, getCmdModifiers} from './command-modifiers.js';
@@ -917,25 +916,6 @@ export const commands: CommandLineActionEntry[] = [
 				default:
 					return failed('Unknown config command');
 			}
-		},
-	},
-	{
-		intent: CmdIntent.Coffee,
-		description: 'Sponsor the development of Epiq!',
-		mode: Mode.COMMAND_LINE,
-		action: () => {
-			const modifier = getCmdState().commandMeta.modifier;
-			if (modifier === 'custom') {
-				openUrl(
-					'https://github.com/sponsors/ljtn?frequency=one-time&sponsor=ljtn',
-				);
-			} else {
-				openUrl(
-					`https://github.com/sponsors/ljtn/sponsorships?sponsor=ljtn&preview=true&frequency=one-time&amount=${modifier}`,
-				);
-			}
-			replaceCmdInput('');
-			return succeeded('Thanks you!', null);
 		},
 	},
 ];


### PR DESCRIPTION
Removes the `coffee` keyword, intent, modifiers, validator and command action from the TUI command line. Nothing else referenced them; the browser opener stays for attachments.

Local gate green (lint, typecheck, unit, containers, GUI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CoXCuo1BiXNR5g4NnxGN15