### PR TITLE
GHGMWRF lead the shortcut bar with : since it reaches every command

### DIFF
--- a/source/lib/actions/default/default-actions.ts
+++ b/source/lib/actions/default/default-actions.ts
@@ -17,6 +17,17 @@ import {PaletteActions} from '../palette/palette-actions.js';
 import {navigationUtils} from './navigation-action-utils.js';
 
 export const DefaultActions: ActionEntry[] = [
+	// First, so it leads the shortcut bar: it is the way to every command.
+	{
+		intent: Intent.InitCommandLine,
+		mode: Mode.DEFAULT,
+		description: '[:] write command',
+		action: () => {
+			patchState({mode: Mode.COMMAND_LINE});
+			replaceCmdInput('');
+			return succeeded('Entering command line mode', null);
+		},
+	},
 	...HelpActions,
 	...PaletteActions,
 	{
@@ -40,15 +51,6 @@ export const DefaultActions: ActionEntry[] = [
 		},
 	},
 
-	{
-		intent: Intent.InitCommandLine,
-		mode: Mode.DEFAULT,
-		action: () => {
-			patchState({mode: Mode.COMMAND_LINE});
-			replaceCmdInput('');
-			return succeeded('Entering command line mode', null);
-		},
-	},
 	{
 		intent: Intent.Confirm,
 		mode: Mode.DEFAULT,
@@ -143,7 +145,7 @@ export const DefaultActions: ActionEntry[] = [
 	{
 		intent: Intent.EditDescription,
 		mode: Mode.DEFAULT,
-		description: '[e] edit description',
+		description: '[e] edit desc',
 		action: () => {
 			patchState({mode: Mode.COMMAND_LINE});
 			replaceCmdInput(`${CmdKeywords.EDIT} description `);

--- a/source/lib/actions/palette/palette-actions.ts
+++ b/source/lib/actions/palette/palette-actions.ts
@@ -35,7 +35,7 @@ export const PaletteActions: ActionEntry[] = [
 	{
 		intent: Intent.InitCommandPalette,
 		mode: Mode.DEFAULT,
-		description: '[?] all commands',
+		description: '[?] command palette',
 		action: () => {
 			replaceCmdInput('');
 			const {contextNode, selectedIndex, selectedNode, breadCrumb} = getState();


### PR DESCRIPTION
Follow-up to NHA59SJ. The `[:]` entry is back, first in the bar, with the labels agreed on:

```
: write command  ? command palette  n new...  d delete  y yank  r rename title  e edit desc  q exit context  m move
```

Fits at 120 columns with `m move` included. Settles 8VHHENB: `:` stays and is advertised.

Gate: lint, typecheck, unit, container e2e green; the GUI suite failed in the gate on a missing per-worker handoff file left by an interrupted earlier run, and passes alone (130/130).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CoXCuo1BiXNR5g4NnxGN15