### PR TITLE
Q1P1BEK treat a repo without origin as a local-only board

### DIFF
--- a/source/git/sync.ts
+++ b/source/git/sync.ts
@@ -16,6 +16,7 @@ import {
 import {
 	execGit,
 	hasInProgressGitOperation,
+	hasRemote,
 	hasStagedChanges,
 	isAheadOfUpstream,
 	isDetachedHead,
@@ -42,7 +43,8 @@ type SyncSummary = {
 	pulled: boolean;
 	pushed: boolean;
 	bootstrapped: boolean;
-	// Local work is committed; the remote could not be reached.
+	// Local work is committed; the remote could not be reached, or there is
+	// none to reach.
 	offline: boolean;
 	// Another process held the state worktree; nothing was attempted.
 	skipped?: boolean;
@@ -253,8 +255,13 @@ const commitOwnEventFileToStateBranch = async ({
 
 const offlineSummary = (
 	summary: Omit<SyncSummary, 'offline' | 'pulled' | 'pushed'>,
+	reason: 'offline' | 'no remote' = 'offline',
 ): Result<SyncSummary> => {
-	const msg = summary.createdCommit ? 'Committed locally, offline' : 'Offline';
+	const msg = summary.createdCommit
+		? `Committed locally, ${reason}`
+		: reason === 'offline'
+		? 'Offline'
+		: 'No remote';
 
 	setSyncOffline(msg);
 
@@ -367,6 +374,21 @@ const runSync = async ({
 	// ============================
 	// Pull remote
 	// ============================
+	// A repository with no origin is a local-only board, not a broken one:
+	// nothing to pull or push, and nothing to fail on every autosync tick.
+	const remoteResult = trace(
+		'hasRemote',
+		await hasRemote({repoRoot: stateBranchRoot}),
+	);
+	if (isFail(remoteResult)) return failSync(remoteResult.message);
+
+	if (!remoteResult.value) {
+		return offlineSummary(
+			{repoRoot, stateBranchRoot, createdCommit, commitSha, bootstrapped},
+			'no remote',
+		);
+	}
+
 	const pullResult = trace(
 		'pullBranchRebaseIfPresent',
 		await pullBranchRebaseIfPresent({

--- a/source/test/git-sync.test.ts
+++ b/source/test/git-sync.test.ts
@@ -15,6 +15,47 @@ import {
 useTempHome();
 
 describe('sync', () => {
+	it('commits locally and reports no remote when the repo has no origin', async () => {
+		const {repoRoot} = await setupRepo();
+		const ownEventFileName = 'u1.alice.jsonl';
+
+		const bootResult = await syncEpiqWithRemote({
+			cwd: repoRoot,
+			ownEventFileName,
+		});
+		if (isFail(bootResult)) throw new Error(bootResult.message);
+
+		const removeResult = await execGit({
+			args: ['remote', 'remove', 'origin'],
+			cwd: repoRoot,
+		});
+		if (isFail(removeResult)) throw new Error(removeResult.message);
+
+		writeFile(
+			getEventsFile({
+				root: bootResult.value.stateBranchRoot,
+				fileName: ownEventFileName,
+			}),
+			eventLine('01H00000000000000000000001'),
+		);
+
+		const syncResult = await syncEpiqWithRemote({
+			cwd: repoRoot,
+			ownEventFileName,
+		});
+		if (isFail(syncResult)) throw new Error(syncResult.message);
+
+		expect(syncResult.value.createdCommit).toBe(true);
+		expect(syncResult.value.offline).toBe(true);
+		expect(syncResult.message).toBe('Committed locally, no remote');
+
+		const again = await syncEpiqWithRemote({cwd: repoRoot, ownEventFileName});
+		if (isFail(again)) throw new Error(again.message);
+
+		expect(again.value.createdCommit).toBe(false);
+		expect(again.message).toBe('No remote');
+	});
+
 	it('allows write sync when main repo is in detached HEAD state', async () => {
 		const {repoRoot} = await setupRepo();
 


### PR DESCRIPTION
On a repo without `origin`, every autosync tick failed with `Failed to fetch __epiq_state__` and logged a stack through `logger.error`, which is what filled the log in MBB6WY5. `runSync` now checks `hasRemote` before the pull and returns the offline summary with a `no remote` reason: the badge reads `Committed locally, no remote` / `No remote`, nothing is logged at error level, and the first tick after a remote is added pulls and pushes as before.

Test in `source/test/git-sync.test.ts` reproduces the fetch failure without the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CoXCuo1BiXNR5g4NnxGN15