### PR TITLE
Stats tab: draw the shares, name the authors, drop the double rules

### DIFF
--- a/source/gui/client/components/IssueStats.tsx
+++ b/source/gui/client/components/IssueStats.tsx
@@ -14,7 +14,9 @@ import {
 	STAT_LABEL,
 	STAT_NOTE,
 	STAT_VALUE,
+	seriesColor,
 } from '../lib/issue-stats.style';
+import {ProportionBar, StackedBar} from './StatBars';
 import {Empty} from './FormPrimitives';
 import {Section} from './Section';
 
@@ -96,10 +98,25 @@ const Stat = ({
 	</div>
 );
 
-const Row = ({left, right}: {left: React.ReactNode; right: string}) => (
-	<div style={ROW}>
+const Row = ({
+	left,
+	right,
+	dot,
+	last = false,
+}: {
+	left: React.ReactNode;
+	right: string;
+	dot?: string;
+	// The section below draws its own top border, so a rule under the final row
+	// is that border twice.
+	last?: boolean;
+}) => (
+	<div style={last ? {...ROW, borderBottom: 'none'} : ROW}>
 		<span
 			style={{
+				display: 'flex',
+				alignItems: 'center',
+				gap: 8,
 				color: GUI_THEME.secondary,
 				minWidth: 0,
 				overflow: 'hidden',
@@ -107,6 +124,20 @@ const Row = ({left, right}: {left: React.ReactNode; right: string}) => (
 				whiteSpace: 'nowrap',
 			}}
 		>
+			{dot && (
+				// The bar above says which share is which by position; this says
+				// it again by name, so the reading never rests on colour alone.
+				<span
+					aria-hidden
+					style={{
+						width: 7,
+						height: 7,
+						borderRadius: 2,
+						background: dot,
+						flexShrink: 0,
+					}}
+				/>
+			)}
 			{left}
 		</span>
 		<span style={{color: GUI_THEME.primary, flexShrink: 0}}>{right}</span>
@@ -147,6 +178,10 @@ export const IssueStats = ({
 		);
 	}
 
+	// The language the ticket is most written in — the one whose comment share
+	// is worth drawing, since the rest are a handful of lines each.
+	const leadComments = comments.byLanguage[0];
+
 	const flaggedFiles = [
 		...flags.dependencyManifests.map(file => ({file, what: 'dependencies'})),
 		...flags.buildOrCiPaths.map(file => ({file, what: 'build or CI'})),
@@ -173,16 +208,24 @@ export const IssueStats = ({
 					<Stat
 						value={String(shape.directories)}
 						label="Directories"
-						note={`across ${plural(shape.commits, 'commit')}`}
+						note={plural(shape.commits, 'commit')}
 					/>
 					<Stat
 						value={percent(shape.concentration)}
-						label="In its largest file"
+						label="In one file"
 						note={
 							shape.largestFile && (
 								<FileLink file={shape.largestFile} onOpen={onOpenFile} />
 							)
 						}
+					/>
+					{/* Off the commits, not off the board: who is assigned a ticket
+					    and who actually wrote its code are different questions, and
+					    this is the second one. */}
+					<Stat
+						value={String(shape.authors.length)}
+						label={shape.authors.length === 1 ? 'Author' : 'Authors'}
+						note={shape.authors.join(', ')}
 					/>
 				</div>
 
@@ -214,6 +257,22 @@ export const IssueStats = ({
 					/>
 				</div>
 
+				{/* The ratio again, as a shape: how much of what this ticket wrote
+				    is test. One series against its track — two colours would claim
+				    two things are being compared. */}
+				<ProportionBar
+					value={
+						tests.testLinesAdded + tests.codeLinesAdded === 0
+							? 0
+							: tests.testLinesAdded /
+							  (tests.testLinesAdded + tests.codeLinesAdded)
+					}
+					color={seriesColor(2)}
+					label={`${tests.testLinesAdded} of ${
+						tests.testLinesAdded + tests.codeLinesAdded
+					} added lines are test`}
+				/>
+
 				<Note when={tests.deletedTestFiles.length > 0}>
 					{`${plural(tests.deletedTestFiles.length, 'test file')} deleted: `}
 					{tests.deletedTestFiles.map(file => (
@@ -240,11 +299,21 @@ export const IssueStats = ({
 			</Section>
 
 			<Section title="Languages">
-				{languages.languages.map(language => (
+				<StackedBar
+					segments={languages.languages.map((language, index) => ({
+						label: language.name,
+						value: language.added + language.removed,
+						color: seriesColor(index),
+					}))}
+				/>
+
+				{languages.languages.map((language, index) => (
 					<Row
 						key={language.name}
+						dot={seriesColor(index)}
 						left={language.name}
 						right={percent(language.share)}
+						last={index === languages.languages.length - 1}
 					/>
 				))}
 
@@ -254,7 +323,28 @@ export const IssueStats = ({
 			</Section>
 
 			<Section title="Comments">
-				{comments.byLanguage.map(language => (
+				{/* One bar, for the language the ticket is mostly written in, with
+				    the repository's own share marked on it. A bar per language
+				    turned three true numbers into a wall of stripes, and the
+				    comparison — this change against this codebase — is the only
+				    reading of a comment share worth anything. */}
+				{leadComments && (
+					<ProportionBar
+						value={leadComments.share}
+						color={seriesColor(0)}
+						label={`${percent(leadComments.share)} of the ${
+							leadComments.name
+						} lines this ticket added are comments`}
+						reference={leadComments.repoShare}
+						referenceLabel={
+							leadComments.repoShare === null
+								? undefined
+								: `This repository sits at ${percent(leadComments.repoShare)}`
+						}
+					/>
+				)}
+
+				{comments.byLanguage.map((language, index) => (
 					<Row
 						key={language.name}
 						left={language.name}
@@ -265,6 +355,7 @@ export const IssueStats = ({
 										language.repoShare,
 								  )}`
 						}
+						last={index === comments.byLanguage.length - 1}
 					/>
 				))}
 

--- a/source/gui/client/components/StatBars.tsx
+++ b/source/gui/client/components/StatBars.tsx
@@ -1,0 +1,109 @@
+import {GUI_THEME} from '../lib/gui-theme';
+import {SERIES_REST} from '../lib/issue-stats.style';
+
+// The two bars the Stats tab draws, and the only colour on it.
+//
+// Both are the same 8px mark: thin, rounded at the ends of the whole bar and
+// square where segments meet, with a 2px gap in the panel colour doing the
+// separating rather than a stroke. Neither carries a legend of its own — the
+// rows underneath name every segment and repeat its colour, so identity is
+// never colour alone.
+
+const BAR_HEIGHT = 8;
+const SEGMENT_GAP = 2;
+
+export type BarSegment = {
+	label: string;
+	value: number;
+	color: string;
+};
+
+/** Parts of a whole: one bar, one segment per part, widths summing to 100%. */
+export const StackedBar = ({segments}: {segments: BarSegment[]}) => {
+	const total = segments.reduce((sum, segment) => sum + segment.value, 0);
+	if (total <= 0) return null;
+
+	return (
+		<div
+			style={{
+				display: 'flex',
+				gap: SEGMENT_GAP,
+				height: BAR_HEIGHT,
+				borderRadius: BAR_HEIGHT / 2,
+				overflow: 'hidden',
+				marginTop: 12,
+			}}
+		>
+			{segments.map(segment => (
+				<div
+					key={segment.label}
+					title={`${segment.label} — ${Math.round(
+						(100 * segment.value) / total,
+					)}%`}
+					style={{
+						flexGrow: segment.value,
+						flexBasis: 0,
+						minWidth: 2,
+						background: segment.color,
+					}}
+				/>
+			))}
+		</div>
+	);
+};
+
+/**
+ * One share against its track, with an optional mark where a comparison sits —
+ * the repository's own figure, in the case this exists for. A second colour
+ * would say "two things"; there is one thing here, and a reference line.
+ */
+export const ProportionBar = ({
+	value,
+	color,
+	label,
+	reference,
+	referenceLabel,
+}: {
+	value: number;
+	color: string;
+	label: string;
+	reference?: number | null;
+	referenceLabel?: string;
+}) => (
+	<div
+		title={label}
+		style={{
+			position: 'relative',
+			height: BAR_HEIGHT,
+			borderRadius: BAR_HEIGHT / 2,
+			background: GUI_THEME.tertiary,
+			overflow: 'hidden',
+			marginTop: 12,
+		}}
+	>
+		<div
+			style={{
+				width: `${Math.min(100, Math.max(0, value * 100))}%`,
+				height: '100%',
+				background: color,
+				borderRadius: BAR_HEIGHT / 2,
+			}}
+		/>
+
+		{typeof reference === 'number' && (
+			<div
+				title={referenceLabel}
+				style={{
+					position: 'absolute',
+					top: 0,
+					bottom: 0,
+					// The 2px gap rule again: the marker is a slot cut in the bar,
+					// not a line drawn over it.
+					left: `calc(${Math.min(100, Math.max(0, reference * 100))}% - 1px)`,
+					width: 2,
+					background: SERIES_REST,
+				}}
+			/>
+		)}
+	</div>
+);

--- a/source/gui/client/lib/issue-stats.style.ts
+++ b/source/gui/client/lib/issue-stats.style.ts
@@ -11,10 +11,10 @@ import {GUI_THEME} from './gui-theme';
 
 export const STAT_GRID: React.CSSProperties = {
 	display: 'grid',
-	// Narrow enough that three stats still sit on one row in the panel at its
-	// default width — wrapping one of three onto a line of its own reads as a
-	// mistake rather than as a layout.
-	gridTemplateColumns: 'repeat(auto-fit, minmax(96px, 1fr))',
+	// Narrow enough that four stats still sit on one row in the panel at its
+	// default width — one of four wrapping onto a line of its own reads as a
+	// mistake rather than as a layout. Labels wrap instead, which reads fine.
+	gridTemplateColumns: 'repeat(auto-fit, minmax(82px, 1fr))',
 	gap: 16,
 	marginTop: 14,
 };
@@ -80,3 +80,28 @@ export const shortPath = (path: string): string => {
 
 	return parts.length <= 2 ? path : `…/${parts.slice(-2).join('/')}`;
 };
+
+/**
+ * The categorical series, in fixed order — slot 1 for the biggest share, and
+ * never cycled: a sixth language folds into "Other" rather than reusing a hue.
+ *
+ * Validated against this panel's own surface (#11141b) rather than assumed:
+ * lightness band, chroma floor, adjacent-pair separation under protanopia and
+ * tritanopia, the normal-vision floor, and contrast all pass. The theme's own
+ * accents do not — they sit at one lightness, and #ffd479 against #8ce99a is
+ * ΔE 3.8 under protanopia, which is the same colour to a good many readers.
+ */
+export const SERIES = [
+	'#3987e5',
+	'#d95926',
+	'#199e70',
+	'#c98500',
+	'#d55181',
+] as const;
+
+// Everything past the fifth language, and the unfilled half of a proportion
+// bar. Neutral on purpose: it is the absence of a series, not a series.
+export const SERIES_REST = GUI_THEME.dim2;
+
+export const seriesColor = (index: number): string =>
+	SERIES[index] ?? SERIES_REST;

--- a/source/test/e2e-gui/issue-stats.pw.ts
+++ b/source/test/e2e-gui/issue-stats.pw.ts
@@ -59,6 +59,15 @@ test('the Stats tab measures the ticket own commits', async ({
 		page.getByText('TypeScript', {exact: true}).first(),
 	).toBeVisible();
 
+	// And drawn: the language bar carries a segment per language, each naming
+	// its own share.
+	await expect(page.getByTitle(/^TypeScript — \d+%$/)).toBeVisible();
+
+	// The contributor count comes off the commits, so the seeded repo's own
+	// git author is the one named — never the board's assignees.
+	await expect(page.getByText('Author', {exact: true})).toBeVisible();
+	await expect(page.getByText('e2e', {exact: true})).toBeVisible();
+
 	expect(pageErrors).toEqual([]);
 });
 


### PR DESCRIPTION
`C0PAYXG`, following `AJC8PXB` on the same tab. (Reopened: #259's branch was deleted before it merged, and this is the same commit rebased onto main.)

**Double rules gone.** A row carried a bottom border and the next section a top one, so every boundary was two hairlines — an artifact of the devtools sketch this was built from, not something to copy. The last row in a list now goes without.

**Three bars, one validated palette.** A 100%-stacked bar for the language split, a proportion bar for the test share, and one for the leading language's comment share with the repository's own figure marked on it. 8px marks, 2px gaps in the panel colour rather than strokes, rounded only at the ends of the whole bar.

The palette was validated, not picked: `#3987e5 #d95926 #199e70 #c98500 #d55181` passes the lightness band, chroma floor, adjacent-pair CVD separation under protanopia and tritanopia, the normal-vision floor and contrast, all against this panel's own surface. The theme's own accents fail it — they sit at one lightness, and `#ffd479` against `#8ce99a` is ΔE 3.8 under protanopia, i.e. the same colour to a good many readers. That is the finding `WF435EW` already raised about `EVENT_CATEGORY_COLORS`.

Identity never rests on colour: every segment is repeated as a named row with a dot and a percentage, and each carries its own title attribute.

**Authors, from git.** Distinct commit authors on the ticket, named underneath — off the commits rather than off the board, since who is assigned a ticket and who wrote its code are different questions.

Also: one comment bar instead of one per language, and shorter labels so four stats sit on one row at the panel's default width. The e2e now asserts the language bar is drawn and that the author count comes from git.