### PR TITLE
N1MV171 W5KWR6H landing: hero glow back, Get started plain

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -241,28 +241,12 @@ h1 {
 	flex-direction: row;
 	align-items: stretch;
 }
-/* Get started is the page's one primary action, so it alone carries the
-   accent: cyan text and border, a faint tint, and a glow that brightens on
-   hover. */
 .hero-cta {
 	min-height: 48px;
 	padding: 0 20px;
 	font: 14px var(--mono);
 	letter-spacing: -0.02em;
 	white-space: nowrap;
-	color: var(--cyan);
-	border-color: rgba(117, 210, 253, 0.55);
-	background: rgba(117, 210, 253, 0.06);
-	box-shadow: 0 0 0 1px rgba(117, 210, 253, 0.06),
-		0 0 28px rgba(117, 210, 253, 0.16);
-	transition: border-color 0.18s ease, background 0.18s ease,
-		box-shadow 0.18s ease;
-}
-.hero-cta:hover {
-	border-color: var(--cyan);
-	background: rgba(117, 210, 253, 0.12);
-	box-shadow: 0 0 0 1px rgba(117, 210, 253, 0.2),
-		0 0 36px rgba(117, 210, 253, 0.28);
 }
 /* In the install panel the commands are alternatives, so they share a width
    instead of each sizing to its own text and landing ragged. Full width also

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -576,11 +576,14 @@ h2 {
 	place-items: center;
 	text-align: center;
 }
+/* The hero clip alone keeps a faint glow, so it lifts off the page where
+   the media further down sits flat on it. */
 .hero-placeholder > img,
 .hero-placeholder > video {
 	width: 100%;
 	max-width: 1640px;
 	border-radius: 8px;
+	box-shadow: 0 0 64px rgba(76, 131, 158, 0.22);
 }
 /* The scrubber still is a near-black strip: no panel, no glow, and its
    edges fade out so it dissolves into the page instead of sitting on it. */


### PR DESCRIPTION
Two commits, one per ticket:

- W5KWR6H: Get started drops the cyan border, tint and glow from #243 and is a plain secondary button again.
- N1MV171: a faint glow returns on the hero clip only, softer than the one S80HXBG removed from all media. Everything further down stays flat.