### PR TITLE
1KEWA6W landing: accent the hero's Get started button

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -241,12 +241,28 @@ h1 {
 	flex-direction: row;
 	align-items: stretch;
 }
+/* Get started is the page's one primary action, so it alone carries the
+   accent: cyan text and border, a faint tint, and a glow that brightens on
+   hover. */
 .hero-cta {
 	min-height: 48px;
 	padding: 0 20px;
 	font: 14px var(--mono);
 	letter-spacing: -0.02em;
 	white-space: nowrap;
+	color: var(--cyan);
+	border-color: rgba(117, 210, 253, 0.55);
+	background: rgba(117, 210, 253, 0.06);
+	box-shadow: 0 0 0 1px rgba(117, 210, 253, 0.06),
+		0 0 28px rgba(117, 210, 253, 0.16);
+	transition: border-color 0.18s ease, background 0.18s ease,
+		box-shadow 0.18s ease;
+}
+.hero-cta:hover {
+	border-color: var(--cyan);
+	background: rgba(117, 210, 253, 0.12);
+	box-shadow: 0 0 0 1px rgba(117, 210, 253, 0.2),
+		0 0 36px rgba(117, 210, 253, 0.28);
 }
 /* In the install panel the commands are alternatives, so they share a width
    instead of each sizing to its own text and landing ragged. Full width also


### PR DESCRIPTION
The Get started button beside the hero install command looked like every other secondary button, so the hero had no visible primary action. It now carries the cyan accent: cyan text and border, a faint tint and a soft glow that brightens on hover. The install command and the install panel are unchanged.