### PR TITLE
The board series is Contributors, not People

### DIFF
--- a/source/gui/client/components/ScrubberSelects.tsx
+++ b/source/gui/client/components/ScrubberSelects.tsx
@@ -61,14 +61,17 @@ const disclosureStyle: React.CSSProperties = {
 const VIEW_LABELS: Record<BoardView, string> = {
 	all: 'Board events',
 	...CATEGORY_LABELS,
-	people: 'People',
+	contributors: 'Contributors',
 };
 
 // Fixed, not sized to its label: the selection changes as the thing is used,
 // and a trigger that grew with it would shove the scope buttons beside it out
-// from under the pointer. Wide enough for the labels themselves; a name long
-// enough to overflow is clipped, and the open list spells it out in full.
-const SELECT_TRIGGER_WIDTH = 148;
+// from under the pointer. Wide enough for the labels themselves — the longest
+// being "Board events (filtered)" at 23 monospace characters, plus the padding,
+// the chevron and a couple of pixels of slack — measured exactly to the text it
+// still ellipsised. A tag or a person's name long enough to overflow past that
+// is clipped, and the open list spells it out in full.
+const SELECT_TRIGGER_WIDTH = 180;
 
 // A select. Filled rather than outlined, unlike the toggles beside it: it is the
 // only control here reporting a colour, and an outline in that colour drowned

--- a/source/gui/client/lib/gui-theme.tsx
+++ b/source/gui/client/lib/gui-theme.tsx
@@ -49,10 +49,11 @@ export const EVENT_CATEGORY_COLORS = {
 	assigning: '#ff9ecd',
 } as const;
 
-// The People series, which is not a kind of event but a way of splitting every
-// kind. Its own hue rather than the Board accent: it plots what "Board events"
-// plots, so sharing a colour would leave the two rows saying the same thing.
-export const BOARD_PEOPLE_COLOR = '#7fd8c4';
+// The Contributors series, which is not a kind of event but a way of splitting
+// every kind. Its own hue rather than the Board accent: it plots what "Board
+// events" plots, so sharing a colour would leave the two rows saying the same
+// thing.
+export const BOARD_CONTRIBUTOR_COLOR = '#7fd8c4';
 
 export const getContrastTextColor = (backgroundColor: string): string => {
 	const hex = backgroundColor.replace('#', '');

--- a/source/gui/client/lib/scrubber.test.ts
+++ b/source/gui/client/lib/scrubber.test.ts
@@ -681,7 +681,7 @@ describe('identity views', () => {
 		expect(identityAxisFor('comments')).toBe('commenter');
 		expect(identityAxisFor('tagging')).toBe('tag');
 		expect(identityAxisFor('assigning')).toBe('assignee');
-		expect(identityAxisFor('people')).toBe('actor');
+		expect(identityAxisFor('contributors')).toBe('actor');
 		// Every event is somebody changing a ticket, so there is nothing to
 		// colour by that the kind does not already say.
 		expect(identityAxisFor('tickets')).toBeNull();

--- a/source/gui/client/lib/scrubber/series.ts
+++ b/source/gui/client/lib/scrubber/series.ts
@@ -4,7 +4,7 @@ import {
 	GuiEventTimelineEntry,
 } from '../gui-state.model';
 import {
-	BOARD_PEOPLE_COLOR,
+	BOARD_CONTRIBUTOR_COLOR,
 	EVENT_CATEGORY_COLORS,
 	GUI_THEME,
 } from '../gui-theme';
@@ -21,25 +21,29 @@ export type EventCategory = (typeof EVENT_CATEGORIES)[number];
 
 // What the Board series is showing. 'all' draws every kind and colours by kind;
 // picking one kind draws only it and colours by the identity behind each event;
-// 'people' draws every kind, like 'all', and colours by who caused each one.
+// 'contributors' draws every kind, like 'all', and colours by who caused each.
 // Exactly one at a time, which is what keeps a colour from meaning two things.
-export type BoardView = 'all' | EventCategory | 'people';
+export type BoardView = 'all' | EventCategory | 'contributors';
 
-export const BOARD_VIEWS: BoardView[] = ['all', ...EVENT_CATEGORIES, 'people'];
+export const BOARD_VIEWS: BoardView[] = [
+	'all',
+	...EVENT_CATEGORIES,
+	'contributors',
+];
 
 export const isBoardView = (value: unknown): value is BoardView =>
 	BOARD_VIEWS.includes(value as BoardView);
 
 // The kind a view draws, or null for the two that draw every kind.
 const viewCategory = (view: BoardView): EventCategory | null =>
-	view === 'all' || view === 'people' ? null : view;
+	view === 'all' || view === 'contributors' ? null : view;
 
 // One place for the series colour, so the bars, the baseline and the filter's
 // own rows cannot drift apart.
 const BOARD_VIEW_COLORS: Record<BoardView, string> = {
 	all: GUI_THEME.accent,
 	...EVENT_CATEGORY_COLORS,
-	people: BOARD_PEOPLE_COLOR,
+	contributors: BOARD_CONTRIBUTOR_COLOR,
 };
 
 export const boardViewColor = (view: BoardView): string =>
@@ -87,7 +91,7 @@ export const identityAxisFor = (view: BoardView): FilterAxis | null =>
 		? 'tag'
 		: view === 'assigning'
 		? 'assignee'
-		: view === 'people'
+		: view === 'contributors'
 		? 'actor'
 		: null;
 

--- a/source/test/e2e-gui/contributor-filter.pw.ts
+++ b/source/test/e2e-gui/contributor-filter.pw.ts
@@ -11,7 +11,7 @@ const addTicket = async (page: Page, title: string) => {
 	await expect(page.locator('aside')).toContainText(title);
 };
 
-test('the People list narrows the board to who caused an event on a ticket', async ({
+test('the Contributors list narrows the board to who caused an event on a ticket', async ({
 	page,
 	appUrl,
 	pageErrors,
@@ -25,9 +25,11 @@ test('the People list narrows the board to who caused an event on a ticket', asy
 
 	await page.getByRole('button', {name: 'Board events'}).click();
 	await page.getByRole('radio', {name: 'Tags'}).click();
-	await page.getByRole('button', {name: 'Pick which people to show'}).click();
+	await page
+		.getByRole('button', {name: 'Pick which contributors to show'})
+		.click();
 
-	// The People list is the actor behind every kind of event, not just the
+	// The Contributors list is the actor behind every kind of event, not just the
 	// author of a comment, so unticking the lot leaves no ticket anybody has
 	// touched. Clicked rather than unchecked: the input is React-controlled, so
 	// its DOM property trails the render answering the click, and uncheck()'s
@@ -38,7 +40,7 @@ test('the People list narrows the board to who caused an event on a ticket', asy
 
 	await expect(page).toHaveURL(/only=actor/);
 	await expect(card(page, touched)).toHaveCount(0);
-	// The chart is still plotting tags: narrowing People filtered the board
+	// The chart is still plotting tags: narrowing Contributors filtered the board
 	// under it without taking the series away.
 	await expect(page).toHaveURL(/view=tagging/);
 


### PR DESCRIPTION
`WP93ATF` follow-up. The board series added yesterday read `People`; the word the rest of the board uses is `Contributors` — `GuiContributor`, the Manage contributors modal, `epiq_contributor_list`.

Renamed through rather than at the label alone: the view id in the URL is `view=contributors` and the colour constant goes with it, so nothing ends up called two things. Nothing links to `view=people` yet — the axis merged an hour ago.

## The trigger had to grow

`Contributors (multi)` wants 120px of a 114px text slot. Measuring that showed `Board events (filtered)` had been ellipsised since the `(filtered)` suffix landed earlier today — 23 monospace characters against 138px of room, clipped before this rename and not caught then.

The select is 180px now, sized to that longest fixed label with a couple of pixels of slack. A tag or a person's name past it is still clipped, which is what the open list is for.

## Checks

The full pre-push gate: typecheck, lint, prettier, 1309 unit tests, the container e2e and collaboration suites, and 136 browser tests.
