### PR TITLE
NHA59SJ list the shortcuts in the bottom bar instead of pointing at the command line

### DIFF
--- a/source/lib/actions/default/default-actions.ts
+++ b/source/lib/actions/default/default-actions.ts
@@ -43,7 +43,6 @@ export const DefaultActions: ActionEntry[] = [
 	{
 		intent: Intent.InitCommandLine,
 		mode: Mode.DEFAULT,
-		description: '[:] focus command line',
 		action: () => {
 			patchState({mode: Mode.COMMAND_LINE});
 			replaceCmdInput('');
@@ -103,7 +102,7 @@ export const DefaultActions: ActionEntry[] = [
 	{
 		intent: Intent.Yank,
 		mode: Mode.DEFAULT,
-		description: '[y] yank to clipboard',
+		description: '[y] yank',
 		action: () => {
 			const {selectedNode} = getState();
 

--- a/source/lib/actions/move/move-actions.ts
+++ b/source/lib/actions/move/move-actions.ts
@@ -20,7 +20,7 @@ export const toggleMoveMode: ActionEntry[] = [
 	{
 		intent: Intent.InitMove,
 		mode: Mode.DEFAULT,
-		description: '[m] move (init/confirm)',
+		description: '[m] move',
 		action: () => {
 			patchState({mode: Mode.COMMAND_LINE});
 			replaceCmdInput(`move start`);
@@ -30,6 +30,7 @@ export const toggleMoveMode: ActionEntry[] = [
 	{
 		intent: Intent.ConfirmMove,
 		mode: Mode.MOVE,
+		description: '[m] confirm move',
 		action: () => {
 			patchState({mode: Mode.COMMAND_LINE});
 			replaceCmdInput(`move confirm`);

--- a/source/lib/actions/palette/palette-actions.ts
+++ b/source/lib/actions/palette/palette-actions.ts
@@ -35,8 +35,7 @@ export const PaletteActions: ActionEntry[] = [
 	{
 		intent: Intent.InitCommandPalette,
 		mode: Mode.DEFAULT,
-		description:
-			'[?] view command palette (explore descriptions for every command)',
+		description: '[?] all commands',
 		action: () => {
 			replaceCmdInput('');
 			const {contextNode, selectedIndex, selectedNode, breadCrumb} = getState();

--- a/source/lib/components/ContextBarInfo.tsx
+++ b/source/lib/components/ContextBarInfo.tsx
@@ -1,5 +1,6 @@
 import {Box, Text} from 'ink';
 import React from 'react';
+import {ActionHint} from '../hints/hints.js';
 import {ModeUnion} from '../model/action-map.model.js';
 import {AppState} from '../model/app-state.model.js';
 import {theme} from '../theme/themes.js';
@@ -10,13 +11,19 @@ interface Props {
 	availableHints: AppState['availableHints'];
 }
 
-const getClampedHints = (availableHints: string[], width: number) => {
-	const clampedHints: string[] = [];
+const SEPARATOR = '  ';
+
+const hintWidth = ({keys, label}: ActionHint) => keys.length + 1 + label.length;
+
+// As many shortcuts as fit on one row, in order; the rest are on the help
+// screen.
+const getClampedHints = (availableHints: ActionHint[], width: number) => {
+	const clampedHints: ActionHint[] = [];
 	let usedWidth = 0;
 
 	for (const hint of availableHints) {
-		const separator = clampedHints.length > 0 ? ' | ' : '';
-		const nextWidth = separator.length + hint.length;
+		const separator = clampedHints.length > 0 ? SEPARATOR.length : 0;
+		const nextWidth = separator + hintWidth(hint);
 
 		if (usedWidth + nextWidth > width - 4) break;
 
@@ -28,8 +35,9 @@ const getClampedHints = (availableHints: string[], width: number) => {
 };
 
 export const ContextBarInfo: React.FC<Props> = ({width, availableHints}) => {
-	const hintLine = getClampedHints(availableHints, width).join(' | ');
-	const EMPTY_PLACEHOLDER = '\u00A0';
+	const hints = getClampedHints(availableHints, width);
+	const EMPTY_PLACEHOLDER = ' ';
+
 	return (
 		<Box
 			width={width}
@@ -37,9 +45,19 @@ export const ContextBarInfo: React.FC<Props> = ({width, availableHints}) => {
 			borderColor={theme.secondary}
 			paddingX={1}
 		>
-			<Text color={theme.secondary2}>
-				{hintLine.length ? hintLine : EMPTY_PLACEHOLDER}
-			</Text>
+			{hints.length ? (
+				<Text wrap="truncate">
+					{hints.map(({keys, label}, index) => (
+						<Text key={`${keys}-${label}`}>
+							{index > 0 ? SEPARATOR : ''}
+							<Text color={theme.accent}>{keys}</Text>
+							<Text color={theme.secondary2}> {label}</Text>
+						</Text>
+					))}
+				</Text>
+			) : (
+				<Text color={theme.secondary2}>{EMPTY_PLACEHOLDER}</Text>
+			)}
 		</Box>
 	);
 };

--- a/source/lib/components/EpiqApp.tsx
+++ b/source/lib/components/EpiqApp.tsx
@@ -54,6 +54,9 @@ export default function EpiqApp({width, height}: EpiqAppProps) {
 	const isSetupMode = !isSetupDone;
 	const isUninitializedRepo = isSetupDone && !state.hasProjectDefinition;
 
+	// The setup and init screens carry their own instructions; the board's
+	// shortcuts do nothing there.
+
 	if (isSetupMode) {
 		return (
 			<Box flexDirection="column">
@@ -62,11 +65,7 @@ export default function EpiqApp({width, height}: EpiqAppProps) {
 					<SettingsUI height={height} width={width} />
 				</Box>
 
-				<ContextBar
-					width={width}
-					mode={state.mode}
-					availableHints={state.availableHints}
-				/>
+				<ContextBar width={width} mode={state.mode} availableHints={[]} />
 			</Box>
 		);
 	}
@@ -79,11 +78,7 @@ export default function EpiqApp({width, height}: EpiqAppProps) {
 					<InitProjectUI height={height} width={width} />
 				</Box>
 
-				<ContextBar
-					width={width}
-					mode={state.mode}
-					availableHints={state.availableHints}
-				/>
+				<ContextBar width={width} mode={state.mode} availableHints={[]} />
 			</Box>
 		);
 	}

--- a/source/lib/components/Help.tsx
+++ b/source/lib/components/Help.tsx
@@ -2,6 +2,7 @@ import {Box, Text} from 'ink';
 import React, {useEffect, useMemo} from 'react';
 import {ulid} from 'ulid';
 import {navigationUtils} from '../actions/default/navigation-action-utils.js';
+import {ActionHint, parseActionHint} from '../hints/hints.js';
 import {isTextNode} from '../model/context.model.js';
 import {NavNode} from '../model/navigation-node.model.js';
 import {isFail, isSuccess} from '../model/result-types.js';
@@ -28,24 +29,15 @@ const getHelpItems = (): HelpItem[] =>
 				),
 		),
 	]
-		.map(desc => {
-			const [leftRaw, rightRaw] = desc.split(']');
-			const keys = leftRaw?.replace('[', '');
-			const action = rightRaw?.trim();
-
-			return [keys, action];
-		})
-		.filter(
-			(entry): entry is [string, string] =>
-				entry[0] !== undefined && entry[1] !== undefined,
-		)
-		.sort(([a], [b]) => {
+		.map(parseActionHint)
+		.filter((hint): hint is ActionHint => hint !== null)
+		.sort(({keys: a}, {keys: b}) => {
 			if (a.length === 1 && b.length !== 1) return -1;
 			if (a.length !== 1 && b.length === 1) return 1;
 
 			return a.localeCompare(b, undefined, {sensitivity: 'base'});
 		})
-		.map(([keys, action]) => ({keys, action}));
+		.map(({keys, label}) => ({keys, action: label}));
 
 const createHelpRootNode = (parentNodeId: string): NavNode<'TEXT'> =>
 	nodes.text({

--- a/source/lib/hints/hints.ts
+++ b/source/lib/hints/hints.ts
@@ -1,25 +1,34 @@
-import chalk from 'chalk';
-import {Mode} from '../model/action-map.model.js';
-import {NavNodeCtx} from '../model/context.model.js';
-import {theme} from '../theme/themes.js';
+import {ActionEntry, ModeUnion} from '../model/action-map.model.js';
 
-const initCommandPalette = chalk.dim.hex(theme.secondary2)(
-	`: for command line`,
-);
+// One keyboard shortcut as the bottom bar and the help screen show it, parsed
+// from an action description of the form `[keys] label`.
+export type ActionHint = {keys: string; label: string};
 
-const exit = `q to exit`;
+export const parseActionHint = (description: string): ActionHint | null => {
+	const match = /^\[(.+?)\]\s*(.+)$/.exec(description);
+	if (!match) return null;
 
-const confirmMove = `${chalk.hex(theme.accent)('m')} ${'to confirm'}`;
+	return {keys: match[1] ?? '', label: match[2] ?? ''};
+};
 
-export const Hints = {
-	[NavNodeCtx.WORKSPACE]: [initCommandPalette],
-	[NavNodeCtx.BOARD]: [initCommandPalette],
-	[NavNodeCtx.BOARD + Mode.COMMAND_LINE]: [initCommandPalette],
-	[NavNodeCtx.SWIMLANE]: [initCommandPalette],
-	[NavNodeCtx.TICKET + Mode.HELP]: [exit],
-	[NavNodeCtx.SWIMLANE + Mode.HELP]: [exit],
-	[NavNodeCtx.TICKET]: [],
-	[NavNodeCtx.FIELD]: [],
-	[NavNodeCtx.SWIMLANE + Mode.MOVE]: [confirmMove],
-	[NavNodeCtx.TICKET + Mode.MOVE]: [confirmMove],
+// Single keys first, then chords and key groups; stable within each rank, so
+// the declaration order of the actions is the order the bar reads in.
+const rankOf = ({keys}: ActionHint): number => (keys.length === 1 ? 0 : 1);
+
+export const getActionHints = (
+	actions: ActionEntry[],
+	mode: ModeUnion,
+): ActionHint[] => {
+	const descriptions = new Set<string>();
+
+	for (const action of actions) {
+		if (action.mode !== mode || !action.description) continue;
+
+		descriptions.add(action.description);
+	}
+
+	return [...descriptions]
+		.map(parseActionHint)
+		.filter((hint): hint is ActionHint => hint !== null)
+		.sort((a, b) => rankOf(a) - rankOf(b));
 };

--- a/source/lib/model/app-state.model.ts
+++ b/source/lib/model/app-state.model.ts
@@ -1,3 +1,4 @@
+import {ActionHint} from '../hints/hints.js';
 import {AppEvent} from '../../lib/event/event.model.js';
 import {failed, Result, succeeded} from './result-types.js';
 import {ActionEntry, ActionIndex, ModeUnion} from './action-map.model.js';
@@ -89,7 +90,7 @@ export type AppState = {
 	mode: ModeUnion;
 	availableActions: ActionEntry[];
 	actionIndex: ActionIndex;
-	availableHints: string[];
+	availableHints: ActionHint[];
 	breadCrumb: BreadCrumb;
 	rootNodeId: string;
 	nodes: Record<string, NavNode<AnyContext>>;

--- a/source/lib/state/state.ts
+++ b/source/lib/state/state.ts
@@ -2,7 +2,7 @@ import {useSyncExternalStore} from 'react';
 import {contextActions} from '../actions/action-map.js';
 import {DefaultActions} from '../actions/default/default-actions.js';
 import {inputActions} from '../actions/input/input-actions.js';
-import {Hints} from '../hints/hints.js';
+import {getActionHints} from '../hints/hints.js';
 import {readProjectFile} from '../project-setup/project-setup.js';
 import {Mode} from '../model/action-map.model.js';
 import type {AppState} from '../model/app-state.model.js';
@@ -69,13 +69,12 @@ function derive(state: BaseState): Result<AppState> {
 	const breadCrumb = breadCrumbResult.value;
 
 	const {context} = contextNode;
-	const availableHints = Hints[context + mode] ?? Hints[context] ?? [];
-
 	const availableActions = [
 		...DefaultActions,
 		...(contextActions[context] ?? []),
 		...inputActions,
 	];
+	const availableHints = getActionHints(availableActions, mode);
 	const actionIndex = buildActionIndex(availableActions);
 
 	const renderedChildrenIndex = buildChildIndex(nodes, filters);

--- a/source/test/e2e/attachments.e2e.test.ts
+++ b/source/test/e2e/attachments.e2e.test.ts
@@ -18,10 +18,17 @@ import {
 	sync,
 } from '../../mcp/epiq-api.js';
 import {commonSteps} from './e2e-common-steps.js';
-import {ARROW_DOWN, ENTER, removeTempRepo, setupTui} from './e2e.helper.js';
+import {
+	ARROW_DOWN,
+	commandLineIsIdle,
+	commandLineShows,
+	ENTER,
+	removeTempRepo,
+	setupTui,
+} from './e2e.helper.js';
 
 const testTimeout = 60_000;
-const EMPTY_CMD = 'for command line';
+const EMPTY_CMD = commandLineIsIdle;
 
 const PNG_1PX = Buffer.from(
 	'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
@@ -32,7 +39,7 @@ type Tui = ReturnType<typeof setupTui>;
 
 const run = async (tui: Tui, cmd: string, echo: string) => {
 	tui.input(cmd);
-	await tui.waitFor(echo, 4_000);
+	await tui.waitFor(commandLineShows(echo), 4_000);
 	tui.input(ENTER);
 	await tui.waitFor(EMPTY_CMD, 5_000);
 };

--- a/source/test/e2e/comments.e2e.test.ts
+++ b/source/test/e2e/comments.e2e.test.ts
@@ -1,15 +1,21 @@
 import {beforeAll, describe, expect, it} from 'vitest';
 import {commonSteps} from './e2e-common-steps.js';
-import {ARROW_DOWN, ENTER, setupTui} from './e2e.helper.js';
+import {
+	ARROW_DOWN,
+	commandLineIsIdle,
+	commandLineShows,
+	ENTER,
+	setupTui,
+} from './e2e.helper.js';
 
 const testTimeout = 60_000;
-const EMPTY_CMD = 'for command line';
+const EMPTY_CMD = commandLineIsIdle;
 
 type Tui = ReturnType<typeof setupTui>;
 
 const run = async (tui: Tui, cmd: string, echo: string) => {
 	tui.input(cmd);
-	await tui.waitFor(echo, 4_000);
+	await tui.waitFor(commandLineShows(echo), 4_000);
 	tui.input(ENTER);
 	await tui.waitFor(EMPTY_CMD, 5_000);
 };

--- a/source/test/e2e/description-box.e2e.test.ts
+++ b/source/test/e2e/description-box.e2e.test.ts
@@ -1,10 +1,15 @@
 import path from 'node:path';
 import {beforeAll, describe, expect, it} from 'vitest';
 import {commonSteps} from './e2e-common-steps.js';
-import {ENTER, setupTui} from './e2e.helper.js';
+import {
+	commandLineIsIdle,
+	commandLineShows,
+	ENTER,
+	setupTui,
+} from './e2e.helper.js';
 
 const testTimeout = 60_000;
-const EMPTY_CMD = 'for command line';
+const EMPTY_CMD = commandLineIsIdle;
 
 // Writes a description longer and wider than the box, so both edges have to
 // hold (see fake-editor-long.sh).
@@ -17,7 +22,7 @@ type Tui = ReturnType<typeof setupTui>;
 
 const run = async (tui: Tui, cmd: string, echo: string) => {
 	tui.input(cmd);
-	await tui.waitFor(echo, 4_000);
+	await tui.waitFor(commandLineShows(echo), 4_000);
 	tui.input(ENTER);
 	await tui.waitFor(EMPTY_CMD, 5_000);
 };

--- a/source/test/e2e/e2e.helper.ts
+++ b/source/test/e2e/e2e.helper.ts
@@ -71,21 +71,34 @@ const createTuiEnv = (extra: Record<string, string> = {}) => {
 const sleep = async (ms: number) =>
 	await new Promise(resolve => setTimeout(resolve, ms));
 
-// Text inside the command-line box, which is the last bordered row of a frame.
-const commandLineContent = (frame: string): string => {
-	const lines = frame.split('\n');
+// Text inside the bottom box: the rows under the last full-width top border,
+// joined, since a long input wraps onto a second row. The bottom border can
+// sit below the last screen row, so the box ends at it or at the frame's end.
+// Null while the box is not there, as when an external editor has the
+// terminal or a frame is only half drawn and still ends in swimlane columns,
+// whose top borders are several boxes wide rather than one.
+const commandLineContent = (frame: string): string | null => {
+	const lines = frame.split('\n').map(line => line.trim());
+	const top = lines.findLastIndex(line => /^╭─+╮$/.test(line));
+	if (top === -1) return null;
 
-	for (let index = lines.length - 1; index >= 0; index--) {
-		const match = /^│(.*)│$/.exec((lines[index] ?? '').trim());
-		if (match) return (match[1] ?? '').trim();
+	const rows: string[] = [];
+
+	for (const line of lines.slice(top + 1)) {
+		if (line.startsWith('╰') || line === '') break;
+
+		const match = /^│([^│]*)│$/.exec(line);
+		if (!match) return null;
+
+		rows.push((match[1] ?? '').trim());
 	}
 
-	return '';
+	return rows.length ? rows.join(' ').trim() : null;
 };
 
 /**
- * True when the command line holds no typed command. Not "contains the
- * placeholder": the caption is absent in some contexts, so waiting on it hangs.
+ * True when the command line holds no typed command: the bottom row is then
+ * the shortcut bar rather than an input.
  */
 // `destroy()` waits for the TUI and kills its process group first, so by now
 // nothing should be writing here; the retries cover a git that escaped anyway.
@@ -98,9 +111,26 @@ export const removeTempRepo = (dir: string): void => {
 	});
 };
 
+// An input opens with `:` or `?` and runs straight into the text or the
+// cursor; the shortcut bar's leading `?` shortcut is followed by a space.
+const isCommandInput = (content: string): boolean =>
+	/^[:?](\S|$)/.test(content);
+
+// The typed command as echoed in the command line, and only there: the
+// shortcut bar repeats command names (`e edit description`), so a match
+// anywhere on screen can fire before a keystroke has landed.
+export const commandLineShows =
+	(text: string) =>
+	(frame: string): boolean => {
+		const content = commandLineContent(frame);
+		return (
+			content !== null && isCommandInput(content) && content.includes(text)
+		);
+	};
+
 export const commandLineIsIdle = (frame: string): boolean => {
 	const content = commandLineContent(frame);
-	return content === '' || content === ': for command line';
+	return content !== null && !isCommandInput(content);
 };
 
 const describeWaitTarget = (

--- a/source/test/e2e/edit-scope.e2e.test.ts
+++ b/source/test/e2e/edit-scope.e2e.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import {afterAll, beforeAll, describe, expect, it} from 'vitest';
 import {
 	commandLineIsIdle,
+	commandLineShows,
 	ENTER,
 	removeTempRepo,
 	setupTui,
@@ -43,7 +44,7 @@ const ENV = {
 // Run a command-line command and wait for it to fully settle (see lifecycle).
 const run = async (tui: Tui, cmd: string, echo: string) => {
 	tui.input(cmd);
-	await tui.waitFor(echo, 4_000);
+	await tui.waitFor(commandLineShows(echo), 4_000);
 	tui.input(ENTER);
 	await tui.waitFor(commandLineIsIdle, 5_000);
 };

--- a/source/test/e2e/filter.e2e.test.ts
+++ b/source/test/e2e/filter.e2e.test.ts
@@ -1,9 +1,14 @@
 import {beforeAll, describe, expect, it} from 'vitest';
 import {commonSteps} from './e2e-common-steps.js';
-import {ENTER, setupTui} from './e2e.helper.js';
+import {
+	commandLineIsIdle,
+	commandLineShows,
+	ENTER,
+	setupTui,
+} from './e2e.helper.js';
 
 const testTimeout = 60_000;
-const EMPTY_CMD = 'for command line';
+const EMPTY_CMD = commandLineIsIdle;
 
 type Tui = ReturnType<typeof setupTui>;
 
@@ -13,7 +18,7 @@ type Tui = ReturnType<typeof setupTui>;
 // this completes lets keystrokes merge into a single un-submitted buffer.
 const run = async (tui: Tui, cmd: string, echo: string) => {
 	tui.input(cmd);
-	await tui.waitFor(echo, 4_000);
+	await tui.waitFor(commandLineShows(echo), 4_000);
 	tui.input(ENTER);
 	await tui.waitFor(EMPTY_CMD, 5_000);
 };

--- a/source/test/e2e/init.e2e.test.ts
+++ b/source/test/e2e/init.e2e.test.ts
@@ -1,9 +1,9 @@
 import {beforeAll, describe, expect, it} from 'vitest';
 import {commonSteps} from './e2e-common-steps.js';
-import {ARROW_DOWN, ENTER, setupTui} from './e2e.helper.js';
+import {ARROW_DOWN, commandLineIsIdle, ENTER, setupTui} from './e2e.helper.js';
 
 const testTimeout = 60_000;
-const EMPTY_COMMAND_LINE = ': for command line';
+const EMPTY_COMMAND_LINE = commandLineIsIdle;
 
 beforeAll(async () => {
 	const tui = setupTui();

--- a/source/test/e2e/lifecycle.e2e.test.ts
+++ b/source/test/e2e/lifecycle.e2e.test.ts
@@ -1,10 +1,16 @@
 import path from 'node:path';
 import {beforeAll, describe, expect, it} from 'vitest';
 import {commonSteps} from './e2e-common-steps.js';
-import {ARROW_DOWN, ENTER, setupTui} from './e2e.helper.js';
+import {
+	ARROW_DOWN,
+	commandLineIsIdle,
+	commandLineShows,
+	ENTER,
+	setupTui,
+} from './e2e.helper.js';
 
 const testTimeout = 60_000;
-const EMPTY_CMD = 'for command line';
+const EMPTY_CMD = commandLineIsIdle;
 
 // `epiq` only accepts editors from a fixed allow-list, but `$EDITOR` is one of
 // them and is expanded through the shell at edit time. So we register `$EDITOR`
@@ -23,7 +29,7 @@ type Tui = ReturnType<typeof setupTui>;
 // this completes lets keystrokes merge into a single un-submitted buffer.
 const run = async (tui: Tui, cmd: string, echo: string) => {
 	tui.input(cmd);
-	await tui.waitFor(echo, 4_000);
+	await tui.waitFor(commandLineShows(echo), 4_000);
 	tui.input(ENTER);
 	await tui.waitFor(EMPTY_CMD, 5_000);
 };

--- a/source/test/e2e/peek.e2e.test.ts
+++ b/source/test/e2e/peek.e2e.test.ts
@@ -1,9 +1,14 @@
 import {beforeAll, describe, expect, it} from 'vitest';
 import {commonSteps} from './e2e-common-steps.js';
-import {ENTER, setupTui} from './e2e.helper.js';
+import {
+	commandLineIsIdle,
+	commandLineShows,
+	ENTER,
+	setupTui,
+} from './e2e.helper.js';
 
 const testTimeout = 60_000;
-const EMPTY_CMD = 'for command line';
+const EMPTY_CMD = commandLineIsIdle;
 const ESCAPE = '\x1B';
 
 type Tui = ReturnType<typeof setupTui>;
@@ -14,7 +19,7 @@ type Tui = ReturnType<typeof setupTui>;
 // this completes lets keystrokes merge into a single un-submitted buffer.
 const run = async (tui: Tui, cmd: string, echo: string) => {
 	tui.input(cmd);
-	await tui.waitFor(echo, 4_000);
+	await tui.waitFor(commandLineShows(echo), 4_000);
 	tui.input(ENTER);
 	await tui.waitFor(EMPTY_CMD, 5_000);
 };

--- a/source/test/hints.test.ts
+++ b/source/test/hints.test.ts
@@ -1,0 +1,63 @@
+import {describe, expect, it} from 'vitest';
+import {getActionHints, parseActionHint} from '../lib/hints/hints.js';
+import {ActionEntry, Mode} from '../lib/model/action-map.model.js';
+import {succeeded} from '../lib/model/result-types.js';
+
+const entry = (
+	description: string | undefined,
+	mode: ActionEntry['mode'] = Mode.DEFAULT,
+): ActionEntry => ({
+	mode,
+	description: description as ActionEntry['description'],
+	action: () => succeeded('noop', null),
+});
+
+describe('parseActionHint', () => {
+	it('splits `[keys] label`', () => {
+		expect(parseActionHint('[n] new...')).toEqual({keys: 'n', label: 'new...'});
+		expect(parseActionHint('[<Enter>] confirm/enter')).toEqual({
+			keys: '<Enter>',
+			label: 'confirm/enter',
+		});
+	});
+
+	it('rejects a description without a key group', () => {
+		expect(parseActionHint('navigate')).toBeNull();
+	});
+});
+
+describe('getActionHints', () => {
+	it('lists only the current mode, single keys first, in declaration order', () => {
+		const hints = getActionHints(
+			[
+				entry('[?] all commands'),
+				entry('[n] new...'),
+				entry('[<Enter>] confirm/enter'),
+				entry(undefined),
+				entry('[d] delete'),
+				entry('[arrows/hjkl] navigate'),
+				entry('[<Esc>] cancel', Mode.MOVE),
+				entry('[m] move (init/confirm)'),
+			],
+			Mode.DEFAULT,
+		);
+
+		expect(hints.map(hint => hint.keys)).toEqual([
+			'?',
+			'n',
+			'd',
+			'm',
+			'<Enter>',
+			'arrows/hjkl',
+		]);
+	});
+
+	it('collapses actions that share a description', () => {
+		const hints = getActionHints(
+			[entry('[arrows/hjkl] navigate'), entry('[arrows/hjkl] navigate')],
+			Mode.DEFAULT,
+		);
+
+		expect(hints).toHaveLength(1);
+	});
+});


### PR DESCRIPTION
The bottom bar in default mode showed a static hint (`: for command line`). It now lists the live shortcuts for the current context and mode, derived from the same `[key] label` action descriptions the help screen parses, key in accent and label beside it, clamped to the width:

```
│ ? all commands  n new...  d delete  y yank  r rename title  e edit description  q exit context  m move   │
```

- `source/lib/hints/hints.ts` owns the parse and order (single keys first, declaration order); `Help.tsx` reuses the parser.
- The `[:] focus command line` entry is gone from the bar and help. The key itself still works, undocumented, until 8VHHENB (human-input-needed) settles whether to remove it: the whole TUI e2e suite and the readme drive commands through `:`.
- `?` moved to the front and two labels shortened so the discovery key survives the clamp at 120 columns; `m` in move mode now reads `confirm move`.
- Setup and init screens show an empty bar; their own copy carries the instructions.
- e2e harness: `commandLineIsIdle` and a new `commandLineShows(text)` read the bottom box properly (top-border anchored, wrapped rows, off-screen bottom border) and tell an input from the bar, since the bar now repeats command names like `edit description`. The seven `run` helpers use it for their echo wait.

Tests: `source/test/hints.test.ts`; `npm test` green; e2e suite green in the container (11/11). The local gate's one failure was a GUI test that passes alone under load 15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CoXCuo1BiXNR5g4NnxGN15