### PR TITLE
Board filters combine across axes, and narrow by who triggered the event

### DIFF
--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -400,10 +400,13 @@ export const App = () => {
 
 	// Who caused an event on each ticket, for the axis the board state cannot
 	// answer. Null past the server's cap, which leaves that axis unenforced
-	// rather than emptying the board.
+	// rather than emptying the board — and null while nobody is narrowing by it,
+	// which is nearly always: this walks the whole window, and a needle drag
+	// broadcasts a new one several times a second.
+	const narrowsByActor = selection.only.actor !== undefined;
 	const eventActorIds = useMemo(
-		() => actorIdsByIssue(history.timeline),
-		[history.timeline],
+		() => (narrowsByActor ? actorIdsByIssue(history.timeline) : null),
+		[narrowsByActor, history.timeline],
 	);
 
 	const zoomed = selection.zoom !== null;

--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -63,6 +63,7 @@ import {
 	GuiUser,
 } from './lib/gui-state.model';
 import {
+	actorIdsByIssue,
 	buildBoardFilter,
 	FilterAxis,
 	isPeriodWindow,
@@ -397,6 +398,14 @@ export const App = () => {
 		[selection.only],
 	);
 
+	// Who caused an event on each ticket, for the axis the board state cannot
+	// answer. Null past the server's cap, which leaves that axis unenforced
+	// rather than emptying the board.
+	const eventActorIds = useMemo(
+		() => actorIdsByIssue(history.timeline),
+		[history.timeline],
+	);
+
 	const zoomed = selection.zoom !== null;
 
 	// The tickets the scrubber's window has an event for, once the board has
@@ -444,6 +453,7 @@ export const App = () => {
 			tag: state?.tags ?? [],
 			commenter: users,
 			assignee: users,
+			actor: users,
 		} satisfies Record<FilterAxis, GuiEventIdentity[]>;
 	}, [state?.tags, state?.contributors, contributors]);
 
@@ -472,6 +482,10 @@ export const App = () => {
 							commenterIds: (commentsByIssueId[issue.id] ?? []).map(
 								comment => comment.author.id,
 							),
+							actorIds:
+								eventActorIds === null
+									? null
+									: [...(eventActorIds.get(issue.id) ?? [])],
 						},
 						boardFilter,
 					) &&
@@ -491,6 +505,7 @@ export const App = () => {
 		boardFilter,
 		textFilter,
 		commentsByIssueId,
+		eventActorIds,
 		windowIds,
 		isolatedIssueId,
 	]);

--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -436,14 +436,19 @@ export const App = () => {
 	const tagOnly = selection.only.tag ?? null;
 	const isolatedTagId = tagOnly?.length === 1 ? tagOnly[0] ?? null : null;
 
-	// Points the chart at tags as well as narrowing the board to one: a chip is
-	// a "show me this tag" gesture, and the picture above answering it in the
-	// tag's own colour is the half the board cannot show.
-	const filterByTag = (tagId: string) =>
+	// Narrowing to a chip points the chart at tags as well: a chip is a "show me
+	// this tag" gesture, and the picture above answering it in the tag's own
+	// colour is the half the board cannot show. Pressing the lit one again only
+	// lets go of the tag — it is not an ask for a series, so whatever the chart
+	// had been switched to since stays where it is.
+	const filterByTag = (tagId: string) => {
+		const next = isolateOnly(tagOnly, tagId);
+
 		changeSelection({
-			view: 'tagging',
-			only: withNarrowing(selection.only, 'tag', isolateOnly(tagOnly, tagId)),
+			...(next === null ? {} : {view: 'tagging' as const}),
+			only: withNarrowing(selection.only, 'tag', next),
 		});
+	};
 
 	// For naming a selected identity the scrubber's window has no event for.
 	const knownIdentities = useMemo(() => {

--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -436,8 +436,12 @@ export const App = () => {
 	const tagOnly = selection.only.tag ?? null;
 	const isolatedTagId = tagOnly?.length === 1 ? tagOnly[0] ?? null : null;
 
+	// Points the chart at tags as well as narrowing the board to one: a chip is
+	// a "show me this tag" gesture, and the picture above answering it in the
+	// tag's own colour is the half the board cannot show.
 	const filterByTag = (tagId: string) =>
 		changeSelection({
+			view: 'tagging',
 			only: withNarrowing(selection.only, 'tag', isolateOnly(tagOnly, tagId)),
 		});
 

--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -56,6 +56,7 @@ import {
 	GuiIssue,
 	GuiCommitEntry,
 	GuiContributor,
+	GuiEventIdentity,
 	GuiEventTimeline,
 	GuiState,
 	GuiSwimlane,
@@ -63,6 +64,7 @@ import {
 } from './lib/gui-state.model';
 import {
 	buildBoardFilter,
+	FilterAxis,
 	isPeriodWindow,
 	issuePassesBoardFilter,
 	windowIssueIds,
@@ -77,6 +79,7 @@ import {
 import {useEventLog} from './lib/use-event-log';
 import {LogDestination} from './lib/log-destination';
 import {Input} from './components/FormPrimitives';
+import {isolateOnly, withNarrowing} from './lib/board-selection';
 import {useBoardSelection} from './lib/use-board-selection';
 import {BoardSocketActions, useBoardSocket} from './lib/use-board-socket';
 import {useIssueDetail} from './lib/use-issue-detail';
@@ -387,10 +390,11 @@ export const App = () => {
 	// title both miss it. Not part of the URL selection: it is a passing
 	// narrowing, not a view worth linking to.
 	const [textFilter, setTextFilter] = useState('');
-	// Null unless the selection has been narrowed to particular tags or people.
+	// One entry per narrowed axis, and empty while nothing is narrowed. Every
+	// axis has to pass, so a tag and an assignee ask one question together.
 	const boardFilter = useMemo(
-		() => buildBoardFilter(selection.view, selection.only),
-		[selection.view, selection.only],
+		() => buildBoardFilter(selection.only),
+		[selection.only],
 	);
 
 	const zoomed = selection.zoom !== null;
@@ -416,17 +420,17 @@ export const App = () => {
 	const isolatedIssueId =
 		selection.ticketOnly && selectedIssue ? selectedIssue.id : null;
 
-	// The tag every card is narrowed to, if the selection is exactly one tag:
-	// its chips read as pressed, and pressing again is the way back.
-	const isolatedTagId =
-		selection.view === 'tagging' && selection.only?.length === 1
-			? selection.only[0] ?? null
-			: null;
+	// The tag every card is narrowed to, if the tag axis is narrowed to exactly
+	// one: its chips read as pressed, and pressing again is the way back. Read
+	// off that axis alone, so a chip stays lit while the board is also narrowed
+	// by assignee or by who touched it.
+	const tagOnly = selection.only.tag ?? null;
+	const isolatedTagId = tagOnly?.length === 1 ? tagOnly[0] ?? null : null;
 
 	const filterByTag = (tagId: string) =>
-		changeSelection(
-			isolatedTagId === tagId ? {only: null} : {view: 'tagging', only: [tagId]},
-		);
+		changeSelection({
+			only: withNarrowing(selection.only, 'tag', isolateOnly(tagOnly, tagId)),
+		});
 
 	// For naming a selected identity the scrubber's window has no event for.
 	const knownIdentities = useMemo(() => {
@@ -436,7 +440,11 @@ export const App = () => {
 		}
 		const users = [...people.values()];
 
-		return {tag: state?.tags ?? [], actor: users, assignee: users};
+		return {
+			tag: state?.tags ?? [],
+			commenter: users,
+			assignee: users,
+		} satisfies Record<FilterAxis, GuiEventIdentity[]>;
 	}, [state?.tags, state?.contributors, contributors]);
 
 	// Memoized, and returning the lanes untouched when nothing is filtered:
@@ -445,7 +453,12 @@ export const App = () => {
 	const {visibleSwimlanes, hiddenIssueCount} = useMemo(() => {
 		const swimlanes = selectedBoard?.swimlanes ?? [];
 		const query = textFilter.trim();
-		if (!boardFilter && !query && windowIds === null && !isolatedIssueId)
+		if (
+			boardFilter.length === 0 &&
+			!query &&
+			windowIds === null &&
+			!isolatedIssueId
+		)
 			return {visibleSwimlanes: swimlanes, hiddenIssueCount: 0};
 
 		let hidden = 0;
@@ -455,9 +468,11 @@ export const App = () => {
 				issue =>
 					issuePassesBoardFilter(
 						issue,
-						(commentsByIssueId[issue.id] ?? []).map(
-							comment => comment.author.id,
-						),
+						{
+							commenterIds: (commentsByIssueId[issue.id] ?? []).map(
+								comment => comment.author.id,
+							),
+						},
 						boardFilter,
 					) &&
 					issueMatchesText(issue, query) &&

--- a/source/gui/client/components/ScrubberControls.tsx
+++ b/source/gui/client/components/ScrubberControls.tsx
@@ -13,6 +13,7 @@ import {
 	scopeButtonLabel,
 	SCOPES,
 	BoardView,
+	FilterAxis,
 } from '../lib/scrubber';
 import {GuiEventIdentity} from '../lib/gui-state.model';
 import {Checkbox} from './Checkbox';
@@ -107,10 +108,11 @@ export const ScrubberControls = ({
 	showCommits,
 	allBoards,
 	boardView,
-	identities,
-	hiddenIdentityIds,
+	identitiesByAxis,
+	hiddenIdsByAxis,
+	narrowed,
 	categoriesExpanded,
-	identitiesExpanded,
+	expandedAxis,
 	categoriesFiltered,
 	isScrubbing,
 	onReturnToLive,
@@ -126,7 +128,7 @@ export const ScrubberControls = ({
 	onToggleIdentity,
 	onOnlyIdentity,
 	onToggleCategoriesExpanded,
-	onSetIdentitiesExpanded,
+	onSetExpandedAxis,
 }: {
 	// Nothing can be fetched with the socket down, so the controls say so rather
 	// than moving the selection over a chart that cannot follow.
@@ -161,10 +163,15 @@ export const ScrubberControls = ({
 	showCommits: boolean;
 	allBoards: boolean;
 	boardView: BoardView;
-	identities: GuiEventIdentity[];
-	hiddenIdentityIds: ReadonlySet<string>;
+	// A legend per filter axis, and what is unticked on each: every axis narrows
+	// the board, not just the one the chart is coloured by.
+	identitiesByAxis: Record<FilterAxis, GuiEventIdentity[]>;
+	hiddenIdsByAxis: Record<FilterAxis, ReadonlySet<string>>;
+	// Any axis at all is narrowed, which is what the collapsed trigger reports.
+	narrowed: boolean;
 	categoriesExpanded: boolean;
-	identitiesExpanded: boolean;
+	// The one axis whose list is open, or null while none is.
+	expandedAxis: FilterAxis | null;
 	// False where the server capped the window: the buckets it fell back to are
 	// pre-summed across every kind, so there is nothing to filter.
 	categoriesFiltered: boolean;
@@ -179,10 +186,10 @@ export const ScrubberControls = ({
 	onChangeShowCommits: (next: boolean) => void;
 	onChangeAllBoards: (next: boolean) => void;
 	onChangeBoardView: (view: BoardView) => void;
-	onToggleIdentity: (id: string, next: boolean) => void;
-	onOnlyIdentity: (id: string) => void;
+	onToggleIdentity: (axis: FilterAxis, id: string, next: boolean) => void;
+	onOnlyIdentity: (axis: FilterAxis, id: string) => void;
 	onToggleCategoriesExpanded: () => void;
-	onSetIdentitiesExpanded: (next: boolean) => void;
+	onSetExpandedAxis: (axis: FilterAxis | null) => void;
 }) => {
 	const everythingInScope = !isPeriodWindow(scope, zoomed);
 
@@ -354,17 +361,18 @@ export const ScrubberControls = ({
 					connected={connected}
 					showIssues={showIssues}
 					view={boardView}
-					identities={identities}
-					hiddenIds={hiddenIdentityIds}
+					identitiesByAxis={identitiesByAxis}
+					hiddenIdsByAxis={hiddenIdsByAxis}
+					narrowed={narrowed}
 					expanded={categoriesExpanded}
-					identitiesExpanded={identitiesExpanded}
+					expandedAxis={expandedAxis}
 					filtered={categoriesFiltered}
 					onChangeShowIssues={onChangeShowIssues}
 					onChangeView={onChangeBoardView}
 					onToggleIdentity={onToggleIdentity}
 					onOnlyIdentity={onOnlyIdentity}
 					onToggleExpanded={onToggleCategoriesExpanded}
-					onSetIdentitiesExpanded={onSetIdentitiesExpanded}
+					onSetExpandedAxis={onSetExpandedAxis}
 				/>
 
 				{/* Beside the series checkboxes rather than by the scope row, so every

--- a/source/gui/client/components/ScrubberSelects.tsx
+++ b/source/gui/client/components/ScrubberSelects.tsx
@@ -15,6 +15,7 @@ import {
 	identityAxisFor,
 	BoardView,
 	EventCategory,
+	FilterAxis,
 } from '../lib/scrubber';
 import {GuiEventIdentity} from '../lib/gui-state.model';
 import {Checkbox} from './Checkbox';
@@ -249,54 +250,76 @@ const Radio = ({
 // at once. The trigger reads back whatever is selected, down to the one tag or
 // person left when the rest are unticked — the same name and colour the bars and
 // dots are then drawn in.
+//
+// Narrowing is the other half, and it is not tied to that choice: every row
+// with a list can be ticked down, several at once, and the board below shows
+// the tickets that pass all of them. Only the plotted row's list changes the
+// picture; the rest narrow what is underneath it.
+const EMPTY_IDENTITIES: GuiEventIdentity[] = [];
+const EMPTY_HIDDEN: ReadonlySet<string> = new Set<string>();
+
 export const BoardSeriesGroup = ({
 	connected,
 	showIssues,
 	view,
-	identities,
-	hiddenIds,
+	identitiesByAxis,
+	hiddenIdsByAxis,
+	narrowed,
 	expanded,
-	identitiesExpanded,
+	expandedAxis,
 	filtered,
 	onChangeShowIssues,
 	onChangeView,
 	onToggleIdentity,
 	onOnlyIdentity,
 	onToggleExpanded,
-	onSetIdentitiesExpanded,
+	onSetExpandedAxis,
 }: {
 	connected: boolean;
 	showIssues: boolean;
 	view: BoardView;
-	// What the current window actually holds, so the list is a legend for what
-	// is on screen rather than a catalogue of the whole repo.
-	identities: GuiEventIdentity[];
-	hiddenIds: ReadonlySet<string>;
+	// What the current window actually holds, per axis, so each list is a legend
+	// for what is on screen rather than a catalogue of the whole repo.
+	identitiesByAxis: Record<FilterAxis, GuiEventIdentity[]>;
+	hiddenIdsByAxis: Record<FilterAxis, ReadonlySet<string>>;
+	narrowed: boolean;
 	expanded: boolean;
-	identitiesExpanded: boolean;
+	expandedAxis: FilterAxis | null;
 	filtered: boolean;
 	onChangeShowIssues: (next: boolean) => void;
 	onChangeView: (view: BoardView) => void;
-	onToggleIdentity: (id: string, next: boolean) => void;
-	onOnlyIdentity: (id: string) => void;
+	onToggleIdentity: (axis: FilterAxis, id: string, next: boolean) => void;
+	onOnlyIdentity: (axis: FilterAxis, id: string) => void;
 	onToggleExpanded: () => void;
-	onSetIdentitiesExpanded: (next: boolean) => void;
+	onSetExpandedAxis: (axis: FilterAxis | null) => void;
 }) => {
+	const viewAxis = identityAxisFor(view);
+	const identities =
+		viewAxis === null ? EMPTY_IDENTITIES : identitiesByAxis[viewAxis];
+	const hiddenIds =
+		viewAxis === null ? EMPTY_HIDDEN : hiddenIdsByAxis[viewAxis];
+
 	// Down to one tag or person, that identity *is* the series, so it gives the
 	// trigger its name and its colour. Several hidden and no single colour would
 	// be honest, so the trigger only says that it is narrowed.
 	const sole = soleVisibleIdentity(identities, hiddenIds);
-	const partial =
-		filtered && hiddenIds.size > 0 && identityAxisFor(view) !== null;
+	const partial = filtered && hiddenIds.size > 0 && viewAxis !== null;
+	// Narrowed somewhere the plotted series does not show: the picture is intact
+	// and the board under it is not, which the trigger has to say or nothing on
+	// this row accounts for the missing tickets.
+	const elsewhere = filtered && narrowed && !partial && sole === null;
 
 	const label = sole
 		? `${VIEW_LABELS[view]}: ${sole.name}`
 		: partial
 		? `${VIEW_LABELS[view]} (multi)`
+		: elsewhere
+		? `${VIEW_LABELS[view]} (filtered)`
 		: VIEW_LABELS[view];
 
 	const color =
-		sole?.color ?? (partial ? GUI_THEME.dim2 : boardViewColor(view));
+		sole?.color ??
+		(partial || elsewhere ? GUI_THEME.dim2 : boardViewColor(view));
 
 	// Where the server capped the window its buckets are pre-summed across every
 	// kind, so nothing in here is selectable. The select still opens — the greyed
@@ -357,12 +380,13 @@ export const BoardSeriesGroup = ({
 				<div role="radiogroup" style={popoverStyle}>
 					{BOARD_VIEWS.map(option => {
 						const selected = view === option;
-						// Drawn from the view alone, not from whether a list has been
-						// loaded for it: only the selected view has its identities to
-						// hand, and hiding the caret until then made every other row
-						// look like it had nothing under it.
-						const hasList = identityAxisFor(option) !== null;
-						const open = selected && identitiesExpanded;
+						const axis = identityAxisFor(option);
+						const open = axis !== null && expandedAxis === axis;
+						// Lit while this row's axis is holding something back, which is
+						// the only sign a row that is not the plotted one leaves on the
+						// closed panel.
+						const rowNarrowed =
+							axis !== null && filtered && hiddenIdsByAxis[axis].size > 0;
 
 						// The whole series heads the list; the kinds of it are indented
 						// under that, which is the hierarchy the word "All" used to say
@@ -388,20 +412,22 @@ export const BoardSeriesGroup = ({
 										square={isWholeSeries}
 										onSelect={() => onChangeView(option)}
 									/>
-									{hasList && (
+									{axis !== null && (
 										<button
 											type="button"
 											disabled={!showIssues || !filtered}
-											// From an unselected row this both selects and opens,
-											// which is the one thing anyone wants from a caret on a
-											// row that is not current.
-											onClick={() => {
-												if (!selected) onChangeView(option);
-												onSetIdentitiesExpanded(!open);
-											}}
+											// Opening a list no longer selects the row: the whole
+											// point of a list per axis is narrowing by one while the
+											// chart goes on plotting another.
+											onClick={() => onSetExpandedAxis(open ? null : axis)}
 											title={open ? 'Hide the list' : 'Pick which to show'}
 											aria-expanded={open}
-											style={disclosureStyle}
+											style={{
+												...disclosureStyle,
+												color: rowNarrowed
+													? GUI_THEME.accent
+													: disclosureStyle.color,
+											}}
 										>
 											{open ? (
 												<IconChevronDown size={12} />
@@ -412,7 +438,7 @@ export const BoardSeriesGroup = ({
 									)}
 								</div>
 
-								{open && identities.length > 0 && (
+								{open && axis !== null && identitiesByAxis[axis].length > 0 && (
 									<div
 										style={{
 											...nestedListStyle,
@@ -422,7 +448,7 @@ export const BoardSeriesGroup = ({
 											overflowY: 'auto',
 										}}
 									>
-										{identities.map(identity => (
+										{identitiesByAxis[axis].map(identity => (
 											<div
 												key={identity.id}
 												style={{
@@ -434,16 +460,18 @@ export const BoardSeriesGroup = ({
 											>
 												<Checkbox
 													label={identity.name}
-													checked={!hiddenIds.has(identity.id)}
+													checked={!hiddenIdsByAxis[axis].has(identity.id)}
 													activeColor={identity.color}
 													disabled={!showIssues}
-													onChange={next => onToggleIdentity(identity.id, next)}
+													onChange={next =>
+														onToggleIdentity(axis, identity.id, next)
+													}
 												/>
 												<button
 													type="button"
 													title={`Show only ${identity.name}`}
 													disabled={!showIssues}
-													onClick={() => onOnlyIdentity(identity.id)}
+													onClick={() => onOnlyIdentity(axis, identity.id)}
 													style={onlyButtonStyle}
 												>
 													only

--- a/source/gui/client/components/ScrubberSelects.tsx
+++ b/source/gui/client/components/ScrubberSelects.tsx
@@ -61,6 +61,7 @@ const disclosureStyle: React.CSSProperties = {
 const VIEW_LABELS: Record<BoardView, string> = {
 	all: 'Board events',
 	...CATEGORY_LABELS,
+	people: 'People',
 };
 
 // Fixed, not sized to its label: the selection changes as the thing is used,

--- a/source/gui/client/components/ScrubberSelects.tsx
+++ b/source/gui/client/components/ScrubberSelects.tsx
@@ -245,6 +245,11 @@ const Radio = ({
 	</button>
 );
 
+// Module scope, so a view that colours by nothing hands the same empty legend
+// down every render rather than a fresh one to re-memoize against.
+const EMPTY_IDENTITIES: GuiEventIdentity[] = [];
+const EMPTY_HIDDEN: ReadonlySet<string> = new Set<string>();
+
 // A checkbox for the series and a select for what it draws, one kind at a time.
 // That is what lets a colour mean one thing: "Board events" colours by kind,
 // and any single kind colours by the tag or person behind each event, never both
@@ -256,9 +261,6 @@ const Radio = ({
 // with a list can be ticked down, several at once, and the board below shows
 // the tickets that pass all of them. Only the plotted row's list changes the
 // picture; the rest narrow what is underneath it.
-const EMPTY_IDENTITIES: GuiEventIdentity[] = [];
-const EMPTY_HIDDEN: ReadonlySet<string> = new Set<string>();
-
 export const BoardSeriesGroup = ({
 	connected,
 	showIssues,
@@ -388,6 +390,7 @@ export const BoardSeriesGroup = ({
 						// closed panel.
 						const rowNarrowed =
 							axis !== null && filtered && hiddenIdsByAxis[axis].size > 0;
+						const rowLabel = VIEW_LABELS[option].toLowerCase();
 
 						// The whole series heads the list; the kinds of it are indented
 						// under that, which is the hierarchy the word "All" used to say
@@ -421,12 +424,22 @@ export const BoardSeriesGroup = ({
 											// point of a list per axis is narrowing by one while the
 											// chart goes on plotting another.
 											onClick={() => onSetExpandedAxis(open ? null : axis)}
-											title={open ? 'Hide the list' : 'Pick which to show'}
+											// Named after its own row: four rows now carry one of
+											// these, and "Pick which to show" on all four says
+											// nothing about which list is being opened.
+											title={
+												open
+													? `Hide the ${rowLabel} list`
+													: `Pick which ${rowLabel} to show`
+											}
 											aria-expanded={open}
 											style={{
 												...disclosureStyle,
+												// In the row's own colour rather than the accent, so
+												// the lit caret reads as belonging to the thing it
+												// is holding back.
 												color: rowNarrowed
-													? GUI_THEME.accent
+													? boardViewColor(option)
 													: disclosureStyle.color,
 											}}
 										>

--- a/source/gui/client/components/TimeScrubber.tsx
+++ b/source/gui/client/components/TimeScrubber.tsx
@@ -686,20 +686,27 @@ export const TimeScrubber = ({
 		const pressedCommit = pressedCommitRef.current;
 		pressedCommitRef.current = null;
 
+		// Everything the gesture was holding goes at once, before deciding what it
+		// was: a second pointer can leave both a range and a needle drag set, and
+		// a ref left behind by the branch not taken would read as a gesture still
+		// in flight — which now holds the window back for good rather than just
+		// parking the thumb.
 		const draggedTo = dragFractionRef.current;
 		const range = rangeDragRef.current;
 
+		dragFractionRef.current = null;
+		rangeDragRef.current = null;
+
 		if (draggedTo !== null) {
 			dispatchScrub(draggedTo, true);
-			dragFractionRef.current = null;
 			setDragFraction(null);
+			setRangeDrag(null);
 			return;
 		}
 
 		if (range === null) return;
 
 		const {from, to} = range;
-		rangeDragRef.current = null;
 		setRangeDrag(null);
 
 		const trackWidth = trackRef.current?.clientWidth ?? 0;

--- a/source/gui/client/components/TimeScrubber.tsx
+++ b/source/gui/client/components/TimeScrubber.tsx
@@ -13,8 +13,11 @@ import {
 import {
 	BoardSelection,
 	hiddenIdsFor,
+	isNarrowed,
 	isolateOnly,
+	narrowingFor,
 	toggleOnly,
+	withNarrowing,
 	withSelectedIdentities,
 } from '../lib/board-selection';
 import {
@@ -29,7 +32,10 @@ import {
 	DOT_EXIT_TOTAL_MS,
 	dotDetail,
 	EventDot,
+	FILTER_AXES,
+	FilterAxis,
 	identityAxisFor,
+	isFilterAxis,
 	listIdentities,
 	soleVisibleIdentity,
 	formatInterval,
@@ -47,13 +53,18 @@ import {
 	usePrefersReducedMotion,
 	windowNamesIssues,
 } from '../lib/scrubber';
-import {usePersistedFlag} from '../lib/use-persisted-flag';
+import {usePersistedChoice, usePersistedFlag} from '../lib/use-persisted-flag';
 import {canPlayTimeline} from '../lib/theatre';
 import {HintContent, ScrubberLayout} from './ScrubberLayout';
 import {ScatterLayer, ScatterPoint} from './ScatterCanvas';
 import {GUI_THEME} from '../lib/gui-theme';
 
 const SCRUB_THROTTLE_MS = 120;
+
+// Module scope, so a view that colours by nothing hands the chart the same
+// empty legend every render rather than a fresh one to re-memoize against.
+const EMPTY_IDENTITIES: GuiEventIdentity[] = [];
+const EMPTY_HIDDEN: ReadonlySet<string> = new Set<string>();
 
 // Still needed by the Volume hover, which reads a bucket's count rather than a
 // dot. The scatter's own hint comes from dotDetail.
@@ -63,7 +74,9 @@ const boardEventRow = (count: number) =>
 const COLLAPSED_STORAGE_KEY = 'epiq.timeScrubber.collapsed';
 const ALL_BOARDS_STORAGE_KEY = 'epiq.timeScrubber.allBoards';
 const CATEGORIES_EXPANDED_STORAGE_KEY = 'epiq.timeScrubber.categoriesExpanded';
-const IDENTITIES_EXPANDED_STORAGE_KEY = 'epiq.timeScrubber.identitiesExpanded';
+// Which axis's list is open in the series popover, not whether one is: with an
+// axis per row only one is shown at a time, so the answer is a name.
+const EXPANDED_AXIS_STORAGE_KEY = 'epiq.timeScrubber.expandedAxis';
 
 export const TimeScrubber = ({
 	timeline,
@@ -128,7 +141,7 @@ export const TimeScrubber = ({
 	selectedIssue: {id: string; createdAt: number} | null;
 	// Every tag and person the board knows, per axis, for naming a selected
 	// identity the window itself holds no event for.
-	knownIdentities: Record<'actor' | 'tag' | 'assignee', GuiEventIdentity[]>;
+	knownIdentities: Record<FilterAxis, GuiEventIdentity[]>;
 	// Anything whose identity changing means the window has to be asked for
 	// again. The window is otherwise fetched only when it moves, which is fine
 	// while it is just a picture — but two things read it as live data. Once it
@@ -193,9 +206,9 @@ export const TimeScrubber = ({
 		CATEGORIES_EXPANDED_STORAGE_KEY,
 		false,
 	);
-	const [identitiesExpanded, setIdentitiesExpanded] = usePersistedFlag(
-		IDENTITIES_EXPANDED_STORAGE_KEY,
-		false,
+	const [expandedAxis, setExpandedAxis] = usePersistedChoice<FilterAxis>(
+		EXPANDED_AXIS_STORAGE_KEY,
+		isFilterAxis,
 	);
 	// Unlike the series toggles this changes what is fetched, not just what is
 	// drawn.
@@ -342,12 +355,26 @@ export const TimeScrubber = ({
 	const changeBoardView = (next: BoardView) => onChangeSelection({view: next});
 
 	// Toggles: isolating again restores the rest, so the button is a way back as
-	// well as a way in. Ticking each of a dozen tags to undo it is not.
-	const isolateIdentity = (id: string) =>
-		onChangeSelection({only: isolateOnly(only, id)});
+	// well as a way in. Ticking each of a dozen tags to undo it is not. Both act
+	// on one axis and leave the others where they are, which is what lets a tag
+	// and an assignee narrow the board at once.
+	const isolateIdentity = (axis: FilterAxis, id: string) =>
+		onChangeSelection({
+			only: withNarrowing(
+				only,
+				axis,
+				isolateOnly(narrowingFor(only, axis), id),
+			),
+		});
 
-	const toggleIdentity = (id: string, next: boolean) =>
-		onChangeSelection({only: toggleOnly(only, identities, id, next)});
+	const toggleIdentity = (axis: FilterAxis, id: string, next: boolean) =>
+		onChangeSelection({
+			only: withNarrowing(
+				only,
+				axis,
+				toggleOnly(narrowingFor(only, axis), identitiesByAxis[axis], id, next),
+			),
+		});
 
 	const changeAllBoards = (next: boolean) => {
 		armEntrance();
@@ -357,7 +384,14 @@ export const TimeScrubber = ({
 	// What narrows the window already in hand. Answered on the spot, with no
 	// round trip, so it can replay the entrance the moment it changes.
 	const filterKey = useMemo(
-		() => JSON.stringify([boardView, only === null ? null : [...only].sort()]),
+		() =>
+			JSON.stringify([
+				boardView,
+				FILTER_AXES.map(axis => {
+					const ids = only[axis];
+					return ids === undefined ? null : [...ids].sort();
+				}),
+			]),
 		[boardView, only],
 	);
 
@@ -397,20 +431,41 @@ export const TimeScrubber = ({
 	// Only a window the server returned events for can be split at all.
 	const categoriesFiltered = (timeline?.events.length ?? 0) > 0;
 
-	const identities = useMemo(() => {
-		const axis = identityAxisFor(boardView);
+	// Every axis's legend, not just the plotted one's: each is a filter of its
+	// own now, and all four are on offer in the popover at once.
+	const identitiesByAxis = useMemo(() => {
+		const lists = {} as Record<FilterAxis, GuiEventIdentity[]>;
 
-		return withSelectedIdentities(
-			listIdentities(shown.timeline, boardView),
-			only,
-			axis === null ? [] : knownIdentities[axis],
-		);
-	}, [shown, boardView, only, knownIdentities]);
+		for (const axis of FILTER_AXES) {
+			lists[axis] = withSelectedIdentities(
+				listIdentities(shown.timeline, axis),
+				narrowingFor(only, axis),
+				knownIdentities[axis],
+			);
+		}
 
-	const hiddenIdentityIds = useMemo(
-		() => hiddenIdsFor(identities, only),
-		[identities, only],
-	);
+		return lists;
+	}, [shown, only, knownIdentities]);
+
+	const hiddenIdsByAxis = useMemo(() => {
+		const hidden = {} as Record<FilterAxis, ReadonlySet<string>>;
+
+		for (const axis of FILTER_AXES) {
+			hidden[axis] = hiddenIdsFor(
+				identitiesByAxis[axis],
+				narrowingFor(only, axis),
+			);
+		}
+
+		return hidden;
+	}, [identitiesByAxis, only]);
+
+	// What the chart itself is coloured by, which is still one axis at a time.
+	const viewAxis = identityAxisFor(boardView);
+	const identities =
+		viewAxis === null ? EMPTY_IDENTITIES : identitiesByAxis[viewAxis];
+	const hiddenIdentityIds =
+		viewAxis === null ? EMPTY_HIDDEN : hiddenIdsByAxis[viewAxis];
 
 	// Filtered down to one tag or person, the bars are that identity and nothing
 	// else, so they take its colour rather than the kind's. The scatter already
@@ -840,10 +895,11 @@ export const TimeScrubber = ({
 				onChangeShowCommits,
 				onChangeAllBoards: changeAllBoards,
 				boardView,
-				identities,
-				hiddenIdentityIds,
+				identitiesByAxis,
+				hiddenIdsByAxis,
+				narrowed: isNarrowed(only),
 				categoriesExpanded,
-				identitiesExpanded,
+				expandedAxis,
 				categoriesFiltered,
 				isScrubbing: timeTravel.mode === 'scrub',
 				onReturnToLive,
@@ -852,7 +908,7 @@ export const TimeScrubber = ({
 				onOnlyIdentity: isolateIdentity,
 				onToggleCategoriesExpanded: () =>
 					setCategoriesExpanded(!categoriesExpanded),
-				onSetIdentitiesExpanded: setIdentitiesExpanded,
+				onSetExpandedAxis: setExpandedAxis,
 			}}
 			chart={{
 				// Only where it is actually hiding something: ticked over a window

--- a/source/gui/client/components/TimeScrubber.tsx
+++ b/source/gui/client/components/TimeScrubber.tsx
@@ -189,6 +189,12 @@ export const TimeScrubber = ({
 		from: number;
 		to: number;
 	} | null>(null);
+	// The same two, live. Pointer moves arrive faster than React commits, so a
+	// release handler reading the state would ask for wherever the last
+	// *rendered* move was rather than where the pointer let go — parking the
+	// board behind the release, or zooming to a window short of it.
+	const dragFractionRef = useRef<number | null>(null);
+	const rangeDragRef = useRef<{from: number; to: number} | null>(null);
 	// Set by the needle's own press, which fires before the track's: it says
 	// this drag moves the needle rather than dragging out a range.
 	const grabbedNeedleRef = useRef(false);
@@ -409,7 +415,18 @@ export const TimeScrubber = ({
 	const shownRef = useRef({timeline, commits});
 	const pendingRequestId = useRef<number | null>(null);
 
+	// Held back while the pointer is down. The window is the coordinate system a
+	// drag is working in — every fraction of the track stands for a moment in
+	// it — so adopting a new one mid-gesture moves the ground under the pointer,
+	// and the needle released at one spot commits another. Scrubbing itself
+	// causes a broadcast and so a fresh window, which is exactly when this
+	// happens. The release re-renders, and that is where the held reply is taken
+	// up.
+	const gestureInFlight =
+		dragFractionRef.current !== null || rangeDragRef.current !== null;
+
 	if (
+		!gestureInFlight &&
 		pendingRequestId.current !== null &&
 		historyId === pendingRequestId.current
 	) {
@@ -668,15 +685,20 @@ export const TimeScrubber = ({
 		const pressedCommit = pressedCommitRef.current;
 		pressedCommitRef.current = null;
 
-		if (dragFraction !== null) {
-			dispatchScrub(dragFraction, true);
+		const draggedTo = dragFractionRef.current;
+		const range = rangeDragRef.current;
+
+		if (draggedTo !== null) {
+			dispatchScrub(draggedTo, true);
+			dragFractionRef.current = null;
 			setDragFraction(null);
 			return;
 		}
 
-		if (rangeDrag === null) return;
+		if (range === null) return;
 
-		const {from, to} = rangeDrag;
+		const {from, to} = range;
+		rangeDragRef.current = null;
 		setRangeDrag(null);
 
 		const trackWidth = trackRef.current?.clientWidth ?? 0;
@@ -964,10 +986,12 @@ export const TimeScrubber = ({
 						// out to have been a click. Scrubbing on the way would checkout
 						// every moment swept over on the way to picking a window.
 						if (!grabbedNeedleRef.current) {
+							rangeDragRef.current = {from: fraction, to: fraction};
 							setRangeDrag({from: fraction, to: fraction});
 							return;
 						}
 
+						dragFractionRef.current = fraction;
 						setDragFraction(fraction);
 						dispatchScrub(fraction, true);
 					},
@@ -975,15 +999,18 @@ export const TimeScrubber = ({
 						// The handler is on the wrapper, so this runs for every move over
 						// the whole scrubber. Measuring the track is a layout read, and
 						// nothing outside a drag has a use for it.
-						if (dragFraction === null && rangeDrag === null) return;
+						const range = rangeDragRef.current;
+						if (dragFractionRef.current === null && range === null) return;
 
 						const fraction = fractionFromClientX(event.clientX);
 
-						if (rangeDrag !== null) {
-							setRangeDrag({from: rangeDrag.from, to: fraction});
+						if (range !== null) {
+							rangeDragRef.current = {from: range.from, to: fraction};
+							setRangeDrag({from: range.from, to: fraction});
 							return;
 						}
 
+						dragFractionRef.current = fraction;
 						setDragFraction(fraction);
 						dispatchScrub(fraction, false);
 					},

--- a/source/gui/client/components/TimeScrubber.tsx
+++ b/source/gui/client/components/TimeScrubber.tsx
@@ -36,7 +36,7 @@ import {
 	FilterAxis,
 	identityAxisFor,
 	isFilterAxis,
-	listIdentities,
+	listIdentitiesByAxis,
 	soleVisibleIdentity,
 	formatInterval,
 	getPeriodRange,
@@ -388,18 +388,18 @@ export const TimeScrubber = ({
 	};
 
 	// What narrows the window already in hand. Answered on the spot, with no
-	// round trip, so it can replay the entrance the moment it changes.
-	const filterKey = useMemo(
-		() =>
-			JSON.stringify([
-				boardView,
-				FILTER_AXES.map(axis => {
-					const ids = only[axis];
-					return ids === undefined ? null : [...ids].sort();
-				}),
-			]),
-		[boardView, only],
-	);
+	// round trip, so it can replay the entrance the moment it changes. Only the
+	// plotted axis counts: narrowing one the chart is not coloured by changes
+	// the board underneath and not a dot up here, and replaying the entrance
+	// over it would animate a picture nothing had happened to.
+	const filterKey = useMemo(() => {
+		const plotted = narrowingFor(only, identityAxisFor(boardView));
+
+		return JSON.stringify([
+			boardView,
+			plotted === null ? null : [...plotted].sort(),
+		]);
+	}, [boardView, only]);
 
 	const entrance = useRef(0);
 	const armed = useRef(true);
@@ -451,11 +451,12 @@ export const TimeScrubber = ({
 	// Every axis's legend, not just the plotted one's: each is a filter of its
 	// own now, and all four are on offer in the popover at once.
 	const identitiesByAxis = useMemo(() => {
+		const listed = listIdentitiesByAxis(shown.timeline);
 		const lists = {} as Record<FilterAxis, GuiEventIdentity[]>;
 
 		for (const axis of FILTER_AXES) {
 			lists[axis] = withSelectedIdentities(
-				listIdentities(shown.timeline, axis),
+				listed[axis],
 				narrowingFor(only, axis),
 				knownIdentities[axis],
 			);

--- a/source/gui/client/lib/board-selection.test.ts
+++ b/source/gui/client/lib/board-selection.test.ts
@@ -16,6 +16,7 @@ import {
 	SelectionCarry,
 	storeSelection,
 	toggleOnly,
+	withNarrowing,
 	withSelectedIdentities,
 	writeSelectionParams,
 } from './board-selection';
@@ -59,12 +60,34 @@ describe('selection in the URL', () => {
 			zoom: null,
 			layout: 'real',
 			view: 'tagging',
-			only: ['bug', 'docs'],
+			only: {tag: ['bug', 'docs'], assignee: ['jola']},
 			windowOnly: true,
 			ticketOnly: false,
 		};
 
 		expect(readSelectionParams(params(written(selection)))).toEqual(selection);
+	});
+
+	it('names the axis of every list it writes', () => {
+		expect(
+			written({
+				...DEFAULT_SELECTION,
+				only: {tag: ['bug'], assignee: ['jola']},
+			}),
+		).toBe('only=tag%3Abug%3Bassignee%3Ajola');
+	});
+
+	// The one-axis form, from before each axis carried its own list: it named
+	// no axis because the view was the axis.
+	it('reads an unprefixed list onto the axis the view colours by', () => {
+		expect(
+			readSelectionParams(params('view=tagging&only=bug,docs'))?.only,
+		).toEqual({tag: ['bug', 'docs']});
+		expect(
+			readSelectionParams(params('view=comments&only=jola'))?.only,
+		).toEqual({commenter: ['jola']});
+		// No axis to put it on, so there is nothing to read it as.
+		expect(readSelectionParams(params('view=all&only=bug'))?.only).toEqual({});
 	});
 
 	it('writes nothing for the defaults, and clears what was there', () => {
@@ -81,19 +104,19 @@ describe('selection in the URL', () => {
 	});
 
 	it('tells an empty narrowing from none', () => {
-		expect(written({...DEFAULT_SELECTION, view: 'tagging', only: []})).toBe(
-			'view=tagging&only=',
+		expect(written({...DEFAULT_SELECTION, only: {tag: []}})).toBe(
+			'only=tag%3A',
 		);
-		expect(readSelectionParams(params('view=tagging&only='))?.only).toEqual([]);
-		expect(readSelectionParams(params('view=tagging'))?.only).toBeNull();
+		expect(readSelectionParams(params('only=tag%3A'))?.only).toEqual({tag: []});
+		expect(readSelectionParams(params('view=tagging'))?.only).toEqual({});
 	});
 
 	it('falls back per field on values it does not recognise', () => {
 		expect(
 			readSelectionParams(
-				params('scope=fortnight&offset=x&layout=3d&view=nope&only=bug'),
+				params('scope=fortnight&offset=x&layout=3d&view=nope&only=nope%3Abug'),
 			),
-		).toEqual({...DEFAULT_SELECTION, only: ['bug']});
+		).toEqual(DEFAULT_SELECTION);
 	});
 
 	it('has no offset under all time, and none negative', () => {
@@ -106,8 +129,8 @@ describe('selection in the URL', () => {
 
 	it('drops duplicate ids', () => {
 		expect(
-			readSelectionParams(params('view=tagging&only=bug,bug,docs'))?.only,
-		).toEqual(['bug', 'docs']);
+			readSelectionParams(params('only=tag%3Abug,bug,docs'))?.only,
+		).toEqual({tag: ['bug', 'docs']});
 	});
 });
 
@@ -118,7 +141,7 @@ describe('applySelectionPatch', () => {
 		zoom: null,
 		layout: 'even',
 		view: 'tagging',
-		only: ['bug'],
+		only: {tag: ['bug']},
 		windowOnly: false,
 		ticketOnly: false,
 	};
@@ -128,23 +151,40 @@ describe('applySelectionPatch', () => {
 		expect(applySelectionPatch(narrowed, {scope: 'week'}).offset).toBe(3);
 	});
 
-	it('drops the narrowing when the view changes, since its ids belonged to the old one', () => {
-		expect(applySelectionPatch(narrowed, {view: 'assigning'}).only).toBeNull();
-		expect(applySelectionPatch(narrowed, {view: 'tagging'}).only).toEqual([
-			'bug',
-		]);
+	// Each axis keeps its own list, so there is nothing belonging to the old
+	// view left to throw away.
+	it('keeps the narrowing when the view changes', () => {
+		expect(applySelectionPatch(narrowed, {view: 'assigning'}).only).toEqual({
+			tag: ['bug'],
+		});
 	});
 
 	it('lets a patch set the view and the narrowing together', () => {
 		expect(
-			applySelectionPatch(DEFAULT_SELECTION, {view: 'tagging', only: ['gui']}),
-		).toEqual({...DEFAULT_SELECTION, view: 'tagging', only: ['gui']});
+			applySelectionPatch(DEFAULT_SELECTION, {
+				view: 'tagging',
+				only: {tag: ['gui']},
+			}),
+		).toEqual({...DEFAULT_SELECTION, view: 'tagging', only: {tag: ['gui']}});
+	});
+
+	it('narrows several axes at once, each on its own', () => {
+		const both = applySelectionPatch(narrowed, {
+			only: withNarrowing(narrowed.only, 'assignee', ['jola']),
+		});
+
+		expect(both.only).toEqual({tag: ['bug'], assignee: ['jola']});
+		expect(
+			applySelectionPatch(both, {
+				only: withNarrowing(both.only, 'tag', null),
+			}).only,
+		).toEqual({assignee: ['jola']});
 	});
 
 	it('is the default once everything is put back', () => {
 		expect(
 			isDefaultSelection(
-				applySelectionPatch(narrowed, {scope: 'all', view: 'all'}),
+				applySelectionPatch(narrowed, {scope: 'all', view: 'all', only: {}}),
 			),
 		).toBe(true);
 		expect(isDefaultSelection(narrowed)).toBe(false);
@@ -283,7 +323,7 @@ describe('stored selection', () => {
 			zoom: {start: 1000, end: 2000},
 			layout: 'real',
 			view: 'tagging',
-			only: ['bug'],
+			only: {tag: ['bug'], assignee: ['jola']},
 			windowOnly: true,
 			ticketOnly: false,
 		});
@@ -294,12 +334,28 @@ describe('stored selection', () => {
 			zoom: null,
 			layout: 'real',
 			view: 'tagging',
-			only: ['bug'],
+			only: {tag: ['bug'], assignee: ['jola']},
 			// Not kept: a filter that hides tickets is not a preference to come
 			// back to days later.
 			windowOnly: false,
 			ticketOnly: false,
 		});
+	});
+
+	// Written before each axis carried its own list, when the stored view was
+	// the axis.
+	it('reads a stored bare list onto the axis the stored view colours by', () => {
+		localStorage.setItem(
+			'epiq.board.selection',
+			'{"scope":"all","layout":"even","view":"assigning","only":["jola"]}',
+		);
+		expect(readStoredSelection().only).toEqual({assignee: ['jola']});
+
+		localStorage.setItem(
+			'epiq.board.selection',
+			'{"scope":"all","layout":"even","view":"all","only":["jola"]}',
+		);
+		expect(readStoredSelection().only).toEqual({});
 	});
 
 	it('shrugs off garbage', () => {

--- a/source/gui/client/lib/board-selection.ts
+++ b/source/gui/client/lib/board-selection.ts
@@ -1,12 +1,17 @@
 import {GuiEventIdentity} from './gui-state.model';
 import {
 	BoardView,
+	FILTER_AXES,
+	FilterAxis,
+	identityAxisFor,
 	isBoardView,
+	isFilterAxis,
 	isLayoutMode,
 	isScope,
 	LayoutMode,
 	PeriodRange,
 	Scope,
+	SelectionNarrowing,
 } from './scrubber';
 
 // What the scrubber is looking at, and what that narrows the board to. Kept
@@ -21,10 +26,12 @@ export type BoardSelection = {
 	zoom: PeriodRange | null;
 	layout: LayoutMode;
 	view: BoardView;
-	// Identity ids the view is narrowed to — a positive list rather than the
-	// hidden ones, so it says what to show without knowing what else exists.
-	// Null when nothing is hidden; [] when everything is.
-	only: readonly string[] | null;
+	// Identity ids the board is narrowed to, per axis — a positive list rather
+	// than the hidden ones, so it says what to show without knowing what else
+	// exists. An axis absent is not narrowed; [] hides everything on it. Axes
+	// hold at once and a ticket has to pass them all, so "assigned to her" and
+	// "tagged bug" is one question rather than two that overwrite each other.
+	only: SelectionNarrowing;
 	// Narrows the board to the tickets the window holds an event for, rather
 	// than to what the selection colours.
 	windowOnly: boolean;
@@ -41,7 +48,7 @@ export const DEFAULT_SELECTION: BoardSelection = {
 	zoom: null,
 	layout: 'even',
 	view: 'all',
-	only: null,
+	only: {},
 	windowOnly: false,
 	ticketOnly: false,
 };
@@ -61,6 +68,48 @@ const PARAM_KEYS = [
 const STORAGE_KEY = 'epiq.board.selection';
 
 const unique = (ids: readonly string[]): string[] => [...new Set(ids)];
+
+// ------------------------------------------------------------- the narrowing
+
+// Whether the board is narrowed at all, on any axis.
+export const isNarrowed = (only: SelectionNarrowing): boolean =>
+	FILTER_AXES.some(axis => only[axis] !== undefined);
+
+// One axis's list, or null where that axis is not narrowed — the shape every
+// legend helper below takes, and what a caller with no axis in hand gets.
+export const narrowingFor = (
+	only: SelectionNarrowing,
+	axis: FilterAxis | null,
+): readonly string[] | null => (axis === null ? null : only[axis] ?? null);
+
+// Setting one axis's list. Null removes the axis rather than storing an empty
+// one: [] already means "everything on this axis is hidden".
+export const withNarrowing = (
+	only: SelectionNarrowing,
+	axis: FilterAxis,
+	ids: readonly string[] | null,
+): SelectionNarrowing => {
+	const next = {...only};
+
+	if (ids === null) {
+		delete next[axis];
+	} else {
+		next[axis] = ids;
+	}
+
+	return next;
+};
+
+const normalizeNarrowing = (only: SelectionNarrowing): SelectionNarrowing => {
+	const next: SelectionNarrowing = {};
+
+	for (const axis of FILTER_AXES) {
+		const ids = only[axis];
+		if (ids !== undefined) next[axis] = unique(ids);
+	}
+
+	return next;
+};
 
 // A window has to be two real moments in order, or the axis it builds spans
 // NaN and every fraction on the chart goes with it.
@@ -91,7 +140,7 @@ const normalize = (selection: BoardSelection): BoardSelection => {
 		// is the only one lit. Enforced here rather than at the patch, so a URL
 		// carrying both cannot put the board in a state the controls cannot say.
 		windowOnly: selection.ticketOnly ? false : selection.windowOnly,
-		only: selection.only === null ? null : unique(selection.only),
+		only: normalizeNarrowing(selection.only),
 	};
 };
 
@@ -101,20 +150,20 @@ export const isDefaultSelection = (selection: BoardSelection): boolean =>
 	selection.zoom === null &&
 	selection.layout === DEFAULT_SELECTION.layout &&
 	selection.view === DEFAULT_SELECTION.view &&
-	selection.only === null &&
+	!isNarrowed(selection.only) &&
 	selection.windowOnly === DEFAULT_SELECTION.windowOnly &&
 	selection.ticketOnly === DEFAULT_SELECTION.ticketOnly;
 
 // A change to one field, with what it implies for the others: a new scope
-// starts at its most recent period, and a new view drops a narrowing that
-// named the previous view's identities.
+// starts at its most recent period. A new view implies nothing for the
+// narrowing any more — every axis keeps its own list, so switching what the
+// chart plots no longer throws away what the board was narrowed to.
 export const applySelectionPatch = (
 	current: BoardSelection,
 	patch: Partial<BoardSelection>,
 ): BoardSelection => {
 	const scopeChanged =
 		patch.scope !== undefined && patch.scope !== current.scope;
-	const viewChanged = patch.view !== undefined && patch.view !== current.view;
 
 	// Reaching for a scope button is how you get back out of a zoom, so it
 	// clears one even when the scope named is the one a zoom inferred — which is
@@ -142,8 +191,6 @@ export const applySelectionPatch = (
 		zoom,
 		ticketOnly,
 		offset: scopeChanged ? 0 : patch.offset ?? current.offset,
-		only:
-			patch.only !== undefined ? patch.only : viewChanged ? null : current.only,
 	});
 };
 
@@ -201,6 +248,49 @@ export const carryChange = (
 export const hasSelectionParams = (params: URLSearchParams): boolean =>
 	PARAM_KEYS.some(key => params.has(key));
 
+// The narrowing rides in the one `only` key rather than a key per axis, which
+// would put four more names in the query's way for the sake of a shape nobody
+// types by hand: `only=tag:a,b;assignee:c`.
+const AXIS_SEPARATOR = ';';
+const NAME_SEPARATOR = ':';
+
+const writeNarrowing = (only: SelectionNarrowing): string | null => {
+	const groups = FILTER_AXES.flatMap(axis => {
+		const ids = only[axis];
+		return ids === undefined
+			? []
+			: [`${axis}${NAME_SEPARATOR}${ids.join(',')}`];
+	});
+
+	return groups.length === 0 ? null : groups.join(AXIS_SEPARATOR);
+};
+
+// A group with no axis in front of it is the one-axis form links were written
+// in before: it named no axis because the view was the axis, so it is read onto
+// whichever axis the view in the same URL colours by.
+const readNarrowing = (
+	value: string | null,
+	view: BoardView,
+): SelectionNarrowing => {
+	if (value === null) return {};
+
+	const only: SelectionNarrowing = {};
+
+	for (const group of value.split(AXIS_SEPARATOR)) {
+		if (group === '') continue;
+
+		const at = group.indexOf(NAME_SEPARATOR);
+		const axis = at === -1 ? identityAxisFor(view) : group.slice(0, at);
+		if (axis === null || !isFilterAxis(axis)) continue;
+
+		only[axis] = (at === -1 ? group : group.slice(at + 1))
+			.split(',')
+			.filter(Boolean);
+	}
+
+	return only;
+};
+
 // Null when the URL says nothing about the selection. Any one key present
 // makes the URL authoritative for all of them, so a link means the same thing
 // whoever opens it.
@@ -211,10 +301,10 @@ export const readSelectionParams = (
 
 	const scope = params.get('scope');
 	const layout = params.get('layout');
-	const view = params.get('view');
-	const only = params.get('only');
+	const viewParam = params.get('view');
 	const from = params.get('from');
 	const to = params.get('to');
+	const view = isBoardView(viewParam) ? viewParam : DEFAULT_SELECTION.view;
 
 	return normalize({
 		scope: isScope(scope) ? scope : DEFAULT_SELECTION.scope,
@@ -224,8 +314,8 @@ export const readSelectionParams = (
 				? null
 				: {start: Number(from), end: Number(to)},
 		layout: isLayoutMode(layout) ? layout : DEFAULT_SELECTION.layout,
-		view: isBoardView(view) ? view : DEFAULT_SELECTION.view,
-		only: only === null ? null : only.split(',').filter(Boolean),
+		view,
+		only: readNarrowing(params.get('only'), view),
 		windowOnly: params.get('window') === '1',
 		ticketOnly: params.get('ticket') === '1',
 	});
@@ -252,7 +342,7 @@ export const writeSelectionParams = (
 	put('to', next.zoom === null ? null : String(next.zoom.end));
 	put('layout', next.layout === DEFAULT_SELECTION.layout ? null : next.layout);
 	put('view', next.view === DEFAULT_SELECTION.view ? null : next.view);
-	put('only', next.only === null ? null : next.only.join(','));
+	put('only', writeNarrowing(next.only));
 	put('window', next.windowOnly ? '1' : null);
 	put('ticket', next.ticketOnly ? '1' : null);
 };
@@ -264,6 +354,30 @@ export const writeSelectionParams = (
 // a surprise. Nor is windowOnly: it hides tickets outright, which is too much
 // to restore silently days later — it travels in the URL and nowhere else. Nor
 // is ticketOnly, which names a ticket that need not even be open next time.
+// A bare array is what was stored before the narrowing had axes; like the URL's
+// unprefixed list it belonged to whichever axis the stored view colours by.
+const readStoredNarrowing = (
+	value: unknown,
+	view: BoardView,
+): SelectionNarrowing => {
+	if (Array.isArray(value)) {
+		const axis = identityAxisFor(view);
+		return axis === null ? {} : {[axis]: value.map(String)};
+	}
+
+	if (typeof value !== 'object' || value === null) return {};
+
+	const stored = value as Record<string, unknown>;
+	const only: SelectionNarrowing = {};
+
+	for (const axis of FILTER_AXES) {
+		const ids = stored[axis];
+		if (Array.isArray(ids)) only[axis] = ids.map(String);
+	}
+
+	return only;
+};
+
 export const readStoredSelection = (): BoardSelection => {
 	try {
 		const stored = localStorage.getItem(STORAGE_KEY);
@@ -273,6 +387,7 @@ export const readStoredSelection = (): BoardSelection => {
 		if (typeof parsed !== 'object' || parsed === null) return DEFAULT_SELECTION;
 
 		const {scope, layout, view, only} = parsed as Record<string, unknown>;
+		const boardView = isBoardView(view) ? view : DEFAULT_SELECTION.view;
 
 		return normalize({
 			scope: isScope(String(scope))
@@ -283,8 +398,8 @@ export const readStoredSelection = (): BoardSelection => {
 			layout: isLayoutMode(String(layout))
 				? (layout as LayoutMode)
 				: DEFAULT_SELECTION.layout,
-			view: isBoardView(view) ? view : DEFAULT_SELECTION.view,
-			only: Array.isArray(only) ? only.map(String) : null,
+			view: boardView,
+			only: readStoredNarrowing(only, boardView),
 			windowOnly: DEFAULT_SELECTION.windowOnly,
 			ticketOnly: DEFAULT_SELECTION.ticketOnly,
 		});

--- a/source/gui/client/lib/board-selection.ts
+++ b/source/gui/client/lib/board-selection.ts
@@ -349,11 +349,6 @@ export const writeSelectionParams = (
 
 // ------------------------------------------------------------------- storage
 
-// Neither the offset nor a zoom is kept: a stretch of last Tuesday is a
-// moment, not a preference, and reopening the board a week later on it would be
-// a surprise. Nor is windowOnly: it hides tickets outright, which is too much
-// to restore silently days later — it travels in the URL and nowhere else. Nor
-// is ticketOnly, which names a ticket that need not even be open next time.
 // A bare array is what was stored before the narrowing had axes; like the URL's
 // unprefixed list it belonged to whichever axis the stored view colours by.
 const readStoredNarrowing = (
@@ -378,6 +373,11 @@ const readStoredNarrowing = (
 	return only;
 };
 
+// Neither the offset nor a zoom is kept: a stretch of last Tuesday is a
+// moment, not a preference, and reopening the board a week later on it would be
+// a surprise. Nor is windowOnly: it hides tickets outright, which is too much
+// to restore silently days later — it travels in the URL and nowhere else. Nor
+// is ticketOnly, which names a ticket that need not even be open next time.
 export const readStoredSelection = (): BoardSelection => {
 	try {
 		const stored = localStorage.getItem(STORAGE_KEY);

--- a/source/gui/client/lib/gui-theme.tsx
+++ b/source/gui/client/lib/gui-theme.tsx
@@ -49,6 +49,11 @@ export const EVENT_CATEGORY_COLORS = {
 	assigning: '#ff9ecd',
 } as const;
 
+// The People series, which is not a kind of event but a way of splitting every
+// kind. Its own hue rather than the Board accent: it plots what "Board events"
+// plots, so sharing a colour would leave the two rows saying the same thing.
+export const BOARD_PEOPLE_COLOR = '#7fd8c4';
+
 export const getContrastTextColor = (backgroundColor: string): string => {
 	const hex = backgroundColor.replace('#', '');
 

--- a/source/gui/client/lib/scrubber.test.ts
+++ b/source/gui/client/lib/scrubber.test.ts
@@ -675,7 +675,7 @@ describe('identity views', () => {
 		]);
 
 	it('colours by the side of the event the view is about', () => {
-		expect(identityAxisFor('comments')).toBe('actor');
+		expect(identityAxisFor('comments')).toBe('commenter');
 		expect(identityAxisFor('tagging')).toBe('tag');
 		expect(identityAxisFor('assigning')).toBe('assignee');
 		// Every event is somebody changing a ticket, so there is nothing to
@@ -685,19 +685,16 @@ describe('identity views', () => {
 	});
 
 	it('lists each identity once, as the legend for what is on screen', () => {
-		expect(listIdentities(window(), 'comments').map(i => i.name)).toEqual([
+		expect(listIdentities(window(), 'commenter').map(i => i.name)).toEqual([
 			'jola',
 			'demo',
 		]);
-		// The tagging view lists tags, not the people who applied them.
-		expect(listIdentities(window(), 'tagging').map(i => i.name)).toEqual([
-			'bug',
-		]);
+		// The tag axis lists tags, not the people who applied them.
+		expect(listIdentities(window(), 'tag').map(i => i.name)).toEqual(['bug']);
 	});
 
-	it('has no list for a view with no identity axis', () => {
-		expect(listIdentities(window(), 'tickets')).toEqual([]);
-		expect(listIdentities(window(), 'all')).toEqual([]);
+	it('has no list without an axis', () => {
+		expect(listIdentities(window(), null)).toEqual([]);
 	});
 
 	it('takes each dot colour from its identity, not its kind', () => {
@@ -734,7 +731,7 @@ describe('identity views', () => {
 	});
 
 	describe('soleVisibleIdentity', () => {
-		const listed = () => listIdentities(window(), 'comments');
+		const listed = () => listIdentities(window(), 'commenter');
 
 		it('names the one identity left when the rest are hidden', () => {
 			expect(soleVisibleIdentity(listed(), new Set([jola.id]))?.name).toBe(
@@ -756,14 +753,13 @@ describe('identity views', () => {
 			// One tag in the whole window: the series really is that tag, whether
 			// anyone unticked their way down to it or it arrived alone.
 			expect(
-				soleVisibleIdentity(listIdentities(window(), 'tagging'), new Set())
-					?.name,
+				soleVisibleIdentity(listIdentities(window(), 'tag'), new Set())?.name,
 			).toBe('bug');
 		});
 
 		it('has nothing to name in a view with no identity axis', () => {
 			expect(
-				soleVisibleIdentity(listIdentities(window(), 'all'), new Set()),
+				soleVisibleIdentity(listIdentities(window(), null), new Set()),
 			).toBeNull();
 		});
 	});
@@ -825,45 +821,79 @@ describe('board filter', () => {
 		assignees: {id: string}[] = [],
 	) => ({id: 'i1', tags, assignees});
 
-	it('does not filter until the selection is narrowed', () => {
+	// Nothing to say about the ticket beyond its own row.
+	const nothing = {commenterIds: []};
+
+	it('does not filter until an axis is narrowed', () => {
 		// A kind with everything still ticked is a colouring choice, not a
 		// question about which tickets matter.
-		expect(buildBoardFilter('tagging', null)).toBeNull();
-	});
-
-	it('does not filter on a view with no identity axis', () => {
-		expect(buildBoardFilter('tickets', [bug.id])).toBeNull();
-		expect(buildBoardFilter('all', [bug.id])).toBeNull();
+		expect(buildBoardFilter({})).toEqual([]);
+		expect(issuePassesBoardFilter(issue(), nothing, [])).toBe(true);
 	});
 
 	it('keeps the tickets carrying a visible tag', () => {
-		const filter = buildBoardFilter('tagging', [bug.id]);
+		const filter = buildBoardFilter({tag: [bug.id]});
 
-		expect(issuePassesBoardFilter(issue([bug]), [], filter)).toBe(true);
-		expect(issuePassesBoardFilter(issue([docs]), [], filter)).toBe(false);
+		expect(issuePassesBoardFilter(issue([bug]), nothing, filter)).toBe(true);
+		expect(issuePassesBoardFilter(issue([docs]), nothing, filter)).toBe(false);
 		// Untagged: nothing visible to match, so it is not part of this answer.
-		expect(issuePassesBoardFilter(issue(), [], filter)).toBe(false);
+		expect(issuePassesBoardFilter(issue(), nothing, filter)).toBe(false);
 	});
 
-	it('reads assignees off the ticket for an assigning view', () => {
-		const filter = buildBoardFilter('assigning', [jola.id]);
+	it('reads assignees off the ticket', () => {
+		const filter = buildBoardFilter({assignee: [jola.id]});
 
-		expect(issuePassesBoardFilter(issue([], [jola]), [], filter)).toBe(true);
-		expect(issuePassesBoardFilter(issue([], [docs]), [], filter)).toBe(false);
+		expect(issuePassesBoardFilter(issue([], [jola]), nothing, filter)).toBe(
+			true,
+		);
+		expect(issuePassesBoardFilter(issue([], [docs]), nothing, filter)).toBe(
+			false,
+		);
 		// A tag of the same id must not satisfy an assignee filter.
-		expect(issuePassesBoardFilter(issue([jola], []), [], filter)).toBe(false);
+		expect(issuePassesBoardFilter(issue([jola], []), nothing, filter)).toBe(
+			false,
+		);
 	});
 
-	it('reads comment authors for a comments view', () => {
-		const filter = buildBoardFilter('comments', [jola.id]);
+	it('reads comment authors on the commenter axis', () => {
+		const filter = buildBoardFilter({commenter: [jola.id]});
 
-		expect(issuePassesBoardFilter(issue(), [jola.id], filter)).toBe(true);
-		expect(issuePassesBoardFilter(issue(), [docs.id], filter)).toBe(false);
-		expect(issuePassesBoardFilter(issue(), [], filter)).toBe(false);
+		expect(
+			issuePassesBoardFilter(issue(), {commenterIds: [jola.id]}, filter),
+		).toBe(true);
+		expect(
+			issuePassesBoardFilter(issue(), {commenterIds: [docs.id]}, filter),
+		).toBe(false);
+		expect(issuePassesBoardFilter(issue(), nothing, filter)).toBe(false);
 	});
 
-	it('passes everything through when there is no filter', () => {
-		expect(issuePassesBoardFilter(issue(), [], null)).toBe(true);
+	it('makes a ticket pass every narrowed axis, not just one', () => {
+		const filter = buildBoardFilter({
+			tag: [bug.id],
+			assignee: [jola.id],
+		});
+
+		expect(issuePassesBoardFilter(issue([bug], [jola]), nothing, filter)).toBe(
+			true,
+		);
+		// Tagged right, assigned wrong.
+		expect(issuePassesBoardFilter(issue([bug], [docs]), nothing, filter)).toBe(
+			false,
+		);
+		// Assigned right, tagged wrong.
+		expect(issuePassesBoardFilter(issue([docs], [jola]), nothing, filter)).toBe(
+			false,
+		);
+	});
+
+	it('fails everything on an axis narrowed to nothing', () => {
+		expect(
+			issuePassesBoardFilter(
+				issue([bug]),
+				nothing,
+				buildBoardFilter({tag: []}),
+			),
+		).toBe(false);
 	});
 });
 

--- a/source/gui/client/lib/scrubber.test.ts
+++ b/source/gui/client/lib/scrubber.test.ts
@@ -16,7 +16,9 @@ import {
 	categoryOf,
 	issuePassesBoardFilter,
 	identityAxisFor,
+	FILTER_AXES,
 	listIdentities,
+	listIdentitiesByAxis,
 	soleVisibleIdentity,
 	chooseSegmentUnit,
 	dotAppearAnimation,
@@ -706,6 +708,26 @@ describe('identity views', () => {
 
 	it('has no list without an axis', () => {
 		expect(listIdentities(window(), null)).toEqual([]);
+	});
+
+	// The popover offers all four at once, and rebuilding them is on the path a
+	// needle drag walks every 120ms, so they are collected in one pass. Same
+	// answer as asking axis by axis, which is the only thing that matters here.
+	it('collects every axis in one pass, agreeing with the single-axis list', () => {
+		const byAxis = listIdentitiesByAxis(window());
+
+		for (const axis of FILTER_AXES) {
+			expect(byAxis[axis]).toEqual(listIdentities(window(), axis));
+		}
+	});
+
+	it('has an empty list per axis with no timeline', () => {
+		expect(listIdentitiesByAxis(null)).toEqual({
+			commenter: [],
+			tag: [],
+			assignee: [],
+			actor: [],
+		});
 	});
 
 	it('takes each dot colour from its identity, not its kind', () => {

--- a/source/gui/client/lib/scrubber.test.ts
+++ b/source/gui/client/lib/scrubber.test.ts
@@ -6,6 +6,7 @@ import {
 	GuiEventTimelineEntry,
 } from './gui-state.model';
 import {
+	actorIdsByIssue,
 	bucketCommitStats,
 	bucketCountForSpan,
 	bucketIssueCounts,
@@ -678,6 +679,7 @@ describe('identity views', () => {
 		expect(identityAxisFor('comments')).toBe('commenter');
 		expect(identityAxisFor('tagging')).toBe('tag');
 		expect(identityAxisFor('assigning')).toBe('assignee');
+		expect(identityAxisFor('people')).toBe('actor');
 		// Every event is somebody changing a ticket, so there is nothing to
 		// colour by that the kind does not already say.
 		expect(identityAxisFor('tickets')).toBeNull();
@@ -691,6 +693,15 @@ describe('identity views', () => {
 		]);
 		// The tag axis lists tags, not the people who applied them.
 		expect(listIdentities(window(), 'tag').map(i => i.name)).toEqual(['bug']);
+	});
+
+	// The commenter axis stops at comments; the actor axis takes whoever caused
+	// anything at all, which is what "who touched this ticket" needs.
+	it('lists the author of every kind of event on the actor axis', () => {
+		expect(listIdentities(window(), 'actor').map(i => i.name)).toEqual([
+			'jola',
+			'demo',
+		]);
 	});
 
 	it('has no list without an axis', () => {
@@ -822,7 +833,7 @@ describe('board filter', () => {
 	) => ({id: 'i1', tags, assignees});
 
 	// Nothing to say about the ticket beyond its own row.
-	const nothing = {commenterIds: []};
+	const nothing = {commenterIds: [], actorIds: []};
 
 	it('does not filter until an axis is narrowed', () => {
 		// A kind with everything still ticked is a colouring choice, not a
@@ -859,12 +870,53 @@ describe('board filter', () => {
 		const filter = buildBoardFilter({commenter: [jola.id]});
 
 		expect(
-			issuePassesBoardFilter(issue(), {commenterIds: [jola.id]}, filter),
+			issuePassesBoardFilter(
+				issue(),
+				{commenterIds: [jola.id], actorIds: []},
+				filter,
+			),
 		).toBe(true);
 		expect(
-			issuePassesBoardFilter(issue(), {commenterIds: [docs.id]}, filter),
+			issuePassesBoardFilter(
+				issue(),
+				{commenterIds: [docs.id], actorIds: []},
+				filter,
+			),
 		).toBe(false);
 		expect(issuePassesBoardFilter(issue(), nothing, filter)).toBe(false);
+	});
+
+	it('reads whoever caused an event on the actor axis', () => {
+		const filter = buildBoardFilter({actor: [jola.id]});
+
+		expect(
+			issuePassesBoardFilter(
+				issue(),
+				{commenterIds: [], actorIds: [jola.id]},
+				filter,
+			),
+		).toBe(true);
+		// Commenting is one way to have touched it, but not the only one, so the
+		// two axes are not each other.
+		expect(
+			issuePassesBoardFilter(
+				issue(),
+				{commenterIds: [jola.id], actorIds: [docs.id]},
+				filter,
+			),
+		).toBe(false);
+	});
+
+	// Past the server's cap the window answers with counts alone, which name
+	// nobody: enforcing the axis there would empty the board.
+	it('leaves the actor axis unenforced where the window cannot say', () => {
+		expect(
+			issuePassesBoardFilter(
+				issue(),
+				{commenterIds: [], actorIds: null},
+				buildBoardFilter({actor: [jola.id]}),
+			),
+		).toBe(true);
 	});
 
 	it('makes a ticket pass every narrowed axis, not just one', () => {
@@ -894,6 +946,37 @@ describe('board filter', () => {
 				buildBoardFilter({tag: []}),
 			),
 		).toBe(false);
+	});
+});
+
+describe('actorIdsByIssue', () => {
+	const jola = person('jola');
+	const demo = person('demo');
+
+	const touched = (t: number, issue: string | null, actor = jola) =>
+		entry(t, 'edit.issue.title', {issue, actor});
+
+	it('collects every person who caused an event on each ticket', () => {
+		const byIssue = actorIdsByIssue(
+			timeline([], undefined, [
+				touched(1, 'i1'),
+				touched(2, 'i1', demo),
+				touched(3, 'i2', demo),
+				// Board-level: no ticket to file it under.
+				touched(4, null),
+			]),
+		);
+
+		expect([...byIssue!.get('i1')!]).toEqual([jola.id, demo.id]);
+		expect([...byIssue!.get('i2')!]).toEqual([demo.id]);
+		expect(byIssue!.has('board')).toBe(false);
+	});
+
+	it('is null where the window names no tickets at all', () => {
+		expect(actorIdsByIssue(null)).toBeNull();
+		// Past its event cap the server sends buckets and no events, so there is
+		// no way to tell whose those counts were.
+		expect(actorIdsByIssue(timeline([{t: 1, count: 40}]))).toBeNull();
 	});
 });
 

--- a/source/gui/client/lib/scrubber/index.ts
+++ b/source/gui/client/lib/scrubber/index.ts
@@ -54,6 +54,7 @@ export {
 	identityAxisFor,
 	categoryOf,
 	listIdentities,
+	listIdentitiesByAxis,
 	soleVisibleIdentity,
 	dotDetail,
 	isShown,

--- a/source/gui/client/lib/scrubber/index.ts
+++ b/source/gui/client/lib/scrubber/index.ts
@@ -61,6 +61,7 @@ export {
 	buildBoardFilter,
 	windowNamesIssues,
 	windowIssueIds,
+	actorIdsByIssue,
 	issuePassesBoardFilter,
 } from './series';
 export type {

--- a/source/gui/client/lib/scrubber/index.ts
+++ b/source/gui/client/lib/scrubber/index.ts
@@ -47,7 +47,6 @@ export type {ScrubberAxis, VolumeBar} from './axis';
 export {
 	BOARD_VIEWS,
 	isBoardView,
-	viewCategory,
 	boardViewColor,
 	FILTER_AXES,
 	isFilterAxis,
@@ -71,7 +70,6 @@ export type {
 	EventDot,
 	FilterAxis,
 	SelectionNarrowing,
-	AxisFilter,
 	BoardFilter,
 	IssueFilterFacts,
 } from './series';

--- a/source/gui/client/lib/scrubber/index.ts
+++ b/source/gui/client/lib/scrubber/index.ts
@@ -47,7 +47,10 @@ export type {ScrubberAxis, VolumeBar} from './axis';
 export {
 	BOARD_VIEWS,
 	isBoardView,
+	viewCategory,
 	boardViewColor,
+	FILTER_AXES,
+	isFilterAxis,
 	identityAxisFor,
 	categoryOf,
 	listIdentities,
@@ -60,7 +63,16 @@ export {
 	windowIssueIds,
 	issuePassesBoardFilter,
 } from './series';
-export type {EventCategory, BoardView, EventDot} from './series';
+export type {
+	EventCategory,
+	BoardView,
+	EventDot,
+	FilterAxis,
+	SelectionNarrowing,
+	AxisFilter,
+	BoardFilter,
+	IssueFilterFacts,
+} from './series';
 export {
 	chooseSegmentUnit,
 	segmentAt,

--- a/source/gui/client/lib/scrubber/series.ts
+++ b/source/gui/client/lib/scrubber/series.ts
@@ -25,18 +25,54 @@ export const BOARD_VIEWS: BoardView[] = ['all', ...EVENT_CATEGORIES];
 export const isBoardView = (value: unknown): value is BoardView =>
 	BOARD_VIEWS.includes(value as BoardView);
 
+// The kind a view draws, or null for the one that draws every kind.
+export const viewCategory = (view: BoardView): EventCategory | null =>
+	view === 'all' ? null : view;
+
 // One place for the series colour, so the bars, the baseline and the filter's
 // own rows cannot drift apart.
+const BOARD_VIEW_COLORS: Record<BoardView, string> = {
+	all: GUI_THEME.accent,
+	...EVENT_CATEGORY_COLORS,
+};
+
 export const boardViewColor = (view: BoardView): string =>
-	view === 'all' ? GUI_THEME.accent : EVENT_CATEGORY_COLORS[view];
+	BOARD_VIEW_COLORS[view];
+
+// The sides of an event the board can be narrowed by. `commenter` reads the
+// author of a comment, which is the only kind of event whose author the board
+// state itself can answer for.
+export const FILTER_AXES = ['commenter', 'tag', 'assignee'] as const;
+
+export type FilterAxis = (typeof FILTER_AXES)[number];
+
+export const isFilterAxis = (value: unknown): value is FilterAxis =>
+	FILTER_AXES.includes(value as FilterAxis);
+
+// The field on a timeline entry each axis reads its identity out of.
+const AXIS_FIELD: Record<FilterAxis, 'actor' | 'tag' | 'assignee'> = {
+	commenter: 'actor',
+	tag: 'tag',
+	assignee: 'assignee',
+};
+
+// The kind of event an axis's legend is drawn from.
+const AXIS_CATEGORY: Record<FilterAxis, EventCategory> = {
+	commenter: 'comments',
+	tag: 'tagging',
+	assignee: 'assigning',
+};
+
+// A narrowing per axis: an axis absent is not narrowed at all, an axis present
+// lists the only ids that pass it. Several can hold at once, and a ticket has
+// to pass every one of them.
+export type SelectionNarrowing = Partial<Record<FilterAxis, readonly string[]>>;
 
 // Which side of the event a view colours by. Tickets has none — every event is
 // somebody changing a ticket, so it stays the plain Board accent.
-export const identityAxisFor = (
-	view: BoardView,
-): 'actor' | 'tag' | 'assignee' | null =>
+export const identityAxisFor = (view: BoardView): FilterAxis | null =>
 	view === 'comments'
-		? 'actor'
+		? 'commenter'
 		: view === 'tagging'
 		? 'tag'
 		: view === 'assigning'
@@ -75,24 +111,26 @@ export const identityOf = (
 	view: BoardView,
 ): GuiEventIdentity | null => {
 	const axis = identityAxisFor(view);
-	return axis === null ? null : entry[axis];
+	return axis === null ? null : entry[AXIS_FIELD[axis]];
 };
 
-// Every identity present in the window under this view, in first-seen order.
+// Every identity present in the window on this axis, in first-seen order.
 // Doubles as the filter's legend, so it lists what is actually there rather
 // than every tag or contributor the repo has ever had.
 export const listIdentities = (
 	timeline: GuiEventTimeline | null,
-	view: BoardView,
+	axis: FilterAxis | null,
 ): GuiEventIdentity[] => {
-	if (!timeline || identityAxisFor(view) === null) return [];
+	if (!timeline || axis === null) return [];
 
+	const category = AXIS_CATEGORY[axis];
+	const field = AXIS_FIELD[axis];
 	const byId = new Map<string, GuiEventIdentity>();
 
 	for (const entry of timeline.events) {
-		if (categoryOf(entry.action) !== view) continue;
+		if (categoryOf(entry.action) !== category) continue;
 
-		const identity = identityOf(entry, view);
+		const identity = entry[field];
 		if (identity && !byId.has(identity.id)) byId.set(identity.id, identity);
 	}
 
@@ -169,7 +207,8 @@ export const isShown = (
 	// ticket drops them too: they are not what happened to it.
 	if (issueOnly !== null && entry.issue !== issueOnly) return false;
 
-	if (view !== 'all' && categoryOf(entry.action) !== view) return false;
+	const category = viewCategory(view);
+	if (category !== null && categoryOf(entry.action) !== category) return false;
 
 	const identity = identityOf(entry, view);
 
@@ -235,24 +274,21 @@ export const buildEventDots = (
 	});
 };
 
-// What the scrubber's selection means for the board below it. Null when the
-// selection narrows nothing, so the board is left alone.
-export type BoardFilter = {
-	axis: 'actor' | 'tag' | 'assignee';
-	visibleIds: ReadonlySet<string>;
-};
+// What the scrubber's selection means for the board below it: one entry per
+// narrowed axis, and empty when the selection narrows nothing.
+export type AxisFilter = {axis: FilterAxis; visibleIds: ReadonlySet<string>};
 
-// Only a narrowed selection filters the board. A kind with everything still
-// ticked is a colouring choice, not a question about which tickets matter.
-export const buildBoardFilter = (
-	view: BoardView,
-	only: readonly string[] | null,
-): BoardFilter | null => {
-	const axis = identityAxisFor(view);
-	if (axis === null || only === null) return null;
+export type BoardFilter = readonly AxisFilter[];
 
-	return {axis, visibleIds: new Set(only)};
-};
+// Only a narrowed axis filters the board. A kind with everything still ticked
+// is a colouring choice, not a question about which tickets matter — and which
+// kind is plotted says nothing either way, so a narrowing survives switching
+// the chart to something else.
+export const buildBoardFilter = (only: SelectionNarrowing): BoardFilter =>
+	FILTER_AXES.flatMap(axis => {
+		const ids = only[axis];
+		return ids === undefined ? [] : [{axis, visibleIds: new Set(ids)}];
+	});
 
 // Whether the window says which tickets its events belong to. Past the
 // server's cap it answers with bucket counts alone, which name none — as
@@ -279,6 +315,12 @@ export const windowIssueIds = (
 	return ids;
 };
 
+// What a ticket carries that its own row cannot answer for.
+export type IssueFilterFacts = {
+	// Who has commented on it, read off the board state at the needle.
+	commenterIds: readonly string[];
+};
+
 // Read off the board's own state, which is already the state at the needle —
 // so a filtered board answers "who/what, as of here", matching the moment the
 // scrubber is parked on rather than the events inside the window.
@@ -288,17 +330,16 @@ export const issuePassesBoardFilter = (
 		tags: {id: string}[];
 		assignees: {id: string}[];
 	},
-	commentAuthorIds: readonly string[],
-	filter: BoardFilter | null,
-): boolean => {
-	if (!filter) return true;
+	facts: IssueFilterFacts,
+	filter: BoardFilter,
+): boolean =>
+	filter.every(({axis, visibleIds}) => {
+		const ids =
+			axis === 'tag'
+				? issue.tags.map(tag => tag.id)
+				: axis === 'assignee'
+				? issue.assignees.map(assignee => assignee.id)
+				: facts.commenterIds;
 
-	const ids =
-		filter.axis === 'tag'
-			? issue.tags.map(tag => tag.id)
-			: filter.axis === 'assignee'
-			? issue.assignees.map(assignee => assignee.id)
-			: commentAuthorIds;
-
-	return ids.some(id => filter.visibleIds.has(id));
-};
+		return ids.some(id => visibleIds.has(id));
+	});

--- a/source/gui/client/lib/scrubber/series.ts
+++ b/source/gui/client/lib/scrubber/series.ts
@@ -31,7 +31,7 @@ export const isBoardView = (value: unknown): value is BoardView =>
 	BOARD_VIEWS.includes(value as BoardView);
 
 // The kind a view draws, or null for the two that draw every kind.
-export const viewCategory = (view: BoardView): EventCategory | null =>
+const viewCategory = (view: BoardView): EventCategory | null =>
 	view === 'all' || view === 'people' ? null : view;
 
 // One place for the series colour, so the bars, the baseline and the filter's

--- a/source/gui/client/lib/scrubber/series.ts
+++ b/source/gui/client/lib/scrubber/series.ts
@@ -16,33 +16,39 @@ export const EVENT_CATEGORIES = [
 export type EventCategory = (typeof EVENT_CATEGORIES)[number];
 
 // What the Board series is showing. 'all' draws every kind and colours by kind;
-// picking one kind draws only it and colours by the identity behind each event.
+// picking one kind draws only it and colours by the identity behind each event;
+// 'people' draws every kind, like 'all', and colours by who caused each one.
 // Exactly one at a time, which is what keeps a colour from meaning two things.
-export type BoardView = 'all' | EventCategory;
+export type BoardView = 'all' | EventCategory | 'people';
 
-export const BOARD_VIEWS: BoardView[] = ['all', ...EVENT_CATEGORIES];
+export const BOARD_VIEWS: BoardView[] = ['all', ...EVENT_CATEGORIES, 'people'];
 
 export const isBoardView = (value: unknown): value is BoardView =>
 	BOARD_VIEWS.includes(value as BoardView);
 
-// The kind a view draws, or null for the one that draws every kind.
+// The kind a view draws, or null for the two that draw every kind.
 export const viewCategory = (view: BoardView): EventCategory | null =>
-	view === 'all' ? null : view;
+	view === 'all' || view === 'people' ? null : view;
 
 // One place for the series colour, so the bars, the baseline and the filter's
 // own rows cannot drift apart.
 const BOARD_VIEW_COLORS: Record<BoardView, string> = {
 	all: GUI_THEME.accent,
 	...EVENT_CATEGORY_COLORS,
+	// Its own hue rather than the Board accent: 'people' plots the same events
+	// 'all' does, so sharing a colour with it would leave the two rows saying
+	// the same thing.
+	people: '#7fd8c4',
 };
 
 export const boardViewColor = (view: BoardView): string =>
 	BOARD_VIEW_COLORS[view];
 
-// The sides of an event the board can be narrowed by. `commenter` reads the
-// author of a comment, which is the only kind of event whose author the board
-// state itself can answer for.
-export const FILTER_AXES = ['commenter', 'tag', 'assignee'] as const;
+// The four sides of an event the board can be narrowed by. `commenter` and
+// `actor` both read the event's author: the first only over comments, so it
+// answers "who talked about this ticket", the second over every kind, so it
+// answers "who touched it".
+export const FILTER_AXES = ['commenter', 'tag', 'assignee', 'actor'] as const;
 
 export type FilterAxis = (typeof FILTER_AXES)[number];
 
@@ -54,13 +60,16 @@ const AXIS_FIELD: Record<FilterAxis, 'actor' | 'tag' | 'assignee'> = {
 	commenter: 'actor',
 	tag: 'tag',
 	assignee: 'assignee',
+	actor: 'actor',
 };
 
-// The kind of event an axis's legend is drawn from.
-const AXIS_CATEGORY: Record<FilterAxis, EventCategory> = {
+// The kind of event an axis's legend is drawn from. Null for `actor`, which
+// lists whoever caused anything at all.
+const AXIS_CATEGORY: Record<FilterAxis, EventCategory | null> = {
 	commenter: 'comments',
 	tag: 'tagging',
 	assignee: 'assigning',
+	actor: null,
 };
 
 // A narrowing per axis: an axis absent is not narrowed at all, an axis present
@@ -77,6 +86,8 @@ export const identityAxisFor = (view: BoardView): FilterAxis | null =>
 		? 'tag'
 		: view === 'assigning'
 		? 'assignee'
+		: view === 'people'
+		? 'actor'
 		: null;
 
 // Listed rather than matched on substrings: "attachment" and "assignee" both
@@ -128,7 +139,7 @@ export const listIdentities = (
 	const byId = new Map<string, GuiEventIdentity>();
 
 	for (const entry of timeline.events) {
-		if (categoryOf(entry.action) !== category) continue;
+		if (category !== null && categoryOf(entry.action) !== category) continue;
 
 		const identity = entry[field];
 		if (identity && !byId.has(identity.id)) byId.set(identity.id, identity);
@@ -315,15 +326,43 @@ export const windowIssueIds = (
 	return ids;
 };
 
+// Who caused an event on each ticket, over the window in hand. Null where the
+// window names no tickets at all — past the server's cap it answers with
+// bucket counts, and reading those as "nobody touched anything" would empty
+// the board rather than leave the axis unanswerable.
+export const actorIdsByIssue = (
+	timeline: GuiEventTimeline | null,
+): Map<string, Set<string>> | null => {
+	if (timeline === null || !windowNamesIssues(timeline)) return null;
+
+	const byIssue = new Map<string, Set<string>>();
+
+	for (const entry of timeline.events) {
+		if (entry.issue === null || entry.actor === null) continue;
+
+		const ids = byIssue.get(entry.issue) ?? new Set<string>();
+		ids.add(entry.actor.id);
+		byIssue.set(entry.issue, ids);
+	}
+
+	return byIssue;
+};
+
 // What a ticket carries that its own row cannot answer for.
 export type IssueFilterFacts = {
 	// Who has commented on it, read off the board state at the needle.
 	commenterIds: readonly string[];
+	// Who has caused any event on it inside the window. Null where the window
+	// cannot say, which leaves that axis unenforced rather than failing every
+	// ticket against it.
+	actorIds: readonly string[] | null;
 };
 
-// Read off the board's own state, which is already the state at the needle —
-// so a filtered board answers "who/what, as of here", matching the moment the
-// scrubber is parked on rather than the events inside the window.
+// Tags and assignees are read off the board's own state, which is already the
+// state at the needle — so a filtered board answers "who/what, as of here",
+// matching the moment the scrubber is parked on rather than the events inside
+// the window. The actor axis is the exception: nothing but the window knows who
+// caused what, so that one narrows by the window.
 export const issuePassesBoardFilter = (
 	issue: {
 		id: string;
@@ -339,7 +378,9 @@ export const issuePassesBoardFilter = (
 				? issue.tags.map(tag => tag.id)
 				: axis === 'assignee'
 				? issue.assignees.map(assignee => assignee.id)
-				: facts.commenterIds;
+				: axis === 'commenter'
+				? facts.commenterIds
+				: facts.actorIds;
 
-		return ids.some(id => visibleIds.has(id));
+		return ids === null || ids.some(id => visibleIds.has(id));
 	});

--- a/source/gui/client/lib/scrubber/series.ts
+++ b/source/gui/client/lib/scrubber/series.ts
@@ -3,7 +3,11 @@ import {
 	GuiEventTimeline,
 	GuiEventTimelineEntry,
 } from '../gui-state.model';
-import {EVENT_CATEGORY_COLORS, GUI_THEME} from '../gui-theme';
+import {
+	BOARD_PEOPLE_COLOR,
+	EVENT_CATEGORY_COLORS,
+	GUI_THEME,
+} from '../gui-theme';
 import {maxOf} from '../../../../lib/utils/minmax.js';
 
 export const EVENT_CATEGORIES = [
@@ -35,10 +39,7 @@ export const viewCategory = (view: BoardView): EventCategory | null =>
 const BOARD_VIEW_COLORS: Record<BoardView, string> = {
 	all: GUI_THEME.accent,
 	...EVENT_CATEGORY_COLORS,
-	// Its own hue rather than the Board accent: 'people' plots the same events
-	// 'all' does, so sharing a colour with it would leave the two rows saying
-	// the same thing.
-	people: '#7fd8c4',
+	people: BOARD_PEOPLE_COLOR,
 };
 
 export const boardViewColor = (view: BoardView): string =>

--- a/source/gui/client/lib/scrubber/series.ts
+++ b/source/gui/client/lib/scrubber/series.ts
@@ -126,6 +126,19 @@ export const identityOf = (
 	return axis === null ? null : entry[AXIS_FIELD[axis]];
 };
 
+// The identity an event offers an axis, or null where it offers none — an
+// assigning event on the tag axis, or a `create.contributor` on the assignee
+// axis, which names nobody assigned.
+const identityOnAxis = (
+	entry: GuiEventTimelineEntry,
+	axis: FilterAxis,
+): GuiEventIdentity | null => {
+	const category = AXIS_CATEGORY[axis];
+	if (category !== null && categoryOf(entry.action) !== category) return null;
+
+	return entry[AXIS_FIELD[axis]];
+};
+
 // Every identity present in the window on this axis, in first-seen order.
 // Doubles as the filter's legend, so it lists what is actually there rather
 // than every tag or contributor the repo has ever had.
@@ -135,18 +148,39 @@ export const listIdentities = (
 ): GuiEventIdentity[] => {
 	if (!timeline || axis === null) return [];
 
-	const category = AXIS_CATEGORY[axis];
-	const field = AXIS_FIELD[axis];
 	const byId = new Map<string, GuiEventIdentity>();
 
 	for (const entry of timeline.events) {
-		if (category !== null && categoryOf(entry.action) !== category) continue;
-
-		const identity = entry[field];
+		const identity = identityOnAxis(entry, axis);
 		if (identity && !byId.has(identity.id)) byId.set(identity.id, identity);
 	}
 
 	return [...byId.values()];
+};
+
+// Every axis's legend at once, in one pass. The popover offers all four, and
+// the lists are rebuilt on every board broadcast — a needle drag makes one
+// every 120ms — so walking a whole window's events once per axis is four times
+// the work for the same answer.
+export const listIdentitiesByAxis = (
+	timeline: GuiEventTimeline | null,
+): Record<FilterAxis, GuiEventIdentity[]> => {
+	const byAxis = {} as Record<FilterAxis, Map<string, GuiEventIdentity>>;
+	for (const axis of FILTER_AXES) byAxis[axis] = new Map();
+
+	for (const entry of timeline?.events ?? []) {
+		for (const axis of FILTER_AXES) {
+			const identity = identityOnAxis(entry, axis);
+			if (identity && !byAxis[axis].has(identity.id)) {
+				byAxis[axis].set(identity.id, identity);
+			}
+		}
+	}
+
+	const lists = {} as Record<FilterAxis, GuiEventIdentity[]>;
+	for (const axis of FILTER_AXES) lists[axis] = [...byAxis[axis].values()];
+
+	return lists;
 };
 
 // The one identity left when everything else in the view is hidden — reached by

--- a/source/gui/client/lib/use-event-log.ts
+++ b/source/gui/client/lib/use-event-log.ts
@@ -7,14 +7,14 @@
 // between one rule and four that drift.
 
 import {useMemo} from 'react';
-import {BoardSelection, hiddenIdsFor} from './board-selection';
+import {BoardSelection, hiddenIdsFor, narrowingFor} from './board-selection';
 import {buildLogEntries, LogEntry, logEntriesUpTo} from './event-log';
 import {
 	GuiCommitEntry,
 	GuiEventTimeline,
 	GuiTimeTravelStatus,
 } from './gui-state.model';
-import {isShown, listIdentities} from './scrubber';
+import {identityAxisFor, isShown, listIdentities} from './scrubber';
 
 // Module scope, so a shut panel does not hand the memos below a new array on
 // every render.
@@ -97,7 +97,13 @@ export const useEventLog = ({
 		// `isShown` is the chart's own rule, imported rather than restated: the
 		// log and the picture above it must never disagree about what is in the
 		// window.
-		const hidden = hiddenIdsFor(listIdentities(timeline, view), only);
+		// Only the axis the chart is coloured by hides events; the others narrow
+		// the board under it without taking anything out of the picture above.
+		const axis = identityAxisFor(view);
+		const hidden = hiddenIdsFor(
+			listIdentities(timeline, axis),
+			narrowingFor(only, axis),
+		);
 
 		return buildLogEntries(
 			showIssues

--- a/source/gui/client/lib/use-persisted-flag.ts
+++ b/source/gui/client/lib/use-persisted-flag.ts
@@ -19,3 +19,25 @@ export const usePersistedFlag = (
 		},
 	];
 };
+
+// The same store, for one choice out of a fixed set rather than a flag, with
+// null for "none of them". A stored value the set no longer holds reads as
+// null, so a renamed option cannot leave a control stuck on something it has
+// stopped offering.
+export const usePersistedChoice = <T extends string>(
+	key: string,
+	isValid: (value: string) => value is T,
+): [T | null, (next: T | null) => void] => {
+	const [value, setValue] = useState<T | null>(() => {
+		const stored = localStorage.getItem(key);
+		return stored !== null && isValid(stored) ? stored : null;
+	});
+
+	return [
+		value,
+		(next: T | null) => {
+			setValue(next);
+			localStorage.setItem(key, next ?? '');
+		},
+	];
+};

--- a/source/test/e2e-gui/board-filter-axes.pw.ts
+++ b/source/test/e2e-gui/board-filter-axes.pw.ts
@@ -74,7 +74,7 @@ test('opening a row list leaves the plotted series alone', async ({
 	// The caret opens that axis's list without selecting its row, which is the
 	// whole point of a list per axis: narrow by one while the chart plots
 	// another.
-	await page.getByRole('button', {name: 'Pick which to show'}).first().click();
+	await page.getByRole('button', {name: 'Pick which comments to show'}).click();
 	await expect(page.getByRole('radio', {name: 'Tags'})).toHaveAttribute(
 		'aria-checked',
 		'true',

--- a/source/test/e2e-gui/board-filter-axes.pw.ts
+++ b/source/test/e2e-gui/board-filter-axes.pw.ts
@@ -1,0 +1,88 @@
+import type {Page} from '@playwright/test';
+import {expect, test} from './fixtures.js';
+
+const card = (page: Page, title: string) =>
+	page.locator('[draggable="true"]').filter({hasText: title});
+
+const addTicket = async (page: Page, title: string) => {
+	await page.getByTitle('Add issue').first().click();
+	await page.getByPlaceholder('issue name').fill(title);
+	await page.getByPlaceholder('issue name').press('Enter');
+	await expect(page.locator('aside')).toContainText(title);
+};
+
+const tagOpenTicket = async (page: Page, tag: string) => {
+	await page
+		.locator('aside')
+		.getByRole('button', {name: '+', exact: true})
+		.first()
+		.click();
+	await page.getByPlaceholder('tag name').fill(tag);
+	await page.getByPlaceholder('tag name').press('Enter');
+	await expect(page.locator('aside')).toContainText(tag);
+};
+
+test('a narrowing survives the chart being pointed somewhere else', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+	const boardUrl = page.url();
+
+	const stamp = Date.now();
+	const tagged = `Tagged ${stamp}`;
+	const plain = `Plain ${stamp}`;
+	const tag = `t${stamp}`;
+
+	await addTicket(page, tagged);
+	await tagOpenTicket(page, tag);
+	await addTicket(page, plain);
+
+	await page.goto(boardUrl);
+	await card(page, tagged)
+		.getByTestId('ticket-tag')
+		.filter({hasText: tag})
+		.click();
+	await expect(card(page, plain)).toHaveCount(0);
+
+	// The narrowing belongs to the tag axis, not to whatever the chart happens
+	// to be plotting, so choosing another series leaves the board where it is.
+	await page.getByRole('button', {name: /^Tags/}).click();
+	await page.getByRole('radio', {name: 'Comments'}).click();
+
+	await expect(page).toHaveURL(/view=comments/);
+	await expect(page).toHaveURL(/only=tag/);
+	await expect(card(page, tagged)).toBeVisible();
+	await expect(card(page, plain)).toHaveCount(0);
+
+	expect(pageErrors).toEqual([]);
+});
+
+test('opening a row list leaves the plotted series alone', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	await page.getByRole('button', {name: 'Board events'}).click();
+	await page.getByRole('radio', {name: 'Tags'}).click();
+
+	// The caret opens that axis's list without selecting its row, which is the
+	// whole point of a list per axis: narrow by one while the chart plots
+	// another.
+	await page.getByRole('button', {name: 'Pick which to show'}).first().click();
+	await expect(page.getByRole('radio', {name: 'Tags'})).toHaveAttribute(
+		'aria-checked',
+		'true',
+	);
+	await expect(page.getByRole('radio', {name: 'Comments'})).toHaveAttribute(
+		'aria-checked',
+		'false',
+	);
+
+	expect(pageErrors).toEqual([]);
+});

--- a/source/test/e2e-gui/people-filter.pw.ts
+++ b/source/test/e2e-gui/people-filter.pw.ts
@@ -25,7 +25,7 @@ test('the People list narrows the board to who caused an event on a ticket', asy
 
 	await page.getByRole('button', {name: 'Board events'}).click();
 	await page.getByRole('radio', {name: 'Tags'}).click();
-	await page.getByRole('button', {name: 'Pick which to show'}).last().click();
+	await page.getByRole('button', {name: 'Pick which people to show'}).click();
 
 	// The People list is the actor behind every kind of event, not just the
 	// author of a comment, so unticking the lot leaves no ticket anybody has

--- a/source/test/e2e-gui/people-filter.pw.ts
+++ b/source/test/e2e-gui/people-filter.pw.ts
@@ -1,0 +1,49 @@
+import type {Page} from '@playwright/test';
+import {expect, test} from './fixtures.js';
+
+const card = (page: Page, title: string) =>
+	page.locator('[draggable="true"]').filter({hasText: title});
+
+const addTicket = async (page: Page, title: string) => {
+	await page.getByTitle('Add issue').first().click();
+	await page.getByPlaceholder('issue name').fill(title);
+	await page.getByPlaceholder('issue name').press('Enter');
+	await expect(page.locator('aside')).toContainText(title);
+};
+
+test('the People list narrows the board to who caused an event on a ticket', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	const touched = `Touched ${Date.now()}`;
+	await addTicket(page, touched);
+	await expect(card(page, touched)).toBeVisible();
+
+	await page.getByRole('button', {name: 'Board events'}).click();
+	await page.getByRole('radio', {name: 'Tags'}).click();
+	await page.getByRole('button', {name: 'Pick which to show'}).last().click();
+
+	// The People list is the actor behind every kind of event, not just the
+	// author of a comment, so unticking the lot leaves no ticket anybody has
+	// touched. Clicked rather than unchecked: the input is React-controlled, so
+	// its DOM property trails the render answering the click, and uncheck()'s
+	// own read of it races that.
+	const person = page.getByRole('radiogroup').getByRole('checkbox').first();
+	await expect(person).toBeChecked();
+	await person.click();
+
+	await expect(page).toHaveURL(/only=actor/);
+	await expect(card(page, touched)).toHaveCount(0);
+	// The chart is still plotting tags: narrowing People filtered the board
+	// under it without taking the series away.
+	await expect(page).toHaveURL(/view=tagging/);
+
+	await person.click();
+	await expect(card(page, touched)).toBeVisible();
+
+	expect(pageErrors).toEqual([]);
+});

--- a/source/test/e2e-gui/scrub-dispatch.pw.ts
+++ b/source/test/e2e-gui/scrub-dispatch.pw.ts
@@ -151,11 +151,34 @@ test('dragging the needle commits the position it ends on', async ({
 		page.getByRole('button', {name: 'Resume', exact: true}),
 	).toBeEnabled();
 
-	const grip = page.getByTestId('scrubber-needle-grip');
-	const gripBox = await grip.boundingBox();
-	if (!gripBox) throw new Error('scrubber needle is not on screen');
+	// That first scrub hands the board a new window, so the moments the track
+	// stands for afterwards are not the ones it stood for before. Only the
+	// drag's own requests are on one coordinate system and so comparable — the
+	// click that set the needle up is not.
+	targets.length = 0;
 
-	await page.mouse.move(gripBox.x + gripBox.width / 2, y);
+	const grip = page.getByTestId('scrubber-needle-grip');
+	const gripCentre = async () => {
+		const gripBox = await grip.boundingBox();
+		if (!gripBox) throw new Error('scrubber needle is not on screen');
+		return gripBox.x + gripBox.width / 2;
+	};
+
+	// The needle is placed against the window, and the scrub above fetches a
+	// fresh one — so where it sits has to be read after it has stopped moving.
+	// Pressing on yesterday's position lands beside the grip, and a press off
+	// the needle drags out a range instead of moving it.
+	let centre = await gripCentre();
+	await expect
+		.poll(async () => {
+			const now = await gripCentre();
+			const settled = Math.abs(now - centre) < 1;
+			centre = now;
+			return settled;
+		})
+		.toBe(true);
+
+	await page.mouse.move(centre, y);
 	await page.mouse.down();
 	for (const at of [0.4, 0.6, 0.8]) {
 		await page.mouse.move(box.x + box.width * at, y);
@@ -163,10 +186,12 @@ test('dragging the needle commits the position it ends on', async ({
 	await page.mouse.up();
 	await page.waitForTimeout(2000);
 
-	expect(targets.length).toBeGreaterThan(1);
-
-	// The release lands on the far right, so the last request must be the
-	// largest moment asked for.
+	// The drag ends on the far right, so the last request must be the largest
+	// moment asked for: that is what says the board holds where the pointer let
+	// go rather than wherever the throttle last got a word in. Not a count —
+	// how many of the moves the throttle passes is not fixed, and a release
+	// landing on a moment already asked for rightly has nothing to add.
+	expect(targets.length).toBeGreaterThan(0);
 	expect(targets[targets.length - 1]).toBe(Math.max(...targets));
 
 	// A needle drag scrubs and nothing more: the window it was dragged across

--- a/source/test/e2e/comments.e2e.test.ts
+++ b/source/test/e2e/comments.e2e.test.ts
@@ -81,16 +81,24 @@ describe('TUI comments', () => {
 				)}${tail}`;
 				await run(tui, `:comment ${body}`, 'comment a fairly');
 
-				// Into the ticket, down to its Comments field, and in.
+				// Into the ticket, down to its Comments field, and in. Every press is
+				// confirmed on the row it lands on before the next goes out: pressing
+				// on a timer and checking the frame afterwards races the render, and
+				// a slow one lets all six presses through — which walks the cursor off
+				// the end of the six rows and back to the one it started on.
 				tui.input(ENTER);
 				await tui.waitFor('Comments (1) ››', 4_000);
-				// Description, Assignees, Tags, History come first; stop on Comments.
-				for (let step = 0; step < 6; step++) {
-					if (/❯\s+Comments \(1\)/.test(tui.output())) break;
+
+				for (const row of [
+					/❯\s+Assignees/,
+					/❯\s+Tags/,
+					/❯\s+History/,
+					/❯\s+Comments \(1\)/,
+				]) {
 					tui.input(ARROW_DOWN);
-					await new Promise(resolve => setTimeout(resolve, 150));
+					await tui.waitFor(row, 4_000);
 				}
-				await tui.waitFor(/❯\s+Comments \(1\)/, 4_000);
+
 				tui.input(ENTER);
 				await tui.waitFor('#1 ', 4_000);
 


### PR DESCRIPTION
Board filters gain a second dimension and a fourth axis, plus two flakes the branch's own gate runs turned up.

## `7TN11YK` filters combine across axes

`BoardSelection.only` is a per-axis map rather than one flat list, over `commenter`, `tag`, `assignee` and `actor`. `buildBoardFilter` returns an entry per narrowed axis and a ticket has to pass all of them, so "assigned to her" and "tagged bug" is one question instead of two that overwrite each other.

- Switching what the chart plots no longer clears the narrowing — each axis owns its list.
- A row's caret in the series popover opens that axis's list without selecting its row. The radio still picks the plotted series; only that axis's ticks change the picture, the rest narrow the board under it.
- The URL keeps one `only` key with axis-prefixed groups (`only=tag:a,b;assignee:c`). An unprefixed list, from an old link or an old localStorage entry, still reads onto whichever axis the view in it colours by.

## `WP93ATF` a People axis

A `People` row plots every event the way `Board events` does but colours by the event's actor, and its list is the fourth filter axis — which tickets somebody has touched, not just which they are assigned or have commented on.

Board state cannot answer that, so `actorIdsByIssue` builds it off the timeline. That makes this one axis window-scoped, and past the server's event cap it returns null and the axis is left unenforced rather than emptying the board.

## `QM0V21Z` the needle drag commits where you let go

Two defects behind a gate flake. `endDrag` read the drag position out of React state, so the release asked for wherever the last *rendered* move was. And scrubbing fetches a fresh window, which was adopted mid-drag — re-deriving the axis under the pointer, so the same fraction meant a different moment before and after. A window arriving while the pointer is down is now held until the release.

## `06N5TME` the TUI comments test walked the rows on a timer

Six presses on a 150ms sleep; under load every check read a stale frame, all six landed, and the cursor wrapped back to where it started. Each press is confirmed on the row it lands on now.

## Checks

`tsc`, eslint, prettier, 1245 unit tests, the container e2e and collaboration suites and all 134 browser tests — the full pre-push gate, green. The drag test was 4/4 red at `--repeat-each=8 --workers=6` before the fix and 40/40 green after.
