### PR TITLE
v1.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "epiq",
-	"version": "1.8.0",
+	"version": "1.8.1",
 	"license": "MIT",
 	"type": "module",
 	"description": "EPIQ - ergonomic, distributed CLI-first issue tracker TUI ready for the agentic era",

--- a/source/version.ts
+++ b/source/version.ts
@@ -1,2 +1,2 @@
 // Auto-generated. Do not edit.
-export const EPIQ_VERSION = '1.8.0';
+export const EPIQ_VERSION = '1.8.1';


### PR DESCRIPTION
MCP
- epiq_issue_get returns the ticket's comments in log order.
- epiq_issue_list filters by swimlaneId, tag, assignee and query; brief: true drops descriptions.
- epiq_issue_close, epiq_issue_move and epiq_issue_tag_add accept issueIds and report an outcome per ticket.

TUI
- Shortcut bar lists the shortcuts, led by :, instead of pointing at the command line.
- :coffee removed.

GUI
- Log panel no longer scrolls into empty space while a movie plays after a hover.

Sync and logging
- A repo without an origin is a local-only board; autosync no longer fails on it.
- Log capped at 500 lines and a byte limit, messages clipped, and a log write can never throw.
- SEA stack frames name the bundle instead of repeating its data URL.

Skill
- Each session boots its own MCP instance and assumes a board name on it; the skill says how.
- Agents ask which name to take, name their window, and self-assign what they file.