### PR TITLE
QPPR7PE cap the log at 500 lines

### DIFF
--- a/source/logger.ts
+++ b/source/logger.ts
@@ -5,7 +5,7 @@ import {isFail} from './lib/model/result-types.js';
 import {EPIQ_DIR_NAME, resolveClosestEpiqRoot} from './lib/storage/paths.js';
 import {LogLevel} from './lib/state/settings.state.js';
 
-export const MAX_LINES = 1000;
+export const MAX_LINES = 500;
 // One message may span many lines (a stack trace does), so the file is bounded
 // in bytes as well: a log past V8's string cap cannot be read back to trim it,
 // and a trim that throws inside the logger takes the whole app down with it.


### PR DESCRIPTION
Halves `MAX_LINES` in the logger from 1000 to 500. The byte cap from MBB6WY5 stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CoXCuo1BiXNR5g4NnxGN15