### PR TITLE
Comments are the part worth reading: yellow in the diff, and on the stats bar

### DIFF
--- a/source/gui/client/components/CodeSnippet.tsx
+++ b/source/gui/client/components/CodeSnippet.tsx
@@ -9,12 +9,13 @@ import {
 import {CopyShaButton} from './CopyShaButton';
 import {IconChevronDown} from './IconChevronDown';
 import {IconChevronRight} from './IconChevronRight';
+import {EPIQ_DIFF_THEME} from '../lib/diff-theme';
 
 // The same highlighter and theme the diff view itself renders with, so a
 // snippet quoted into a comment looks like the code it was taken from rather
 // than like markdown text. `name` is what infers the language, which is why
 // the quoting side keeps the real file path around.
-const PIERRE_THEME = 'github-dark';
+const PIERRE_THEME = EPIQ_DIFF_THEME;
 
 // The theme's own background is a near match for the comment card the
 // snippet sits in; the app's darker one keeps the two apart. The theme sets

--- a/source/gui/client/components/DiffPanel.tsx
+++ b/source/gui/client/components/DiffPanel.tsx
@@ -18,10 +18,12 @@ import {FormHeader} from './FormHeader';
 import {FullscreenToggleButton} from './FullscreenToggleButton';
 import {PanelDockMenu} from './PanelDockMenu';
 import {AsideDock} from '../lib/aside-dock';
+import {EPIQ_DIFF_THEME} from '../lib/diff-theme';
 
 // A single dark theme: the app has no light mode to match (GUI_THEME is a
-// fixed dark palette), so there is no pair to switch between.
-const PIERRE_THEME = 'github-dark';
+// fixed dark palette), so there is no pair to switch between. github-dark with
+// its comments brought forward — see lib/diff-theme.
+const PIERRE_THEME = EPIQ_DIFF_THEME;
 
 // Independently-nullable before/after strings don't structurally match
 // DiffFileInput's three-branch union (it forbids "both null"), so this picks

--- a/source/gui/client/components/IssueStats.tsx
+++ b/source/gui/client/components/IssueStats.tsx
@@ -190,7 +190,7 @@ export const IssueStats = ({
 
 	return (
 		<div style={{fontSize: TEXT.ui}}>
-			<Section title="The change" first>
+			<Section title="Code" first>
 				<div style={STAT_GRID}>
 					<Stat
 						value={String(shape.files)}
@@ -242,13 +242,21 @@ export const IssueStats = ({
 			<Section title="Tests">
 				<div style={STAT_GRID}>
 					<Stat
-						value={tests.ratio === null ? '—' : tests.ratio.toFixed(2)}
-						label="Test lines per code line"
-						note={`${tests.testLinesAdded} test, ${tests.codeLinesAdded} code`}
+						value={String(tests.testLinesAdded)}
+						label="Test lines added"
+						note={
+							tests.addedTestFiles.length > 0
+								? plural(tests.addedTestFiles.length, 'new file')
+								: 'in files that already existed'
+						}
 					/>
 					<Stat
 						value={String(tests.addedTestFiles.length)}
-						label="Test files added"
+						label={
+							tests.addedTestFiles.length === 1
+								? 'Test file added'
+								: 'Test files added'
+						}
 						note={tests.addedTestFiles.slice(0, 3).map(file => (
 							<div key={file.path}>
 								<FileLink file={file} onOpen={onOpenFile} />
@@ -256,22 +264,6 @@ export const IssueStats = ({
 						))}
 					/>
 				</div>
-
-				{/* The ratio again, as a shape: how much of what this ticket wrote
-				    is test. One series against its track — two colours would claim
-				    two things are being compared. */}
-				<ProportionBar
-					value={
-						tests.testLinesAdded + tests.codeLinesAdded === 0
-							? 0
-							: tests.testLinesAdded /
-							  (tests.testLinesAdded + tests.codeLinesAdded)
-					}
-					color={seriesColor(2)}
-					label={`${tests.testLinesAdded} of ${
-						tests.testLinesAdded + tests.codeLinesAdded
-					} added lines are test`}
-				/>
 
 				<Note when={tests.deletedTestFiles.length > 0}>
 					{`${plural(tests.deletedTestFiles.length, 'test file')} deleted: `}
@@ -331,7 +323,11 @@ export const IssueStats = ({
 				{leadComments && (
 					<ProportionBar
 						value={leadComments.share}
-						color={seriesColor(0)}
+						// Yellow for the prose, blue for the code it explains — the
+						// same yellow the diff itself now gives a comment, so the bar
+						// and the file agree about which is which.
+						color={seriesColor(3)}
+						restColor={seriesColor(0)}
 						label={`${percent(leadComments.share)} of the ${
 							leadComments.name
 						} lines this ticket added are comments`}

--- a/source/gui/client/components/StatBars.tsx
+++ b/source/gui/client/components/StatBars.tsx
@@ -1,5 +1,4 @@
 import {GUI_THEME} from '../lib/gui-theme';
-import {SERIES_REST} from '../lib/issue-stats.style';
 
 // The two bars the Stats tab draws, and the only colour on it.
 //
@@ -53,19 +52,24 @@ export const StackedBar = ({segments}: {segments: BarSegment[]}) => {
 };
 
 /**
- * One share against its track, with an optional mark where a comparison sits —
- * the repository's own figure, in the case this exists for. A second colour
- * would say "two things"; there is one thing here, and a reference line.
+ * A part against the whole it is part of: the filled share in one colour, what
+ * is left in another, and an optional mark where a comparison sits — the
+ * repository's own figure, in the case this exists for.
+ *
+ * The mark is a slot cut through the bar in the panel's own colour rather than
+ * a line drawn over it, so it reads the same whichever segment it lands in.
  */
 export const ProportionBar = ({
 	value,
 	color,
+	restColor = GUI_THEME.tertiary,
 	label,
 	reference,
 	referenceLabel,
 }: {
 	value: number;
 	color: string;
+	restColor?: string;
 	label: string;
 	reference?: number | null;
 	referenceLabel?: string;
@@ -76,7 +80,7 @@ export const ProportionBar = ({
 			position: 'relative',
 			height: BAR_HEIGHT,
 			borderRadius: BAR_HEIGHT / 2,
-			background: GUI_THEME.tertiary,
+			background: restColor,
 			overflow: 'hidden',
 			marginTop: 12,
 		}}
@@ -97,11 +101,9 @@ export const ProportionBar = ({
 					position: 'absolute',
 					top: 0,
 					bottom: 0,
-					// The 2px gap rule again: the marker is a slot cut in the bar,
-					// not a line drawn over it.
 					left: `calc(${Math.min(100, Math.max(0, reference * 100))}% - 1px)`,
 					width: 2,
-					background: SERIES_REST,
+					background: GUI_THEME.panel,
 				}}
 			/>
 		)}

--- a/source/gui/client/lib/diff-theme.ts
+++ b/source/gui/client/lib/diff-theme.ts
@@ -1,0 +1,67 @@
+// The diff's syntax theme: github-dark, with one thing changed.
+//
+// Every editor theme there is paints comments grey and recedes them, on the
+// premise that they are not the code. That is exactly backwards for reading
+// somebody else's change: a comment is the only part of a diff that says *why*,
+// and it is the part a reviewer most wants to find. So comments come forward in
+// the same yellow the Stats tab uses for them — if a line is worth writing in
+// prose, it is worth reading.
+
+import {registerCustomTheme, resolveTheme} from '@pierre/diffs';
+
+const BASE_THEME = 'github-dark';
+
+export const EPIQ_DIFF_THEME = 'epiq-dark';
+
+// The Stats tab's comment share wears this too, so the bar and the file agree
+// about which half is prose.
+export const COMMENT_COLOR = '#ffd479';
+
+// A tmTheme rule's scope is one selector or a list of them, and a comment is
+// scoped `comment` or `comment.line…`/`comment.block…` depending on the
+// grammar. Matching the prefix catches every shape without catching, say,
+// `constant`.
+const isCommentScope = (scope: string | string[] | undefined): boolean =>
+	(Array.isArray(scope) ? scope : [scope ?? '']).some(
+		selector =>
+			selector === 'comment' ||
+			selector.startsWith('comment.') ||
+			selector.startsWith('comment '),
+	);
+
+let registered = false;
+
+/**
+ * Idempotent, and called for its side effect: the highlighter resolves a theme
+ * by name, so the name has to be known before the first diff renders. Both
+ * call sites (the ticket's Commits tab and the scrubber's own diff panel) call
+ * this at module load.
+ */
+export const registerEpiqDiffTheme = (): void => {
+	if (registered) return;
+	registered = true;
+
+	registerCustomTheme(EPIQ_DIFF_THEME, async () => {
+		const base = await resolveTheme(BASE_THEME);
+
+		return {
+			...base,
+			name: EPIQ_DIFF_THEME,
+			settings: base.settings.map(setting =>
+				isCommentScope(setting.scope)
+					? {
+							...setting,
+							settings: {
+								...setting.settings,
+								foreground: COMMENT_COLOR,
+								// github-dark leaves comments upright; italics on top of
+								// the colour would be shouting twice.
+							},
+					  }
+					: setting,
+			),
+		};
+	});
+};
+
+registerEpiqDiffTheme();

--- a/source/lib/stats/issue-stats.model.ts
+++ b/source/lib/stats/issue-stats.model.ts
@@ -77,14 +77,11 @@ export type LanguageBreakdown = {
 };
 
 export type TestSignal = {
+	// Lines, not a ratio against the code beside them: test-lines-per-code-line
+	// says more about how a language is written than about whether a change is
+	// tested, and a number nobody can act on is a number in the way.
 	testLinesAdded: number;
 	testLinesRemoved: number;
-	codeLinesAdded: number;
-	// Null when the ticket added no code lines at all: dividing by nothing
-	// would print Infinity for a tests-only ticket, which is exactly the case
-	// somebody would misread as the best score on the board.
-	ratio: number | null;
-	touchedTests: boolean;
 
 	// The test files this ticket added, so the count links to the tests
 	// themselves rather than only asserting they exist.

--- a/source/lib/stats/test-signal.ts
+++ b/source/lib/stats/test-signal.ts
@@ -19,22 +19,16 @@ import {TicketPatch} from './patch-scan.js';
 export const deriveTestSignal = ({patch}: {patch: TicketPatch}): TestSignal => {
 	let testLinesAdded = 0;
 	let testLinesRemoved = 0;
-	let codeLinesAdded = 0;
 	const addedTestFiles: FilePointer[] = [];
 	const deletedTestFiles: FilePointer[] = [];
 	let skippedTestLinesAdded = 0;
 	let focusedTestLinesAdded = 0;
-	let touchedTests = false;
 
 	for (const file of patch.files) {
 		if (file.binary || isGeneratedPath(file.path)) continue;
 
-		if (!isTestPath(file.path)) {
-			codeLinesAdded += file.addedCount;
-			continue;
-		}
+		if (!isTestPath(file.path)) continue;
 
-		touchedTests = true;
 		testLinesAdded += file.addedCount;
 		testLinesRemoved += file.removed;
 		if (file.status === 'added') addedTestFiles.push(filePointer(file));
@@ -49,9 +43,6 @@ export const deriveTestSignal = ({patch}: {patch: TicketPatch}): TestSignal => {
 	return {
 		testLinesAdded,
 		testLinesRemoved,
-		codeLinesAdded,
-		ratio: codeLinesAdded === 0 ? null : testLinesAdded / codeLinesAdded,
-		touchedTests,
 		addedTestFiles,
 		deletedTestFiles,
 		skippedTestLinesAdded,

--- a/source/test/e2e-gui/issue-stats.pw.ts
+++ b/source/test/e2e-gui/issue-stats.pw.ts
@@ -50,8 +50,8 @@ test('the Stats tab measures the ticket own commits', async ({
 	await expect(page.getByText('Directories', {exact: true})).toBeVisible();
 
 	// The test signal: one test line per code line, and one test file added.
-	await expect(page.getByText('Test lines per code line')).toBeVisible();
-	await expect(page.getByText('Test files added')).toBeVisible();
+	await expect(page.getByText('Test lines added')).toBeVisible();
+	await expect(page.getByText('Test file added')).toBeVisible();
 
 	// Named twice on the page — once for its share of the change, once for its
 	// comment share — so this is the first, not the only.

--- a/source/test/stats-languages.test.ts
+++ b/source/test/stats-languages.test.ts
@@ -124,7 +124,7 @@ describe('deriveLanguages', () => {
 });
 
 describe('deriveTestSignal', () => {
-	it('reports the ratio of test lines to code lines', () => {
+	it('counts the test lines and leaves the code beside them alone', () => {
 		const signal = deriveTestSignal({
 			patch: patchOf(
 				[
@@ -134,18 +134,23 @@ describe('deriveTestSignal', () => {
 			),
 		});
 
-		expect(signal.codeLinesAdded).toBe(2);
 		expect(signal.testLinesAdded).toBe(1);
-		expect(signal.ratio).toBeCloseTo(0.5);
-		expect(signal.touchedTests).toBe(true);
 	});
 
-	it('gives no ratio at all for a ticket that added no code lines', () => {
+	it('counts test lines added to a file that already existed', () => {
 		const signal = deriveTestSignal({
-			patch: patchOf(file('source/test/app.test.ts', ['expect(a).toBe(1);'])),
+			patch: patchOf(
+				file('source/test/app.test.ts', [
+					'expect(a).toBe(1);',
+					'expect(b).toBe(2);',
+				]),
+			),
 		});
 
-		expect(signal.ratio).toBeNull();
+		// No new test file, which is not the same as no new tests — the reason
+		// the count is lines rather than files.
+		expect(signal.addedTestFiles).toEqual([]);
+		expect(signal.testLinesAdded).toBe(2);
 	});
 
 	it('counts deleted test files and removed test lines', () => {


### PR DESCRIPTION
`P6MWRDM`. Two halves of one idea, plus a stat that had to go.

**The diff paints comments bright yellow.** Every editor theme greys them out, on the premise that a comment is not the code. That is backwards for reading somebody else's change: the comment is the only part of a diff that says *why*, and it is what a reviewer most wants to find. `lib/diff-theme.ts` registers github-dark with every `comment*` scope repainted `#ffd479`, and both the Commits tab and quoted snippets use it — so a snippet still looks like the file it came from.

**The Stats tab's comment bar wears the same yellow**, with the code it explains in blue, so the bar and the file agree about which half is prose. The pair validates on this panel's surface (ΔE 27.4 protan, 30.7 normal vision), and the repo-baseline mark is now a slot cut through the bar in the panel colour rather than a grey line that disappeared against blue.

**Test lines per code line is gone**, and the green bar with it. It says more about how a language is written than about whether a change is tested. What replaces it is test *lines* added — which also fixes a case the ratio hid: a ticket adding forty lines to an existing test file used to read as "0 test files added".

Also: "The change" is now "Code".