### PR TITLE
The colon walks while a command runs

### DIFF
--- a/source/lib/command-line/command-line-sigil.ts
+++ b/source/lib/command-line/command-line-sigil.ts
@@ -1,0 +1,49 @@
+import {CONFIRM_MSG} from './command-validation.js';
+
+// The sigil, while a confirmed command is still running. Two dots — the colon
+// itself — walking the corners of the braille cell: one column wide, so nothing
+// on the line shifts under it, and the same quiet register as the sync badge's
+// drift rather than a spinner competing with the board for attention.
+export const PENDING_FRAMES = ['⠃', '⠆', '⠰', '⠘'] as const;
+
+export const PENDING_FRAME_MS = 120;
+
+// What sits at the head of the command line. A running command animates the
+// colon in place: the line reads as busy without a word being added to it, and
+// idle it is the plain sigil it has always been.
+export const commandLineSigil = ({
+	isPalette,
+	isPending,
+	frame,
+}: {
+	isPalette: boolean;
+	isPending: boolean;
+	frame: number;
+}): string => {
+	if (isPending) {
+		const at =
+			((frame % PENDING_FRAMES.length) + PENDING_FRAMES.length) %
+			PENDING_FRAMES.length;
+
+		return PENDING_FRAMES[at]!;
+	}
+
+	return isPalette ? '?' : ':';
+};
+
+// "<ENTER> to confirm" is an instruction, and once the command is running it is
+// the wrong one — pressing Enter again is exactly what somebody does when a
+// slow command looks like it never landed. Every other message stays put: a
+// failed result arrives while pending is still true, and that one has to show.
+//
+// Matched on rather than compared: the message arrives styled, wrapped in the
+// escape codes `hintDefault` paints it with, so equality against the bare
+// string silently never holds.
+export const commandLineHint = ({
+	infoMessage,
+	isPending,
+}: {
+	infoMessage: string;
+	isPending: boolean;
+}): string =>
+	isPending && infoMessage.includes(CONFIRM_MSG) ? '' : infoMessage;

--- a/source/lib/components/CommandLine.tsx
+++ b/source/lib/components/CommandLine.tsx
@@ -3,6 +3,12 @@ import {Box, Text} from 'ink';
 import React, {useEffect, useMemo, useState} from 'react';
 import {CmdKeyword} from '../command-line/cmd-keywords.js';
 import {CmdValidity, cmdValidity} from '../command-line/cmd-validity.js';
+import {
+	commandLineHint,
+	commandLineSigil,
+	PENDING_FRAMES,
+	PENDING_FRAME_MS,
+} from '../command-line/command-line-sigil.js';
 import {AutoCompletion} from '../command-line/command-auto-complete.js';
 import {Mode, ModeUnion} from '../model/action-map.model.js';
 import {
@@ -174,6 +180,39 @@ export const CommandLine: React.FC<{width: number; mode: ModeUnion}> = ({
 	const isFailureMessage =
 		commandIsPending && validationStatus === cmdValidity.Invalid;
 
+	const hint = commandLineHint({infoMessage, isPending: commandIsPending});
+
+	// Only while something is running, so an idle command line costs no timer.
+	const [pendingFrame, setPendingFrame] = useState(0);
+
+	useEffect(() => {
+		if (!commandIsPending) {
+			setPendingFrame(0);
+			return;
+		}
+
+		const id = setInterval(() => {
+			setPendingFrame(prev => (prev + 1) % PENDING_FRAMES.length);
+		}, PENDING_FRAME_MS);
+
+		return () => {
+			clearInterval(id);
+		};
+	}, [commandIsPending]);
+
+	// Outside the line's own memo: this changes several times a second while a
+	// command runs, and re-styling every character for it would be work for a
+	// single column. It also picks up `mode`, which the memo reads without
+	// listing.
+	// Outside the line's own memo: this changes several times a second while a
+	// command runs, and re-styling every character for it would be work for a
+	// single column.
+	const sigil = commandLineSigil({
+		isPalette: mode === Mode.PALETTE,
+		isPending: commandIsPending,
+		frame: pendingFrame,
+	});
+
 	const fullLine = useMemo(() => {
 		const safeCursor = Math.max(0, Math.min(cursorPosition, value.length));
 		const commandRange = getCommandRange({value, command});
@@ -232,12 +271,7 @@ export const CommandLine: React.FC<{width: number; mode: ModeUnion}> = ({
 			renderedAfter = GRAY(autoCompletion.remainder.slice(1) + afterCursor);
 		}
 
-		return (
-			GRAY(mode === Mode.PALETTE ? '?' : ':') +
-			renderedBefore +
-			renderedCursor +
-			renderedAfter
-		);
+		return renderedBefore + renderedCursor + renderedAfter;
 	}, [value, cursorPosition, autoCompletion, command, modifier]);
 	return (
 		<Box flexDirection="column" justifyContent="flex-start">
@@ -249,13 +283,16 @@ export const CommandLine: React.FC<{width: number; mode: ModeUnion}> = ({
 				width={width}
 			>
 				<Box>
-					<Text>{fullLine}</Text>
-					{infoMessage && (
+					<Text>
+						{GRAY(sigil)}
+						{fullLine}
+					</Text>
+					{hint && (
 						<Text
 							wrap="truncate"
 							color={isFailureMessage ? theme.red : theme.secondary2}
 						>
-							{` ${infoMessage} `}
+							{` ${hint} `}
 						</Text>
 					)}
 				</Box>

--- a/source/test/command-line-sigil.test.ts
+++ b/source/test/command-line-sigil.test.ts
@@ -1,0 +1,73 @@
+import {describe, expect, it} from 'vitest';
+import {CONFIRM_MSG} from '../lib/command-line/command-validation.js';
+import {
+	commandLineHint,
+	commandLineSigil,
+	PENDING_FRAMES,
+} from '../lib/command-line/command-line-sigil.js';
+
+const sigil = (isPending: boolean, frame = 0, isPalette = false) =>
+	commandLineSigil({isPalette, isPending, frame});
+
+describe('the command line sigil', () => {
+	it('is the plain colon, or the palette mark, while nothing is running', () => {
+		expect(sigil(false)).toBe(':');
+		expect(sigil(false, 0, true)).toBe('?');
+	});
+
+	// The whole point: a running command has to look different from one that was
+	// typed and never submitted, or the reader presses Enter again.
+	it('is never the idle sigil while a command is running', () => {
+		for (let frame = 0; frame < PENDING_FRAMES.length * 3; frame++) {
+			expect(sigil(true, frame)).not.toBe(':');
+			expect(sigil(true, frame, true)).not.toBe('?');
+		}
+	});
+
+	it('walks every frame and comes back round', () => {
+		const walked = PENDING_FRAMES.map((_, frame) => sigil(true, frame));
+
+		expect(walked).toEqual([...PENDING_FRAMES]);
+		expect(sigil(true, PENDING_FRAMES.length)).toBe(PENDING_FRAMES[0]);
+	});
+
+	// One column, so the line cannot shift under it as it animates.
+	it('is one character wide, whatever it says', () => {
+		for (const frame of [0, 1, 2, 3]) {
+			expect([...sigil(true, frame)]).toHaveLength(1);
+		}
+		expect([...sigil(false)]).toHaveLength(1);
+	});
+});
+
+describe('the command line hint', () => {
+	// As it actually arrives: `hintDefault` paints it, so the string carries the
+	// dim escape codes around it and never equals the bare constant.
+	const styled = `\u001b[2m${CONFIRM_MSG}\u001b[22m`;
+
+	it('drops the confirm instruction once the command is running', () => {
+		expect(commandLineHint({infoMessage: CONFIRM_MSG, isPending: true})).toBe(
+			'',
+		);
+		expect(commandLineHint({infoMessage: CONFIRM_MSG, isPending: false})).toBe(
+			CONFIRM_MSG,
+		);
+	});
+
+	it('drops it however it was styled on the way in', () => {
+		expect(commandLineHint({infoMessage: styled, isPending: true})).toBe('');
+		expect(commandLineHint({infoMessage: styled, isPending: false})).toBe(
+			styled,
+		);
+	});
+
+	// A failed result arrives while pending is still true, and it is the one
+	// thing the reader needs.
+	it('keeps every other message, pending or not', () => {
+		for (const isPending of [true, false]) {
+			expect(commandLineHint({infoMessage: 'Command failed', isPending})).toBe(
+				'Command failed',
+			);
+		}
+	});
+});


### PR DESCRIPTION
`D7CF45S`. A confirmed command sets `commandIsPending`, awaits its action, and clears the line only once that resolves — so for the whole run the command line shows the composed text under `<ENTER> to confirm`, exactly what it shows before Enter is pressed at all. Nothing said it was running.

```
idle      : init  <ENTER> to confirm
running   ⠃init     ⠆init     ⠰init     ⠘init
```

Two braille dots — the colon itself — walking the corners of one cell at 120ms. Same quiet register as the sync badge, which already drifts a single braille dot, rather than a spinner competing with the board. One column wide, so nothing on the line shifts under it, and the timer exists only while something is pending.

The confirm hint goes while the command runs. It is an instruction, and once the command is away it is the wrong one — pressing Enter again is what the missing feedback provokes. Every other message stays: a failure arrives while pending is still true, and that one has to show.

The decision is a pure function with its own test, the way `inline-editor-layout` is tested, rather than something only reachable by rendering the component.

## Worth knowing

The first cut had six green unit tests and was still visibly broken. It compared `infoMessage === CONFIRM_MSG`, but `hintDefault` paints the message, so it arrives wrapped in dim escape codes and the comparison never held. Driving the real TUI through a pty — with a temporary delay to widen the pending window — is what showed it. The helper matches on the message now, and the test feeds it the styled form.

## Checks

The full pre-push gate: typecheck, lint, prettier, 1308 unit tests, the container e2e and collaboration suites, and the browser suite.
