### PR TITLE
2KBWD7E boot the TUI from the local log and pull in the background

### DIFF
--- a/source/boot-tui.tsx
+++ b/source/boot-tui.tsx
@@ -1,5 +1,9 @@
 import {renderApp} from './Index.js';
-import {loadProject, loadWithoutProject} from './lib/boot/load-project.js';
+import {
+	loadProject,
+	loadWithoutProject,
+	refreshProjectInBackground,
+} from './lib/boot/load-project.js';
 import {resolveEnvActor} from './lib/config/actor-env.js';
 import {loadSettingsFromConfig} from './lib/config/user-config.js';
 import {initListeners} from './lib/listeners/keypress-listener.js';
@@ -36,6 +40,11 @@ export async function bootTui(): Promise<Result<void>> {
 		if (isFail(renderResult)) return failAt(6, renderResult.message);
 
 		initListeners();
+
+		// After the first frame, so the board is up while the network answers.
+		if (isSuccess(repoRootResult)) {
+			refreshProjectInBackground(repoRootResult.value);
+		}
 
 		return succeeded('Booted Epiq', undefined);
 	} catch (error) {

--- a/source/git/sync-and-reload-state.ts
+++ b/source/git/sync-and-reload-state.ts
@@ -158,6 +158,36 @@ const syncAndReloadStateUnsafe = async (): Promise<Result<boolean>> => {
 
 	const {stateBranchRoot, offline} = syncResult.value;
 
+	const reloadResult = reloadStateFromEventLog(stateBranchRoot);
+	if (isFail(reloadResult)) return reloadResult;
+
+	patchState({
+		hasProjectDefinition: true,
+		// The reload succeeded either way; only the remote half did not.
+		syncStatus: offline
+			? {msg: 'Committed locally, offline', status: 'offline'}
+			: {msg: 'Synced', status: 'synced'},
+	});
+
+	logger.debug('[sync] syncAndReloadState:done', {
+		syncStatus: getState().syncStatus,
+	});
+
+	return succeeded('Synced', true);
+};
+
+/**
+ * Re-materialises the board from the event log on disk without losing the
+ * user's place: filters are view state the replay would reset, and navigation
+ * is anchored before and restored after. Refused while editing, so a reload
+ * never drops half-typed input.
+ *
+ * Shared by the sync and by the boot-time pull: both leave new lines on disk
+ * that the board has to show.
+ */
+export const reloadStateFromEventLog = (
+	stateBranchRoot: string,
+): Result<null> => {
 	logger.debug('[sync] loading merged events after sync', {
 		stateBranchRoot,
 	});
@@ -298,19 +328,7 @@ const syncAndReloadStateUnsafe = async (): Promise<Result<boolean>> => {
 		return restoreResult;
 	}
 
-	patchState({
-		hasProjectDefinition: true,
-		// The reload succeeded either way; only the remote half did not.
-		syncStatus: offline
-			? {msg: 'Committed locally, offline', status: 'offline'}
-			: {msg: 'Synced', status: 'synced'},
-	});
-
-	logger.debug('[sync] syncAndReloadState:done', {
-		syncStatus: getState().syncStatus,
-	});
-
-	return succeeded('Synced', true);
+	return succeeded('Reloaded state from event log', null);
 };
 
 const failReloadIfNotDefaultMode = (): Result<null> | null => {

--- a/source/git/sync.ts
+++ b/source/git/sync.ts
@@ -534,7 +534,7 @@ const runSync = async ({
  * `finally`, because a sync that failed part-way is exactly when a rebase is
  * left half-applied.
  */
-const withEventLogsIntact = async <T>(
+export const withEventLogsIntact = async <T>(
 	stateBranchRoot: string,
 	fn: () => Promise<T>,
 ): Promise<T> => {

--- a/source/lib/boot/load-project.ts
+++ b/source/lib/boot/load-project.ts
@@ -1,18 +1,72 @@
+import {getStateBranch} from '../../git/git-constants.js';
 import {getStateBranchRoot} from '../../git/git-storage.js';
-import {execGit} from '../../git/git-utils.js';
+import {
+	hasRemote,
+	isRemoteUnreachable,
+	pullBranchRebaseIfPresent,
+} from '../../git/git-utils.js';
 import {ensureStateBranchWorktree} from '../../git/git.js';
+import {reloadStateFromEventLog} from '../../git/sync-and-reload-state.js';
+import {withSyncLock} from '../../git/sync-lock.js';
+import {withEventLogsIntact} from '../../git/sync.js';
 import {recordRecentProject} from '../config/recent-projects.js';
 import {bootStateFromEventLog} from '../event/event-boot.js';
 import {loadMergedEventsWithUnreadable} from '../event/event-load.js';
-import {Result, isFail, succeeded} from '../model/result-types.js';
+import {AppEvent} from '../event/event.model.js';
+import {Result, failed, isFail, succeeded} from '../model/result-types.js';
 import {getProjectFileContents} from '../project-setup/project-setup.js';
 import {patchState} from '../state/state.js';
-import {failAt} from '../utils/logger.utils.js';
+import {
+	failSync,
+	setSynced,
+	setSyncing,
+	setSyncOffline,
+} from '../state/sync-state.js';
+import {resolveClosestEpiqProjectRoot} from '../storage/paths.js';
+import {failAt, formatUnknownError} from '../utils/logger.utils.js';
+
+// A log with no init event cannot boot: a contributor registration alone is
+// what a clone holds before its first pull.
+const hasWorkspaceInit = (events: AppEvent[]): boolean =>
+	events.some(event => event.action === 'init.workspace');
+
+// The sync's own pull, so a board that was never pushed, local commits a push
+// never sent, and lines appended since the last commit are all handled the
+// way a sync handles them, rather than failing a fast-forward.
+const pullStateBranch = async (
+	repoRoot: string,
+	stateBranchRoot: string,
+): Promise<Result<boolean>> => {
+	const branchResult = getStateBranch(repoRoot);
+	if (isFail(branchResult)) return failed(branchResult.message);
+
+	return pullBranchRebaseIfPresent({
+		cwd: stateBranchRoot,
+		branch: branchResult.value,
+	});
+};
+
+// `:open` moves the process to another project; a pull that was in flight
+// when it did must not materialise the old one over it.
+const isCurrentProject = (stateBranchRoot: string): boolean => {
+	const rootResult = resolveClosestEpiqProjectRoot(process.cwd());
+	if (isFail(rootResult)) return false;
+
+	const currentResult = getStateBranchRoot({repoRoot: rootResult.value});
+
+	return !isFail(currentResult) && currentResult.value === stateBranchRoot;
+};
 
 /**
  * Boots the app state from the project at `repoRoot`: ensures its state
- * worktree, pulls what it can, and materialises the event log. Shared by the
- * initial TUI boot and by `:open`, which switches into another project.
+ * worktree and materialises the event log. Shared by the initial TUI boot and
+ * by `:open`, which switches into another project.
+ *
+ * The remote is not consulted when there is a local log to show: a pull is a
+ * network round-trip, and nothing reaches the screen until this returns.
+ * `refreshProjectFromRemote` catches up once the first frame is up. A project
+ * with no local log pulls first, since booting it empty would draw the init
+ * prompt over a board that already exists.
  */
 export const loadProject = async (repoRoot: string): Promise<Result<void>> => {
 	const stateBranchRootResult = getStateBranchRoot({repoRoot});
@@ -20,9 +74,11 @@ export const loadProject = async (repoRoot: string): Promise<Result<void>> => {
 		return failAt(3, stateBranchRootResult.message);
 	}
 
+	const stateBranchRoot = stateBranchRootResult.value;
+
 	const ensureWorktreeResult = await ensureStateBranchWorktree({
 		repoRoot,
-		stateBranchRoot: stateBranchRootResult.value,
+		stateBranchRoot,
 		stateBranchName: getProjectFileContents().stateBranch,
 	});
 
@@ -30,19 +86,16 @@ export const loadProject = async (repoRoot: string): Promise<Result<void>> => {
 		return failAt(3, ensureWorktreeResult.message);
 	}
 
-	const pullResult = await execGit({
-		cwd: stateBranchRootResult.value,
-		args: ['pull', '--ff-only'],
-	});
-
-	if (isFail(pullResult)) {
-		logger.info(3, pullResult.message);
-	}
-
-	const eventsResult = loadMergedEventsWithUnreadable(
-		stateBranchRootResult.value,
-	);
+	let eventsResult = loadMergedEventsWithUnreadable(stateBranchRoot);
 	if (isFail(eventsResult)) return failAt(3, eventsResult.message);
+
+	if (!hasWorkspaceInit(eventsResult.value.events)) {
+		const pullResult = await pullStateBranch(repoRoot, stateBranchRoot);
+		if (isFail(pullResult)) logger.info(3, pullResult.message);
+
+		eventsResult = loadMergedEventsWithUnreadable(stateBranchRoot);
+		if (isFail(eventsResult)) return failAt(3, eventsResult.message);
+	}
 
 	const {events, unreadable} = eventsResult.value;
 
@@ -60,6 +113,81 @@ export const loadProject = async (repoRoot: string): Promise<Result<void>> => {
 	if (isFail(recordResult)) logger.info(recordResult.message);
 
 	return succeeded('Loaded project', undefined);
+};
+
+/**
+ * The pull `loadProject` left out: brings the state branch up to date and
+ * re-materialises the board only if that moved it, reporting through the sync
+ * pill like any other sync. Taken under the sync lock, since a sync from
+ * another process may be driving the same worktree.
+ */
+export const refreshProjectFromRemote = async (
+	repoRoot: string,
+): Promise<Result<void>> => {
+	const stateBranchRootResult = getStateBranchRoot({repoRoot});
+	if (isFail(stateBranchRootResult)) {
+		return failed(stateBranchRootResult.message);
+	}
+
+	const stateBranchRoot = stateBranchRootResult.value;
+
+	const remoteResult = await hasRemote({repoRoot: stateBranchRoot});
+	if (isFail(remoteResult)) return failed(remoteResult.message);
+	if (!remoteResult.value) return succeeded('No remote to pull', undefined);
+
+	const lockedResult = await withSyncLock({
+		worktreeRoot: stateBranchRoot,
+		operation: 'boot pull',
+		fn: () =>
+			withEventLogsIntact(stateBranchRoot, () => {
+				setSyncing('Pulling');
+				return pullStateBranch(repoRoot, stateBranchRoot);
+			}),
+	});
+	if (isFail(lockedResult)) return failSync(lockedResult.message);
+
+	if (lockedResult.value === null) {
+		return succeeded('Another process holds the state worktree', undefined);
+	}
+
+	const movedResult = lockedResult.value;
+
+	if (isFail(movedResult)) {
+		if (isRemoteUnreachable(movedResult.message)) {
+			setSyncOffline('Offline');
+			return succeeded('Offline', undefined);
+		}
+
+		return failSync(movedResult.message);
+	}
+
+	if (!movedResult.value) {
+		setSynced('Already synced');
+		return succeeded('Already synced', undefined);
+	}
+
+	if (!isCurrentProject(stateBranchRoot)) {
+		return succeeded('Project changed during the pull', undefined);
+	}
+
+	// Sets the pill itself on every way it can fail.
+	const reloadResult = reloadStateFromEventLog(stateBranchRoot);
+	if (isFail(reloadResult)) return reloadResult;
+
+	setSynced('Pulled');
+
+	return succeeded('Pulled and reloaded', undefined);
+};
+
+/** For callers that must not wait on the network; the outcome goes to the log. */
+export const refreshProjectInBackground = (repoRoot: string): void => {
+	void refreshProjectFromRemote(repoRoot)
+		.then(result => {
+			if (isFail(result)) logger.info(3, result.message);
+		})
+		.catch(error => {
+			logger.error(`[boot] pull failed: ${formatUnknownError(error)}`);
+		});
 };
 
 export const loadWithoutProject = (): Result<void> => {

--- a/source/lib/command-line/commands/open.cmd.ts
+++ b/source/lib/command-line/commands/open.cmd.ts
@@ -1,6 +1,9 @@
 import os from 'node:os';
 import path from 'node:path';
-import {loadProject} from '../../boot/load-project.js';
+import {
+	loadProject,
+	refreshProjectInBackground,
+} from '../../boot/load-project.js';
 import {
 	listRecentProjects,
 	RecentProject,
@@ -85,6 +88,8 @@ export const openProjectCommand = async (): Promise<Result<null>> => {
 		process.chdir(previousCwd);
 		return failed(loadResult.message);
 	}
+
+	refreshProjectInBackground(root);
 
 	return succeeded(`Opened ${recentProjectName(root)}`, null);
 };

--- a/source/test/load-project.test.ts
+++ b/source/test/load-project.test.ts
@@ -3,15 +3,37 @@ import path from 'node:path';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {ensureLocalStateBranch} from '../git/git.js';
 import {execGit} from '../git/git-utils.js';
-import {loadProject, loadWithoutProject} from '../lib/boot/load-project.js';
+import {syncEpiqWithRemote} from '../git/sync.js';
+import {
+	loadProject,
+	loadWithoutProject,
+	refreshProjectFromRemote,
+} from '../lib/boot/load-project.js';
+import {ACTOR_NAME_ENV} from '../lib/config/actor-env.js';
 import {
 	listRecentProjects,
 	readRecentProjects,
 } from '../lib/config/recent-projects.js';
+import {createDefaultEvents} from '../lib/event/event-boot.js';
+import {materializeAndPersistAll} from '../lib/event/event-materialize-and-persist.js';
+import {getPersistFileName} from '../lib/event/event-persist.js';
+import {AppEvent} from '../lib/event/event.model.js';
 import {isFail} from '../lib/model/result-types.js';
 import {DEFAULT_STATE_BRANCH} from '../lib/project-setup/project-setup.js';
 import {getState} from '../lib/state/state.js';
-import {makeTempDir, useTempHome} from './helpers/git-repo.js';
+import {
+	assumeActor,
+	createIssue,
+	listBoards,
+	listSwimlanes,
+} from '../mcp/epiq-api.js';
+import {
+	cloneRepo,
+	makeTempDir,
+	setupRepo,
+	useTempHome,
+	writeProjectFile,
+} from './helpers/git-repo.js';
 
 const git = async (cwd: string, args: string[]) => {
 	const result = await execGit({cwd, args});
@@ -114,6 +136,155 @@ describe('loadProject', () => {
 		expect(isFail(result)).toBe(true);
 		const recorded = readRecentProjects();
 		expect(!isFail(recorded) && recorded.value).toEqual([]);
+	});
+});
+
+// Two clones of one remote: alice writes, bob boots. Alice's writes go through
+// the same API the MCP uses, so bob replays real events, not hand-made lines.
+const seedRemote = async () => {
+	const {remoteRoot, repoRoot: alice} = await setupRepo();
+
+	const assumed = await assumeActor({repoRoot: alice, name: 'alice'});
+	if (isFail(assumed)) throw new Error(assumed.message);
+
+	const ownEventFileName = getPersistFileName(assumed.value);
+
+	const sync = () => syncEpiqWithRemote({cwd: alice, ownEventFileName});
+
+	const bootstrapped = await sync();
+	if (isFail(bootstrapped)) throw new Error(bootstrapped.message);
+
+	const bob = makeTempDir();
+	await cloneRepo({remoteRoot, cloneRoot: bob});
+	writeProjectFile(bob);
+
+	const seedBoard = async () => {
+		const defaults = createDefaultEvents(assumed.value);
+		if (isFail(defaults)) throw new Error(defaults.message);
+
+		const seeded = materializeAndPersistAll(
+			[...defaults.value] as AppEvent[],
+			bootstrapped.value.stateBranchRoot,
+		);
+		if (isFail(seeded)) throw new Error(seeded.message);
+
+		const pushed = await sync();
+		if (isFail(pushed)) throw new Error(pushed.message);
+	};
+
+	const writeIssue = async (title: string) => {
+		const boards = await listBoards({repoRoot: alice});
+		if (isFail(boards)) throw new Error(boards.message);
+
+		const swimlanes = await listSwimlanes({
+			repoRoot: alice,
+			boardId: boards.value[0]!.id,
+		});
+		if (isFail(swimlanes)) throw new Error(swimlanes.message);
+
+		const created = await createIssue({
+			repoRoot: alice,
+			title,
+			parentId: swimlanes.value[0]!.id,
+		});
+		if (isFail(created)) throw new Error(created.message);
+
+		const pushed = await sync();
+		if (isFail(pushed)) throw new Error(pushed.message);
+	};
+
+	const bobSync = async () => {
+		const result = await syncEpiqWithRemote({
+			cwd: bob,
+			ownEventFileName: 'u2.bob.jsonl',
+		});
+		if (isFail(result)) throw new Error(result.message);
+	};
+
+	return {bob, seedBoard, writeIssue, bobSync};
+};
+
+const titles = () => Object.values(getState().nodes).map(node => node.title);
+
+describe('loadProject against a remote', () => {
+	const originalCwd = process.cwd();
+
+	afterEach(() => {
+		process.chdir(originalCwd);
+		delete process.env[ACTOR_NAME_ENV];
+	});
+
+	it('boots from the local log and picks the remote up afterwards', async () => {
+		const {bob, seedBoard, writeIssue, bobSync} = await seedRemote();
+		await seedBoard();
+		await bobSync();
+		await writeIssue('written after boot');
+		process.chdir(bob);
+
+		const loaded = await loadProject(bob);
+		if (isFail(loaded)) throw new Error(loaded.message);
+
+		expect(titles()).not.toContain('written after boot');
+
+		const refreshed = await refreshProjectFromRemote(bob);
+		if (isFail(refreshed)) throw new Error(refreshed.message);
+
+		expect(titles()).toContain('written after boot');
+		expect(getState().syncStatus).toEqual({status: 'synced', msg: 'Pulled'});
+
+		const again = await refreshProjectFromRemote(bob);
+		if (isFail(again)) throw new Error(again.message);
+
+		expect(getState().syncStatus.msg).toBe('Already synced');
+	});
+
+	it('leaves the board alone when the project changed during the pull', async () => {
+		const {bob, seedBoard, writeIssue, bobSync} = await seedRemote();
+		await seedBoard();
+		await bobSync();
+		await writeIssue('written after boot');
+
+		const loaded = await loadProject(bob);
+		if (isFail(loaded)) throw new Error(loaded.message);
+
+		// Somewhere that is not bob's project, as after an `:open` elsewhere.
+		process.chdir(makeTempDir());
+
+		const refreshed = await refreshProjectFromRemote(bob);
+		if (isFail(refreshed)) throw new Error(refreshed.message);
+
+		expect(refreshed.message).toBe('Project changed during the pull');
+		expect(titles()).not.toContain('written after boot');
+	});
+
+	it('does not flag a board the remote has never seen', async () => {
+		// An origin, but the state branch exists only locally: never synced.
+		const {repoRoot} = await setupRepo();
+		const branch = await ensureLocalStateBranch({
+			repoRoot,
+			stateBranchName: DEFAULT_STATE_BRANCH,
+		});
+		if (isFail(branch)) throw new Error(branch.message);
+		process.chdir(repoRoot);
+
+		const loaded = await loadProject(repoRoot);
+		if (isFail(loaded)) throw new Error(loaded.message);
+
+		const refreshed = await refreshProjectFromRemote(repoRoot);
+		if (isFail(refreshed)) throw new Error(refreshed.message);
+
+		expect(getState().syncStatus.status).toBe('synced');
+	});
+
+	it('pulls first when there is no local log to boot from', async () => {
+		const {bob, seedBoard, bobSync} = await seedRemote();
+		await bobSync();
+		await seedBoard();
+
+		const loaded = await loadProject(bob);
+		if (isFail(loaded)) throw new Error(loaded.message);
+
+		expect(getState().hasInitializingEvents).toBe(true);
 	});
 });
 

--- a/source/test/open-project.cmd.test.ts
+++ b/source/test/open-project.cmd.test.ts
@@ -5,6 +5,7 @@ import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
 vi.mock('../lib/boot/load-project.js', () => ({
 	loadProject: vi.fn(),
+	refreshProjectInBackground: vi.fn(),
 }));
 
 vi.mock('../lib/state/cmd.state.js', () => ({


### PR DESCRIPTION
The TUI awaited a pull on the state worktree before drawing anything. On this board that is ~700 of ~800 ms boot; against a remote that does not answer it is a blank terminal for the whole TCP timeout.

Now `loadProject` materialises the local log and renders, and `refreshProjectFromRemote` runs after the first frame: the sync's own fetch-and-rebase pull under the sync lock, a reload only if HEAD moved, reported through the sync pill (`...` while pulling, then `Already synced` / `Pulled` / `off` / `---`). A clone whose log has no init event still pulls first, so it never draws the init prompt over an existing board. `:open` gets the same treatment, and a pull still in flight when `:open` switches projects skips its reload.

The reload tail of `syncAndReloadState` is extracted into `reloadStateFromEventLog` and shared.

Measured with a pty harness against an unreachable origin (`git://10.255.255.1`):

| build | board on screen |
|---|---|
| main | 75.3 s |
| this branch | 0.23 s (pill settles to `off` at 75 s) |

Stress run (960k events) matches main within noise.

Regression tests: boots from the local log then picks the remote up; pulls first when there is no local init event; skips the reload when the project changed during the pull; a board the remote has never seen is not flagged.

Review found the same project-switch race in the sync path on main; filed as 0YC23TC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fhBMbwzSZy6djvf77rZ6g