### PR TITLE
Commits tab: counts on shut files, lone commit opens, caret and rail dot on the commit row

### DIFF
--- a/source/gui/client/components/IssueCommits.test.ts
+++ b/source/gui/client/components/IssueCommits.test.ts
@@ -21,6 +21,8 @@ const file: GuiCommitDiffFile = {
 	path: 'source/a.ts',
 	before: 'before one\nbefore two\nbefore three\nbefore four',
 	after: 'after one\nafter two\nafter three\nafter four',
+	insertions: 4,
+	deletions: 4,
 };
 
 describe('extractSnippet', () => {

--- a/source/gui/client/components/IssueCommits.tsx
+++ b/source/gui/client/components/IssueCommits.tsx
@@ -1003,8 +1003,14 @@ export const IssueCommits = ({
 	const autoOpenedShas = useRef(new Set<string>());
 	const autoOpenedFiles = useRef(new Set<string>());
 
+	// The reading layout opens every commit; either layout opens the only
+	// commit, since with one there is nothing to choose between and the click
+	// that would open it is just in the way. Once each, so collapsing it by
+	// hand sticks.
+	const openCommitsOnArrival = expandAll || commits.length === 1;
+
 	useEffect(() => {
-		if (!expandAll) return;
+		if (!openCommitsOnArrival) return;
 
 		const fresh = commits.filter(
 			commit => !autoOpenedShas.current.has(commit.sha),
@@ -1021,7 +1027,7 @@ export const IssueCommits = ({
 			const existing = diffsBySha[commit.sha];
 			if (!existing || existing.error) onLoadDiff(commit.sha);
 		}
-	}, [expandAll, commits]);
+	}, [openCommitsOnArrival, commits]);
 
 	// A commit's files open as they arrive, in either layout: the diff is what
 	// the reader came for. Once per commit, the moment its files first land,

--- a/source/gui/client/components/IssueCommits.tsx
+++ b/source/gui/client/components/IssueCommits.tsx
@@ -225,10 +225,13 @@ export const readDiffLocationParams = (
 
 // The timeline rail: a dot per commit, in the scrubber's own commit-series
 // color, connected to the next by a line. RAIL_DOT_OFFSET lines the dot up
-// with the header's text (padding-top plus half its line height), not the
-// row's overall height, which grows when a commit is expanded.
+// with the header's text — the card's border, then the header's padding,
+// then half its content height (the copy button, its tallest child, at 20px,
+// with the subject centred against it) — not the row's overall height, which
+// grows when a commit is expanded.
 const RAIL_WIDTH = 24;
-const RAIL_DOT_OFFSET = 19;
+const COMMIT_HEADER_PADDING = 13;
+const RAIL_DOT_OFFSET = 1 + COMMIT_HEADER_PADDING + 10;
 const ROW_GAP = 14;
 
 const disclosureStyle: React.CSSProperties = {
@@ -839,15 +842,21 @@ const CommitRow = ({
 				aria-expanded={expanded}
 				style={{
 					...disclosureStyle,
-					padding: '13px 14px',
+					padding: `${COMMIT_HEADER_PADDING}px 14px`,
 					background: revealed ? DISCLOSURE_HOVER_BG : 'transparent',
 				}}
 			>
-				{/* Subject leads the row with nothing before it — the sha and caret
-			    are lookup/navigation chrome, not part of reading the list, so
-			    they sit at the far right instead of crowding the start of every
-			    line. The sha itself only appears on hover or once expanded —
-			    reachable without a full expand, but not permanent clutter. */}
+				{/* The caret leads, as it does on the file rows, so a row reads as
+			    foldable and its state is plain. flexShrink: 0 because a tight
+			    panel width would otherwise squeeze it toward invisible rather
+			    than truncate the (already-shrinkable) subject further. */}
+				<span style={{flexShrink: 0, display: 'flex'}}>
+					{expanded ? (
+						<IconChevronDown size={12} />
+					) : (
+						<IconChevronRight size={12} />
+					)}
+				</span>
 				<span
 					style={{
 						flex: 1,
@@ -860,7 +869,10 @@ const CommitRow = ({
 					{commit.subject}
 				</span>
 				<DiffStat insertions={commit.insertions} deletions={commit.deletions} />
-				{/* Always mounted, opacity-toggled rather than conditionally rendered:
+				{/* The sha is lookup chrome, not part of reading the list, so it
+			    sits at the far right and only appears on hover or once expanded —
+			    reachable without a full expand, but not permanent clutter.
+			    Always mounted, opacity-toggled rather than conditionally rendered:
 			    swapping it in/out of the tree changed the row's flex height on
 			    hover, which the rail lines (sized off that height) visibly jumped
 			    with. Keeping it in flow always reserves the same space. */}
@@ -873,16 +885,6 @@ const CommitRow = ({
 					}}
 				>
 					<CopyShaButton sha={commit.sha} />
-				</span>
-				{/* Flex items shrink by default; without this a tight panel width
-			    squeezes the caret toward invisible rather than truncating the
-			    (already-shrinkable) subject text further. */}
-				<span style={{flexShrink: 0, display: 'flex'}}>
-					{expanded ? (
-						<IconChevronDown size={12} />
-					) : (
-						<IconChevronRight size={12} />
-					)}
 				</span>
 			</div>
 

--- a/source/gui/client/components/IssueCommits.tsx
+++ b/source/gui/client/components/IssueCommits.tsx
@@ -1,7 +1,6 @@
 import React, {useEffect, useRef, useState} from 'react';
 import {
 	DiffLineAnnotation,
-	FileDiffMetadata,
 	SelectedLineRange,
 	SelectionSide,
 } from '@pierre/diffs/react';
@@ -476,15 +475,12 @@ const DiffCommentAnnotation = ({
 // The one header a file gets, open or shut. Open, the highlighter renders it
 // in its sticky slot in place of its own (change icon, name, counts), so the
 // name that stays in view while the diff scrolls is also the one that folds
-// it; shut, FileRow stands it in the same box by itself. The counts come off
-// the highlighter's own parse, so they only appear once the diff is open — a
-// shut file is not parsed at all.
+// it; shut, FileRow stands it in the same box by itself.
 const FileHeader = ({
 	file,
 	expanded,
 	onToggle,
 	commentCount,
-	stat,
 	reviewed,
 	onReviewed,
 }: {
@@ -492,7 +488,6 @@ const FileHeader = ({
 	expanded: boolean;
 	onToggle: () => void;
 	commentCount: number;
-	stat?: FileDiffMetadata;
 	reviewed: boolean;
 	onReviewed: (next: boolean) => void;
 }) => {
@@ -576,18 +571,7 @@ const FileHeader = ({
 					</span>
 				)}
 			</button>
-			{stat && (
-				<DiffStat
-					insertions={stat.hunks.reduce(
-						(sum, hunk) => sum + hunk.additionLines,
-						0,
-					)}
-					deletions={stat.hunks.reduce(
-						(sum, hunk) => sum + hunk.deletionLines,
-						0,
-					)}
-				/>
-			)}
+			<DiffStat insertions={file.insertions} deletions={file.deletions} />
 			{/* Beside the toggle rather than inside it: ticking a file off must
 			    not also fold or unfold it by accident. */}
 			<Checkbox
@@ -698,13 +682,12 @@ const FileRow = ({
 		});
 	}
 
-	const header = (stat?: FileDiffMetadata) => (
+	const header = () => (
 		<FileHeader
 			file={file}
 			expanded={expanded}
 			onToggle={onToggle}
 			commentCount={fileComments.length}
-			stat={stat}
 			reviewed={reviewed}
 			onReviewed={onReviewed}
 		/>

--- a/source/gui/client/lib/gui-state.model.ts
+++ b/source/gui/client/lib/gui-state.model.ts
@@ -133,6 +133,8 @@ export type GuiCommitDiffFile = {
 	path: string;
 	before: string;
 	after: string;
+	insertions: number;
+	deletions: number;
 };
 
 export type GuiCommitDiff = {

--- a/source/mcp/epiq-time-travel.ts
+++ b/source/mcp/epiq-time-travel.ts
@@ -566,6 +566,8 @@ export type CommitDiffFile = {
 	path: string;
 	before: string;
 	after: string;
+	insertions: number;
+	deletions: number;
 };
 
 export type CommitDiff = {
@@ -588,6 +590,10 @@ const isZeroBlob = (hash: string): boolean => /^0+$/.test(hash);
 const RAW_DIFF_LINE =
 	/^:\d{6} \d{6} ([0-9a-f]{40}) ([0-9a-f]{40}) [A-Z]\d*\t(.+)$/;
 
+// `<insertions>\t<deletions>\t<path>`, or `-\t-\t<path>` for a binary file,
+// which has no line count to give.
+const NUMSTAT_LINE = /^(\d+|-)\t(\d+|-)\t(.+)$/;
+
 type ChangedFileBlobs = {
 	path: string;
 	// null means "no blob on this side" (the file was added or deleted here),
@@ -595,12 +601,17 @@ type ChangedFileBlobs = {
 	// blob as — not a git failure.
 	beforeBlob: string | null;
 	afterBlob: string | null;
+	insertions: number;
+	deletions: number;
 };
 
 // Blob hashes straight from git's own diff, rather than getChangedFilePaths'
 // name-only listing: this is what lets getCommitDiff below read every
 // changed file's content in one `git cat-file --batch` round trip instead of
-// two `git show` spawns per file. `--abbrev=40` forces full hashes — unlike
+// two `git show` spawns per file. `--numstat` rides along in the same spawn,
+// so each file's line counts come for free: git prints the raw block and the
+// numstat block one after the other, and the two line shapes are disjoint.
+// `--abbrev=40` forces full hashes — unlike
 // `--full-index` (documented for this but, at least as of Apple Git 2.39.5,
 // a no-op outside of `-p` patch output), this reliably defeats the
 // repo-size-dependent abbreviation `--raw` uses by default.
@@ -610,35 +621,63 @@ const getChangedFileBlobs = async (
 ): Promise<Result<ChangedFileBlobs[]>> => {
 	const diffResult = await execGit({
 		cwd: repoRoot,
-		args: ['diff', '--raw', '--no-renames', '--abbrev=40', `${sha}~1`, sha],
+		args: [
+			'diff',
+			'--raw',
+			'--numstat',
+			'--no-renames',
+			'--abbrev=40',
+			`${sha}~1`,
+			sha,
+		],
 	});
 	if (isFail(diffResult)) return failed(diffResult.message);
 
 	const lines = diffResult.value.stdout.split('\n').filter(line => line !== '');
 
-	// A line git's --raw format doesn't match is a sign the assumed format
-	// itself is wrong for this git version/commit shape (already bit once
-	// this session: --full-index turned out to be a no-op here) — surfacing
-	// it as a failure beats silently under-reporting a commit's real files.
-	const unparseable = lines.filter(line => !RAW_DIFF_LINE.test(line));
+	// A line neither format matches is a sign the assumed format itself is
+	// wrong for this git version/commit shape (already bit once this session:
+	// --full-index turned out to be a no-op) — surfacing it as a failure beats
+	// silently under-reporting a commit's real files.
+	const unparseable = lines.filter(
+		line => !RAW_DIFF_LINE.test(line) && !NUMSTAT_LINE.test(line),
+	);
 	if (unparseable.length > 0) {
 		return failed(
-			`Could not parse ${unparseable.length} line(s) of "git diff --raw" output, e.g. "${unparseable[0]}"`,
+			`Could not parse ${unparseable.length} line(s) of "git diff --raw --numstat" output, e.g. "${unparseable[0]}"`,
 		);
 	}
 
-	const entries = lines.map((line): ChangedFileBlobs => {
-		const match = RAW_DIFF_LINE.exec(line);
-		const beforeBlob = match?.[1] ?? '';
-		const afterBlob = match?.[2] ?? '';
-		const path = match?.[3] ?? '';
+	// A binary file's `-` counts as nothing changed line-wise, which is true.
+	const countsByPath = new Map<
+		string,
+		{insertions: number; deletions: number}
+	>();
+	for (const line of lines) {
+		const match = NUMSTAT_LINE.exec(line);
+		if (!match) continue;
 
-		return {
-			path,
-			beforeBlob: isZeroBlob(beforeBlob) ? null : beforeBlob,
-			afterBlob: isZeroBlob(afterBlob) ? null : afterBlob,
-		};
-	});
+		countsByPath.set(match[3] ?? '', {
+			insertions: match[1] === '-' ? 0 : Number(match[1]),
+			deletions: match[2] === '-' ? 0 : Number(match[2]),
+		});
+	}
+
+	const entries = lines
+		.filter(line => RAW_DIFF_LINE.test(line))
+		.map((line): ChangedFileBlobs => {
+			const match = RAW_DIFF_LINE.exec(line);
+			const beforeBlob = match?.[1] ?? '';
+			const afterBlob = match?.[2] ?? '';
+			const path = match?.[3] ?? '';
+
+			return {
+				path,
+				beforeBlob: isZeroBlob(beforeBlob) ? null : beforeBlob,
+				afterBlob: isZeroBlob(afterBlob) ? null : afterBlob,
+				...(countsByPath.get(path) ?? {insertions: 0, deletions: 0}),
+			};
+		});
 
 	if (entries.length === 0) {
 		return failed('No changed files found for this commit');
@@ -690,6 +729,8 @@ export const getCommitDiff = async (
 		path: entry.path,
 		before: entry.beforeBlob ? blobs.get(entry.beforeBlob) ?? '' : '',
 		after: entry.afterBlob ? blobs.get(entry.afterBlob) ?? '' : '',
+		insertions: entry.insertions,
+		deletions: entry.deletions,
 	}));
 
 	return succeeded('Loaded commit diff', {sha: input.sha, files});

--- a/source/test/e2e-gui/fullscreen-lanes.pw.ts
+++ b/source/test/e2e-gui/fullscreen-lanes.pw.ts
@@ -106,12 +106,16 @@ test('the lanes open every commit and file, ready to read', async ({
 	)?.trim();
 	expect(ref).toBeTruthy();
 
+	// Two commits: a lone one opens on its own in either layout, and the point
+	// here is what the lanes do that the tabs do not.
 	const fileName = linkedFileName(ref!);
+	const otherFile = `other-${ref}.txt`;
 	commitLinkedFile(repoRoot, ref!, 'add notes');
+	commitLinkedFile(repoRoot, ref!, 'add more', otherFile);
 	await page.waitForTimeout(COMMIT_CACHE_MS);
 	await page.reload();
 	await expect(
-		page.getByRole('button', {name: /^Commits \(1\)/}),
+		page.getByRole('button', {name: /^Commits \(2\)/}),
 	).toBeVisible();
 
 	// Tabbed: collapsed, as before.
@@ -121,15 +125,15 @@ test('the lanes open every commit and file, ready to read', async ({
 	).toHaveAttribute('aria-expanded', 'false');
 	await expect(page.locator('[data-line]')).toHaveCount(0);
 
-	// Lanes: the diff is simply there.
+	// Lanes: the diffs are simply there.
 	await page.getByTitle('Fullscreen').click();
 	await expect(page.getByTestId('lane-commits')).toBeVisible();
-	await expect(page.locator('[data-line]')).toHaveCount(3);
+	await expect(page.locator('[data-line]')).toHaveCount(6);
 	await expect(page.locator('[data-line]').first()).toHaveText('alpha');
 
 	// And collapsing by hand sticks.
 	await page.getByRole('button', {name: fileName}).click();
-	await expect(page.locator('[data-line]')).toHaveCount(0);
+	await expect(page.locator('[data-line]')).toHaveCount(3);
 
 	expect(pageErrors).toEqual([]);
 });

--- a/source/test/e2e-gui/large-diff.pw.ts
+++ b/source/test/e2e-gui/large-diff.pw.ts
@@ -55,7 +55,11 @@ test('a commit opens the ordinary files and leaves a lockfile shut', async ({
 	await expect(page.locator('aside')).toContainText(`Lockfile ${stamp}`);
 
 	await page.getByRole('button', {name: /^Commits/}).click();
-	await page.getByRole('button', {name: 'bump deps'}).click();
+	// The ticket's only commit, so the tab opens it on its own.
+	await expect(page.getByRole('button', {name: /^bump deps/})).toHaveAttribute(
+		'aria-expanded',
+		'true',
+	);
 
 	const code = page.getByRole('button', {name: codeFile});
 	const lock = page.getByRole('button', {name: lockFile});

--- a/source/test/e2e-gui/lone-commit.pw.ts
+++ b/source/test/e2e-gui/lone-commit.pw.ts
@@ -1,0 +1,55 @@
+import type {Page} from '@playwright/test';
+import {expect, test} from './fixtures.js';
+import {
+	COMMIT_CACHE_MS,
+	commitLinkedFile,
+	linkedFileName,
+} from './linked-commit.js';
+
+const addTicket = async (page: Page, title: string) => {
+	await page.getByTitle('Add issue').first().click();
+	await page.getByPlaceholder('issue name').fill(title);
+	await page.getByPlaceholder('issue name').press('Enter');
+	await expect(page.locator('aside')).toContainText(title);
+};
+
+test.beforeEach(async ({page, appUrl}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+});
+
+// With one commit there is nothing to choose between, so the tab opens it
+// rather than waiting for the click that would.
+test('a ticket with a single commit opens it unasked', async ({
+	page,
+	pageErrors,
+	repoRoot,
+}) => {
+	await addTicket(page, `Lone ${Date.now()}`);
+	const ref = (
+		await page.locator('aside button[title^="Copy "]').first().textContent()
+	)?.trim();
+	expect(ref).toBeTruthy();
+
+	commitLinkedFile(repoRoot, ref!, 'add notes');
+	await page.waitForTimeout(COMMIT_CACHE_MS);
+	await page.reload();
+	await expect(
+		page.getByRole('button', {name: /^Commits \(1\)/}),
+	).toBeVisible();
+
+	await page.getByRole('button', {name: /^Commits/}).click();
+	const commit = page.getByRole('button', {name: 'add notes +3 -0'});
+	await expect(commit).toHaveAttribute('aria-expanded', 'true');
+	await expect(
+		page.getByRole('button', {name: linkedFileName(ref!)}),
+	).toHaveAttribute('aria-expanded', 'true');
+	await expect(page.locator('[data-line]')).toHaveCount(3);
+
+	// Opened once: shutting it by hand sticks.
+	await commit.click();
+	await expect(commit).toHaveAttribute('aria-expanded', 'false');
+	await expect(page.locator('[data-line]')).toHaveCount(0);
+
+	expect(pageErrors).toEqual([]);
+});

--- a/source/test/e2e-gui/reviewed-files.pw.ts
+++ b/source/test/e2e-gui/reviewed-files.pw.ts
@@ -58,10 +58,12 @@ test('a file ticked off as reviewed folds, and arrives folded next time', async 
 	await expect(toggle(files[1]!)).toHaveAttribute('aria-expanded', 'true');
 	await expect(reviewed(files[0]!)).not.toBeChecked();
 
-	// Ticking one off folds it; the other is untouched.
+	// Ticking one off folds it; the other is untouched. Folded, it still says
+	// how big it is.
 	await reviewed(files[0]!).check();
 	await expect(toggle(files[0]!)).toHaveAttribute('aria-expanded', 'false');
 	await expect(toggle(files[1]!)).toHaveAttribute('aria-expanded', 'true');
+	await expect(row(files[0]!)).toContainText('+2');
 
 	// Folded, it can still be opened for another look without unticking it.
 	await toggle(files[0]!).click();

--- a/source/test/e2e-gui/reviewed-files.pw.ts
+++ b/source/test/e2e-gui/reviewed-files.pw.ts
@@ -44,7 +44,9 @@ test('a file ticked off as reviewed folds, and arrives folded next time', async 
 	await page.reload();
 	await expect(page.locator('aside')).toContainText(`Review ${stamp}`);
 	await page.getByRole('button', {name: /^Commits/}).click();
-	await page.getByRole('button', {name: 'two files'}).click();
+	// The ticket's only commit, so the tab opens it on its own.
+	const commit = page.getByRole('button', {name: /^two files/});
+	await expect(commit).toHaveAttribute('aria-expanded', 'true');
 
 	const row = (fileName: string) =>
 		page.getByTestId('file-row').filter({hasText: fileName});
@@ -74,7 +76,7 @@ test('a file ticked off as reviewed folds, and arrives folded next time', async 
 	await page.reload();
 	await expect(page.locator('aside')).toContainText(`Review ${stamp}`);
 	await page.getByRole('button', {name: /^Commits/}).click();
-	await page.getByRole('button', {name: 'two files'}).click();
+	await expect(commit).toHaveAttribute('aria-expanded', 'true');
 
 	await expect(reviewed(files[0]!)).toBeChecked();
 	await expect(toggle(files[0]!)).toHaveAttribute('aria-expanded', 'false');

--- a/source/test/epiq-time-travel.test.ts
+++ b/source/test/epiq-time-travel.test.ts
@@ -1359,8 +1359,17 @@ describe('epiq-time-travel', () => {
 		// no blob (the file was added or deleted at this commit) — the zero hash
 		// getChangedFileBlobs reads as "no blob on this side", same convention
 		// its caller already keys off.
+		// `binary` stands in for git's `-\t-` numstat line, a file with no line
+		// count to give.
 		const mockGitForFiles = (
-			entries: {path: string; before?: string; after?: string}[],
+			entries: {
+				path: string;
+				before?: string;
+				after?: string;
+				insertions?: number;
+				deletions?: number;
+				binary?: boolean;
+			}[],
 		) => {
 			const blobs = new Map<string, string>();
 
@@ -1375,20 +1384,27 @@ describe('epiq-time-travel', () => {
 
 			vi.mocked(execGit).mockImplementation(async ({args}) => {
 				if (args[0] === 'diff') {
-					const stdout = entries
-						.map(entry => {
-							const beforeBlob =
-								entry.before !== undefined
-									? blobHash(`before:${entry.path}`)
-									: ZERO_BLOB;
-							const afterBlob =
-								entry.after !== undefined
-									? blobHash(`after:${entry.path}`)
-									: ZERO_BLOB;
+					const raw = entries.map(entry => {
+						const beforeBlob =
+							entry.before !== undefined
+								? blobHash(`before:${entry.path}`)
+								: ZERO_BLOB;
+						const afterBlob =
+							entry.after !== undefined
+								? blobHash(`after:${entry.path}`)
+								: ZERO_BLOB;
 
-							return `:100644 100644 ${beforeBlob} ${afterBlob} M\t${entry.path}`;
-						})
-						.join('\n');
+						return `:100644 100644 ${beforeBlob} ${afterBlob} M\t${entry.path}`;
+					});
+					// The raw block first, then the numstat block, as git prints them.
+					const numstat = entries.map(entry =>
+						entry.binary
+							? `-\t-\t${entry.path}`
+							: `${entry.insertions ?? 0}\t${entry.deletions ?? 0}\t${
+									entry.path
+							  }`,
+					);
+					const stdout = [...raw, ...numstat].join('\n');
 
 					return succeeded('changed files', {stdout, stderr: '', exitCode: 0});
 				}
@@ -1424,10 +1440,51 @@ describe('epiq-time-travel', () => {
 				expect(result.value).toEqual({
 					sha: validSha,
 					files: [
-						{path: 'source/a.ts', before: 'a before', after: 'a after'},
-						{path: 'source/b.ts', before: 'b before', after: 'b after'},
+						{
+							path: 'source/a.ts',
+							before: 'a before',
+							after: 'a after',
+							insertions: 0,
+							deletions: 0,
+						},
+						{
+							path: 'source/b.ts',
+							before: 'b before',
+							after: 'b after',
+							insertions: 0,
+							deletions: 0,
+						},
 					],
 				});
+			}
+		});
+
+		it("carries each file's line counts, reading a binary's as none", async () => {
+			mockGitForFiles([
+				{
+					path: 'source/a.ts',
+					before: 'a',
+					after: 'b',
+					insertions: 7,
+					deletions: 2,
+				},
+				{path: 'logo.png', before: 'x', after: 'y', binary: true},
+			]);
+
+			const result = await getCommitDiff({sha: validSha});
+
+			expect(isSuccess(result)).toBe(true);
+			if (isSuccess(result)) {
+				expect(
+					result.value.files.map(({path, insertions, deletions}) => ({
+						path,
+						insertions,
+						deletions,
+					})),
+				).toEqual([
+					{path: 'source/a.ts', insertions: 7, deletions: 2},
+					{path: 'logo.png', insertions: 0, deletions: 0},
+				]);
 			}
 		});
 
@@ -1445,6 +1502,8 @@ describe('epiq-time-travel', () => {
 						path: 'source/new-file.ts',
 						before: '',
 						after: 'brand new content',
+						insertions: 0,
+						deletions: 0,
 					},
 				]);
 			}
@@ -1544,6 +1603,7 @@ describe('epiq-time-travel', () => {
 					args: [
 						'diff',
 						'--raw',
+						'--numstat',
 						'--no-renames',
 						'--abbrev=40',
 						`${validSha}~1`,
@@ -1554,7 +1614,13 @@ describe('epiq-time-travel', () => {
 			expect(isSuccess(result)).toBe(true);
 			if (isSuccess(result)) {
 				expect(result.value.files).toEqual([
-					{path: 'source/a.ts', before: 'before', after: 'after'},
+					{
+						path: 'source/a.ts',
+						before: 'before',
+						after: 'after',
+						insertions: 0,
+						deletions: 0,
+					},
 				]);
 			}
 		});


### PR DESCRIPTION
Three tickets, one commit each, following up #247 on the ticket's Commits tab:

- **YS1NXGK** A collapsed file header still shows its +N/-N. `getCommitDiff` adds `--numstat` to the same `git diff --raw` spawn (the two line shapes are disjoint, so one parse sorts them), carries `insertions`/`deletions` on each file, and the header draws its stat from that in both states instead of from pierre's parse, which only existed once the diff was open. A binary's `-` reads as zero.
- **S2MWH9F** A ticket with a single commit opens it unasked, in either layout: with one there is nothing to choose between. Opened once, so shutting it by hand sticks. `fullscreen-lanes` now seeds two commits so the tabbed layout still has something shut to contrast with the lanes; new `lone-commit.pw.ts`.
- **Z3KAERC** The commit row leads with its caret, as the file rows do, instead of hiding it after the copy button; and the rail dot sits on the subject's text line. The offset is now derived (card border + header padding + half the header's content height) rather than a magic 19, and measured in the browser as coinciding with the subject's centre to the pixel.

The pre-push gate passed in full on this push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163q29TNaRARP6hCVUadp5o
