### PR TITLE
EM8829M key the carried board selection to its query, so a re-render cannot put the ticket narrowing back on

### DIFF
--- a/source/gui/client/lib/board-selection.test.ts
+++ b/source/gui/client/lib/board-selection.test.ts
@@ -3,6 +3,9 @@ import {GuiEventIdentity} from './gui-state.model';
 import {
 	applySelectionPatch,
 	BoardSelection,
+	carryChange,
+	carryRender,
+	DEFAULT_CARRY,
 	DEFAULT_SELECTION,
 	hasSelectionParams,
 	hiddenIdsFor,
@@ -10,6 +13,7 @@ import {
 	isolateOnly,
 	readSelectionParams,
 	readStoredSelection,
+	SelectionCarry,
 	storeSelection,
 	toggleOnly,
 	withSelectedIdentities,
@@ -304,6 +308,63 @@ describe('stored selection', () => {
 
 		localStorage.setItem('epiq.board.selection', '{"scope":"never","only":3}');
 		expect(readStoredSelection()).toEqual(DEFAULT_SELECTION);
+	});
+});
+
+describe('carried selection', () => {
+	// What the hook does with these: derive the selection from the query, or
+	// from the carried values when the query says nothing, then offer that
+	// selection back to the carry.
+	const derive = (carry: SelectionCarry, query: string): BoardSelection =>
+		readSelectionParams(params(query)) ?? {
+			...readStoredSelection(),
+			...carry.values,
+		};
+
+	const render = (carry: SelectionCarry, query: string) => {
+		const selection = derive(carry, query);
+		return {carry: carryRender(carry, query, selection), selection};
+	};
+
+	it('picks the four up from a query that names them', () => {
+		const {carry} = render(DEFAULT_CARRY, 'ticket=1&scope=week&offset=2');
+		expect(carry.values.ticketOnly).toBe(true);
+		expect(carry.values.offset).toBe(2);
+	});
+
+	it('hands them to a query that has been rebuilt without them', () => {
+		const {carry} = render(DEFAULT_CARRY, 'ticket=1');
+		const opened = render(carry, '');
+		expect(opened.selection.ticketOnly).toBe(true);
+	});
+
+	// The bug: a change is two steps — the carried values, then the URL a
+	// render later — and a re-render from anywhere else lands in between still
+	// holding the pre-change query. Unkeyed it read the switched-off narrowing
+	// back over the change, and the empty query then put it straight back on.
+	it('survives a re-render landing between the change and its URL', () => {
+		let {carry} = render(DEFAULT_CARRY, 'ticket=1');
+
+		const next = applySelectionPatch(derive(carry, 'ticket=1'), {
+			ticketOnly: false,
+		});
+		carry = carryChange(carry, next);
+
+		({carry} = render(carry, 'ticket=1'));
+
+		expect(render(carry, '').selection.ticketOnly).toBe(false);
+	});
+
+	// The same guard must not stick: once the query really does move on, what
+	// it says is newer than anything held here.
+	it('takes up what a later query says', () => {
+		let {carry} = render(DEFAULT_CARRY, 'ticket=1');
+		carry = carryChange(carry, {...derive(carry, 'ticket=1'), offset: 3});
+
+		({carry} = render(carry, 'window=1'));
+		expect(carry.values.windowOnly).toBe(true);
+		expect(carry.values.ticketOnly).toBe(false);
+		expect(carry.values.offset).toBe(0);
 	});
 });
 

--- a/source/gui/client/lib/board-selection.ts
+++ b/source/gui/client/lib/board-selection.ts
@@ -147,6 +147,55 @@ export const applySelectionPatch = (
 	});
 };
 
+// ---------------------------------------------------------------- carrying
+
+// What a route change carries that neither the rebuilt query nor storage does:
+// opening a ticket rebuilds the query from scratch, and none of a board
+// narrowed to a window, a stretch dragged out of the chart, or a window paged
+// back off the present must come undone under the reader who clicked one of
+// the cards it left showing.
+export type CarriedSelection = Pick<
+	BoardSelection,
+	'offset' | 'zoom' | 'windowOnly' | 'ticketOnly'
+>;
+
+// The carried values together with the query they were read out of. The query
+// is what makes a change survive: writing one is two steps — the values here,
+// then the URL a render later — and any re-render in between still reads the
+// pre-change query. Keyed, such a render is recognised as having nothing newer
+// to say and leaves the values alone; unkeyed it reads the switched-off
+// narrowing back over them, and a bare query then puts it straight back on.
+export type SelectionCarry = {query: string; values: CarriedSelection};
+
+const carriedFrom = (selection: BoardSelection): CarriedSelection => ({
+	offset: selection.offset,
+	zoom: selection.zoom,
+	windowOnly: selection.windowOnly,
+	ticketOnly: selection.ticketOnly,
+});
+
+export const DEFAULT_CARRY: SelectionCarry = {
+	query: '',
+	values: carriedFrom(DEFAULT_SELECTION),
+};
+
+// A render offering the selection it derived. The query is compared as a
+// string rather than by identity, since a fresh URLSearchParams for the same
+// query says nothing new either.
+export const carryRender = (
+	carry: SelectionCarry,
+	query: string,
+	selection: BoardSelection,
+): SelectionCarry =>
+	carry.query === query ? carry : {query, values: carriedFrom(selection)};
+
+// A change, ahead of the URL it is about to write. The query stays the one
+// these values now supersede, so the renders still holding it are skipped.
+export const carryChange = (
+	carry: SelectionCarry,
+	next: BoardSelection,
+): SelectionCarry => ({query: carry.query, values: carriedFrom(next)});
+
 // ------------------------------------------------------------------- the URL
 
 export const hasSelectionParams = (params: URLSearchParams): boolean =>

--- a/source/gui/client/lib/use-board-selection.ts
+++ b/source/gui/client/lib/use-board-selection.ts
@@ -3,16 +3,17 @@ import {useSearchParams} from 'react-router-dom';
 import {
 	applySelectionPatch,
 	BoardSelection,
+	carryChange,
+	carryRender,
+	DEFAULT_CARRY,
 	hasSelectionParams,
 	isDefaultSelection,
 	readSelectionParams,
 	readStoredSelection,
+	SelectionCarry,
 	storeSelection,
 	writeSelectionParams,
 } from './board-selection';
-
-// What a route change carries that neither the rebuilt query nor storage does.
-type CarriedKey = 'offset' | 'zoom' | 'windowOnly' | 'ticketOnly';
 
 // The URL wins when it says anything; a bare board link falls back to what
 // was last used here, and gets that written into the address bar so copying
@@ -25,36 +26,24 @@ export const useBoardSelection = (): [
 
 	const fromUrl = hasSelectionParams(searchParams);
 
-	// The four storage does not keep, carried across the routes of this
-	// session instead: opening a ticket rebuilds the query from scratch, and
-	// none of a board narrowed to a window, a stretch dragged out of the chart,
-	// or a window paged back off the present must come undone under the reader
-	// who clicked one of the cards it left showing. A reload still starts wide,
-	// unzoomed and at the present — where somebody is looking is a moment, not
-	// a preference to restore.
+	// The four storage does not keep, carried across the routes of this session
+	// instead. A reload still starts wide, unzoomed and at the present — where
+	// somebody is looking is a moment, not a preference to restore.
 	//
 	// The ticket narrowing travels with them, so it follows to whichever ticket
 	// is opened next and re-derives there rather than being cancelled by the
 	// click that moved between them.
-	const carried = useRef<Pick<BoardSelection, CarriedKey>>({
-		offset: 0,
-		zoom: null,
-		windowOnly: false,
-		ticketOnly: false,
-	});
+	const carried = useRef<SelectionCarry>(DEFAULT_CARRY);
+
+	const query = searchParams.toString();
 
 	const selection = useMemo(() => {
 		const fromParams = readSelectionParams(searchParams);
 
-		return fromParams ?? {...readStoredSelection(), ...carried.current};
+		return fromParams ?? {...readStoredSelection(), ...carried.current.values};
 	}, [searchParams]);
 
-	carried.current = {
-		offset: selection.offset,
-		zoom: selection.zoom,
-		windowOnly: selection.windowOnly,
-		ticketOnly: selection.ticketOnly,
-	};
+	carried.current = carryRender(carried.current, query, selection);
 
 	useEffect(() => {
 		if (fromUrl) {
@@ -88,14 +77,8 @@ export const useBoardSelection = (): [
 			// Carried forward here rather than waiting for the render the new URL
 			// causes: turning the last of these off empties the query, and a bare
 			// query reads the carried values back — which, a beat before that
-			// render, are still the ones just switched off. The narrowing would
-			// put itself straight back on.
-			carried.current = {
-				offset: next.offset,
-				zoom: next.zoom,
-				windowOnly: next.windowOnly,
-				ticketOnly: next.ticketOnly,
-			};
+			// render, would still be the ones just switched off.
+			carried.current = carryChange(carried.current, next);
 
 			setSearchParams(
 				prev => {


### PR DESCRIPTION
Unticking "Ticket only" could silently fail: the box went back to ticked and `?ticket=1` reappeared in the URL.

Found because `5NPENPY`'s own e2e — "it follows to the next ticket rather than being cancelled by it" — failed in a loaded pre-push run. It looked like a flake (it passes 131/131 on a quiet machine), but it is a real race.

### The race

`useBoardSelection` carries four values a route change would otherwise drop (`offset`, `zoom`, `windowOnly`, `ticketOnly`) in a ref written during render, from the selection it derives off `searchParams`. Writing a change is therefore two steps: the ref first, then the URL a render later.

Any unrelated re-render landing between those two steps still reads the pre-change query — a `timeline` message off the socket is enough. It recomputes the selection from `ticket=1` and puts `ticketOnly: true` back over the change. The bare query then arrives, `hasSelectionParams` is false, so the selection falls back to the carried values — now reverted — and the effect writes `ticket=1` back into the address bar.

That is exactly what the ref's own comment says it exists to prevent; the guard just could not survive an interleaving render. Reachable in normal use, not only under test load.

### The fix

The carried values now travel with the query they were read out of (`SelectionCarry = {query, values}`), moved only by `carryRender` and `carryChange`:

- `carryRender` returns the carry unchanged when the query matches the one already held, so the stale render is recognised as having nothing newer to say.
- `carryChange` keeps the *old* query as the key, since its values are precisely the ones superseding it.

Compared as a string, not by identity: react-router 7 can hand back a fresh `URLSearchParams` for the same query, in which case the `useMemo` recomputes from the stale query and clobbers just the same — identity comparison would have fixed only half of it.

Pulled out as pure functions so the race is a unit test rather than an e2e that only fails under load. `useBoardSelection` got shorter on the way: the inline `CarriedKey` type and both hand-rolled field copies are gone.

### Testing

Four cases in `board-selection.test.ts`, the key one replaying render `ticket=1` → change to `ticketOnly: false` → stale re-render on the old query → the bare query landing. Verified red before green: with the guard removed it fails `expected true to be false`, the same symptom as the browser.

Full gate green: lint, typecheck, 1234 unit, containers (17 e2e, 15 collaboration), 131/131 GUI browser including the previously failing case.

Closes `EM8829M`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Vuz7fJrAAc5jn53RsYhdX
