### PR TITLE
XDWJY08 a command registry for the GUI, and a palette over it that remembers what you ran

### DIFF
--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -44,6 +44,10 @@ import {TimeScrubber} from './components/TimeScrubber';
 import {TheatrePlayer} from './components/TheatrePlayer';
 import {EventLog} from './components/EventLog';
 import {useAsideDock} from './lib/aside-dock';
+import {CommandPalette} from './components/CommandPalette';
+import {buildCommandRegistry} from './lib/commands/command-registry';
+import {useRecentCommands} from './lib/commands/command-recents';
+import {useCommandPalette} from './lib/use-command-palette';
 import {moveIssue} from './lib/gui-move-issue';
 import {moveSwimlane} from './lib/gui-move-swimlane';
 import {DropTarget} from './lib/gui-result.model';
@@ -1135,6 +1139,44 @@ export const App = () => {
 		confirmDeleteSwimlane,
 	} = useSwimlaneEditing({send, setState, selectedBoard, visibleSwimlanes});
 
+	const commandPalette = useCommandPalette();
+	const recentCommands = useRecentCommands();
+	const commands = useMemo(() => buildCommandRegistry(), []);
+
+	// Rebuilt each render rather than memoized: it reads most of the board, so
+	// the dependency list would be the thing to get wrong, and the commands only
+	// read it when the palette is open.
+	const commandContext = {
+		connected,
+		scrubbing: state?.timeTravel?.mode === 'scrub',
+		issue: selectedIssue,
+		tags: state?.tags ?? [],
+		contributors,
+		handlers: {
+			// The palette has no column in hand, so a ticket goes to the first one
+			// — the same place the board's own + button starts from.
+			createIssue: () => {
+				const swimlaneId = visibleSwimlanes[0]?.id;
+				if (swimlaneId) setCreateIssueModal({swimlaneId, title: ''});
+			},
+			createSwimlane: () => setCreateSwimlaneTitle(''),
+			closeIssue,
+			reopenIssue,
+			addIssueTag,
+			removeIssueTag,
+			addIssueAssignee,
+			removeIssueAssignee,
+			// Opens the thread rather than posting: what to say is the point, and
+			// the palette has nowhere to say it.
+			commentOnIssue: (id: string) => openIssueTab(id, 'comments'),
+			copyRef: (ref: string) => void navigator.clipboard?.writeText(ref),
+			sync: () => send('sync', {}),
+			startTheatre,
+			returnToLive,
+			toggleLog: () => setLogOpen(!logOpen),
+		},
+	};
+
 	// A dead socket cannot carry a mutation, so the board wears the same
 	// readonly it wears mid-scrub — every existing guard keys off this, so the
 	// kebabs, the + buttons, dragging and the editors all stand down together.
@@ -1777,6 +1819,16 @@ export const App = () => {
 						onChangeTitle={setCreateSwimlaneTitle}
 						onCreate={createSwimlane}
 						onClose={() => setCreateSwimlaneTitle(null)}
+					/>
+				)}
+
+				{commandPalette.open && (
+					<CommandPalette
+						commands={commands}
+						context={commandContext}
+						recentIds={recentCommands.ids}
+						onRun={command => recentCommands.remember(command.id)}
+						onClose={() => commandPalette.setOpen(false)}
 					/>
 				)}
 			</div>

--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -810,14 +810,19 @@ export const App = () => {
 	// Opening a ticket at a named tab, as against `selectIssue`, which carries
 	// whichever tab is already open. Used wherever the thing being followed says
 	// which view it belongs in — a comment reference, a log line.
-	const openIssueTab = (nextIssueId: string, tab: IssueDetailsTab) => {
-		if (!boardSlug) return;
+	// `board` names which one to open it on, for the project-wide search, whose
+	// hit need not be on the board being looked at. Everything else means the
+	// one already on screen.
+	const openIssueTab = (
+		nextIssueId: string,
+		tab: IssueDetailsTab,
+		board = boardSlug,
+	) => {
+		if (!board) return;
 
 		setCommitDiff(null);
 
-		void navigate(
-			`/board/${boardSlug}/issue/${nodeRef(nextIssueId)}?tab=${tab}`,
-		);
+		void navigate(`/board/${board}/issue/${nodeRef(nextIssueId)}?tab=${tab}`);
 	};
 
 	const selectIssueComments = (nextIssueId: string) =>
@@ -1139,6 +1144,24 @@ export const App = () => {
 		confirmDeleteSwimlane,
 	} = useSwimlaneEditing({send, setState, selectedBoard, visibleSwimlanes});
 
+	// Flattened once per state change rather than per keystroke: the palette
+	// matches over this on every character typed into its second step.
+	const searchableTickets = useMemo(
+		() =>
+			(state?.boards ?? []).flatMap(board =>
+				board.swimlanes.flatMap(swimlane =>
+					swimlane.issues.map(issue => ({
+						id: issue.id,
+						ref: issue.ref,
+						title: issue.title,
+						boardTitle: board.title,
+						boardRef: board.ref,
+					})),
+				),
+			),
+		[state],
+	);
+
 	const commandPalette = useCommandPalette();
 	const recentCommands = useRecentCommands();
 	const commands = useMemo(() => buildCommandRegistry(), []);
@@ -1151,6 +1174,7 @@ export const App = () => {
 		scrubbing: state?.timeTravel?.mode === 'scrub',
 		issue: selectedIssue,
 		tags: state?.tags ?? [],
+		tickets: searchableTickets,
 		contributors,
 		handlers: {
 			// The palette has no column in hand, so a ticket goes to the first one
@@ -1160,6 +1184,8 @@ export const App = () => {
 				if (swimlaneId) setCreateIssueModal({swimlaneId, title: ''});
 			},
 			createSwimlane: () => setCreateSwimlaneTitle(''),
+			openIssue: (id: string, boardRef: string) =>
+				openIssueTab(id, 'overview', boardRef),
 			closeIssue,
 			reopenIssue,
 			addIssueTag,
@@ -1322,6 +1348,7 @@ export const App = () => {
 						onReconnect={reconnectNow}
 						scrubbing={state?.timeTravel?.mode === 'scrub'}
 						syncStatus={syncStatus}
+						onOpenCommands={() => commandPalette.setOpen(true)}
 					/>
 				</div>
 

--- a/source/gui/client/components/CommandPalette.tsx
+++ b/source/gui/client/components/CommandPalette.tsx
@@ -16,6 +16,12 @@ type ArgumentStep = {command: GuiCommand; options: CommandArgument[]};
 
 const MAX_ROWS = 8;
 
+// How many rows are ever built. The list scrolls eight at a time and a project
+// can hold thousands of tickets: rendering every match would put thousands of
+// nodes behind a window showing eight of them, which is the difference between
+// a palette that opens instantly and one that stutters on every keystroke.
+const MAX_MATCHES = 50;
+
 export const CommandPalette = ({
 	commands,
 	context,
@@ -37,12 +43,32 @@ export const CommandPalette = ({
 	const inputRef = useRef<HTMLInputElement>(null);
 	const listRef = useRef<HTMLDivElement>(null);
 
-	const rank = useMemo(() => commandRank(context), [context]);
+	// Deliberately two memos rather than one over both cases.
+	//
+	// The command list is short and its ranking reads the whole context, which
+	// is rebuilt on every board broadcast — so it recomputes constantly, and at
+	// fifteen items that costs nothing.
+	//
+	// The argument list is the opposite: a project-wide search can hold
+	// thousands of tickets, and its options were captured when the step opened.
+	// Keyed on the step and the query alone, it re-ranks when somebody types and
+	// not when a ticket moves on the board behind the palette.
+	const commandMatches = useMemo(
+		() =>
+			step
+				? []
+				: matchItems(commands, query, {
+						recentIds,
+						rank: commandRank(context),
+						limit: MAX_MATCHES,
+				  }),
+		[step, query, commands, recentIds, context],
+	);
 
-	const matches = useMemo(() => {
-		if (!step) return matchItems(commands, query, {recentIds, rank});
+	const argumentMatches = useMemo(() => {
+		if (!step) return [];
 
-		const found = matchItems(step.options, query);
+		const found = matchItems(step.options, query, {limit: MAX_MATCHES});
 
 		// A name that is not on the list yet, offered last so it never displaces
 		// an existing one under a finger already reaching for Enter.
@@ -54,7 +80,15 @@ export const CommandPalette = ({
 		return fresh && !exists
 			? [...found, {item: {...fresh, hint: 'new'}, hits: [], score: 0}]
 			: found;
-	}, [step, query, commands, recentIds, rank]);
+	}, [step, query]);
+
+	const matches = step ? argumentMatches : commandMatches;
+
+	// Said without a number: the matcher returns the capped list, so the count
+	// of what it cut is not known here — and "N more" built from the options it
+	// started with would count every ticket that did not match, which is not
+	// what a reader would take it to mean.
+	const capped = matches.length >= MAX_MATCHES;
 
 	// Whatever the query does to the list, the highlight belongs on a row that
 	// is in it.
@@ -245,6 +279,18 @@ export const CommandPalette = ({
 							/>
 						);
 					})}
+
+					{capped && (
+						<div
+							style={{
+								padding: '6px 12px',
+								fontSize: TEXT.label,
+								color: GUI_THEME.dim,
+							}}
+						>
+							More matches — keep typing to narrow
+						</div>
+					)}
 				</div>
 			</div>
 		</div>

--- a/source/gui/client/components/CommandPalette.tsx
+++ b/source/gui/client/components/CommandPalette.tsx
@@ -1,0 +1,252 @@
+import {useEffect, useMemo, useRef, useState} from 'react';
+import {GUI_THEME, TEXT} from '../lib/gui-theme';
+import {matchItems} from '../lib/commands/command-match';
+import {commandRank} from '../lib/commands/command-registry';
+import {
+	CommandArgument,
+	CommandContext,
+	GuiCommand,
+} from '../lib/commands/command.model';
+import {CommandPaletteRow} from './CommandPaletteRow';
+
+// The second step of a two-stage command: which command it is for, and what it
+// offered. Held rather than recomputed, so a board update mid-choice cannot
+// swap the list under the pointer.
+type ArgumentStep = {command: GuiCommand; options: CommandArgument[]};
+
+const MAX_ROWS = 8;
+
+export const CommandPalette = ({
+	commands,
+	context,
+	recentIds,
+	onRun,
+	onClose,
+}: {
+	commands: GuiCommand[];
+	context: CommandContext;
+	recentIds: readonly string[];
+	// Told what ran, so the caller can remember it. Fired for the command, not
+	// for the argument: what you reach for again is "add a tag", not "add gui".
+	onRun: (command: GuiCommand) => void;
+	onClose: () => void;
+}) => {
+	const [query, setQuery] = useState('');
+	const [step, setStep] = useState<ArgumentStep | null>(null);
+	const [selected, setSelected] = useState(0);
+	const inputRef = useRef<HTMLInputElement>(null);
+	const listRef = useRef<HTMLDivElement>(null);
+
+	const rank = useMemo(() => commandRank(context), [context]);
+
+	const matches = useMemo(() => {
+		if (!step) return matchItems(commands, query, {recentIds, rank});
+
+		const found = matchItems(step.options, query);
+
+		// A name that is not on the list yet, offered last so it never displaces
+		// an existing one under a finger already reaching for Enter.
+		const fresh = step.command.freeTextArgument?.(query);
+		const exists = found.some(
+			match => match.item.title.toLowerCase() === query.trim().toLowerCase(),
+		);
+
+		return fresh && !exists
+			? [...found, {item: {...fresh, hint: 'new'}, hits: [], score: 0}]
+			: found;
+	}, [step, query, commands, recentIds, rank]);
+
+	// Whatever the query does to the list, the highlight belongs on a row that
+	// is in it.
+	useEffect(() => {
+		setSelected(0);
+	}, [query, step]);
+
+	useEffect(() => {
+		inputRef.current?.focus();
+	}, [step]);
+
+	// Keeps the highlighted row on screen when it is moved by the keyboard,
+	// which is the only way it can leave the visible window.
+	useEffect(() => {
+		listRef.current?.children[selected]?.scrollIntoView({block: 'nearest'});
+	}, [selected]);
+
+	const runMatch = (index: number) => {
+		const match = matches[index];
+		if (!match) return;
+
+		if (step) {
+			step.command.run(context, match.item as CommandArgument);
+			onRun(step.command);
+			onClose();
+			return;
+		}
+
+		const command = match.item as GuiCommand;
+		if (command.unavailable(context)) return;
+
+		// A command that takes an argument opens its list rather than firing:
+		// the palette stays open and becomes the second step.
+		const options = command.getArguments?.(context);
+		if (options) {
+			setStep({command, options});
+			setQuery('');
+			return;
+		}
+
+		command.run(context);
+		onRun(command);
+		onClose();
+	};
+
+	const onKeyDown = (event: React.KeyboardEvent) => {
+		if (event.key === 'Escape') {
+			event.preventDefault();
+			// Out of the argument list first, out of the palette second — Escape
+			// undoes one step at a time.
+			return step ? setStep(null) : onClose();
+		}
+
+		if (event.key === 'ArrowDown' || (event.key === 'n' && event.ctrlKey)) {
+			event.preventDefault();
+			return setSelected(current => Math.min(current + 1, matches.length - 1));
+		}
+
+		if (event.key === 'ArrowUp' || (event.key === 'p' && event.ctrlKey)) {
+			event.preventDefault();
+			return setSelected(current => Math.max(current - 1, 0));
+		}
+
+		if (event.key === 'Enter') {
+			event.preventDefault();
+			return runMatch(selected);
+		}
+
+		// Backspace on an empty query leaves the argument list, so the way back
+		// is where a reader's finger already is.
+		if (event.key === 'Backspace' && step && query === '') {
+			event.preventDefault();
+			return setStep(null);
+		}
+	};
+
+	return (
+		<div
+			data-testid="command-palette"
+			style={{
+				position: 'fixed',
+				inset: 0,
+				background: 'rgba(0, 0, 0, 0.35)',
+				backdropFilter: 'blur(1px)',
+				display: 'flex',
+				alignItems: 'flex-start',
+				justifyContent: 'center',
+				// Below the top edge rather than centred: the list grows downward,
+				// and a centred box jumps as it does.
+				paddingTop: '12vh',
+				zIndex: 1100,
+			}}
+			onMouseDown={onClose}
+		>
+			<div
+				onMouseDown={event => event.stopPropagation()}
+				onKeyDown={onKeyDown}
+				style={{
+					width: 'min(560px, calc(100vw - 32px))',
+					background: GUI_THEME.panel,
+					border: `1px solid ${GUI_THEME.edge}`,
+					borderRadius: 8,
+					boxShadow: '0 16px 48px rgba(0, 0, 0, 0.55)',
+					overflow: 'hidden',
+				}}
+			>
+				<div
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+						gap: 8,
+						padding: '10px 12px',
+						borderBottom: `1px solid ${GUI_THEME.line}`,
+					}}
+				>
+					{step && (
+						<span
+							style={{
+								fontSize: TEXT.label,
+								color: GUI_THEME.accent,
+								border: `1px solid ${GUI_THEME.line}`,
+								borderRadius: 4,
+								padding: '2px 6px',
+								flexShrink: 0,
+							}}
+						>
+							{step.command.title}
+						</span>
+					)}
+
+					<input
+						ref={inputRef}
+						autoFocus
+						value={query}
+						onChange={event => setQuery(event.target.value)}
+						placeholder={step ? 'Pick one…' : 'Type a command…'}
+						aria-label="Command palette"
+						style={{
+							flex: 1,
+							background: 'transparent',
+							border: 'none',
+							outline: 'none',
+							color: GUI_THEME.primary,
+							fontSize: TEXT.prose,
+							fontFamily: 'inherit',
+						}}
+					/>
+				</div>
+
+				<div
+					ref={listRef}
+					role="listbox"
+					style={{
+						maxHeight: MAX_ROWS * 34,
+						overflowY: 'auto',
+						padding: '4px 0',
+					}}
+				>
+					{matches.length === 0 && (
+						<div
+							style={{
+								padding: '12px',
+								fontSize: TEXT.ui,
+								color: GUI_THEME.dim,
+							}}
+						>
+							Nothing matches “{query}”
+						</div>
+					)}
+
+					{matches.map((match, index) => {
+						const asCommand = step ? null : (match.item as GuiCommand);
+						const asArgument = step ? (match.item as CommandArgument) : null;
+
+						return (
+							<CommandPaletteRow
+								key={match.item.id}
+								title={asCommand?.title ?? asArgument?.title ?? ''}
+								hits={match.hits}
+								group={asCommand?.group}
+								reason={asCommand?.unavailable(context)}
+								hint={asArgument?.hint}
+								color={asArgument?.color}
+								hasArguments={Boolean(asCommand?.getArguments)}
+								selected={index === selected}
+								onHover={() => setSelected(index)}
+								onRun={() => runMatch(index)}
+							/>
+						);
+					})}
+				</div>
+			</div>
+		</div>
+	);
+};

--- a/source/gui/client/components/CommandPaletteHint.tsx
+++ b/source/gui/client/components/CommandPaletteHint.tsx
@@ -1,0 +1,80 @@
+import {useState} from 'react';
+import {GUI_THEME, TEXT} from '../lib/gui-theme';
+
+// The chord as the platform writes it. A Mac reader shown `Ctrl` reaches for
+// the wrong key, and the pill exists to teach the shortcut — getting it wrong
+// is worse than not showing one.
+const isApple = (): boolean =>
+	typeof navigator !== 'undefined' &&
+	/Mac|iPhone|iPad/.test(navigator.userAgent);
+
+// One key, drawn as a key. Two caps side by side rather than one `⌘K` run: the
+// glyph and the letter are separate presses, and set solid they read as a
+// single strange word.
+const Key = ({children}: {children: string}) => (
+	<kbd
+		style={{
+			display: 'inline-flex',
+			alignItems: 'center',
+			justifyContent: 'center',
+			minWidth: 18,
+			height: 18,
+			padding: '0 4px',
+			boxSizing: 'border-box',
+			borderRadius: 4,
+			background: GUI_THEME.panel2,
+			border: `1px solid ${GUI_THEME.line}`,
+			color: GUI_THEME.secondary,
+			font: 'inherit',
+			fontSize: TEXT.label,
+			lineHeight: 1,
+		}}
+	>
+		{children}
+	</kbd>
+);
+
+/**
+ * The affordance that says the palette exists.
+ *
+ * A shortcut nobody can discover is a shortcut nobody uses, so this sits in the
+ * topbar the way a docs site puts its search chord there. Clickable as well as
+ * readable: the point is to be found by somebody who does not yet know the key.
+ */
+export const CommandPaletteHint = ({onOpen}: {onOpen: () => void}) => {
+	const [hovered, setHovered] = useState(false);
+
+	return (
+		<button
+			type="button"
+			data-testid="command-palette-hint"
+			onClick={onOpen}
+			onMouseEnter={() => setHovered(true)}
+			onMouseLeave={() => setHovered(false)}
+			title="Open the command palette"
+			aria-label="Open the command palette"
+			style={{
+				display: 'inline-flex',
+				alignItems: 'center',
+				gap: 7,
+				// Only the keys wear a box: a bordered pill around bordered caps is
+				// two frames deep for one control.
+				background: hovered ? GUI_THEME.hover : 'transparent',
+				border: 'none',
+				borderRadius: 6,
+				padding: '3px 6px',
+				color: GUI_THEME.dim2,
+				fontSize: TEXT.label,
+				fontFamily: 'inherit',
+				cursor: 'pointer',
+				whiteSpace: 'nowrap',
+			}}
+		>
+			<span style={{display: 'inline-flex', alignItems: 'center', gap: 3}}>
+				<Key>{isApple() ? '⌘' : 'Ctrl'}</Key>
+				<Key>K</Key>
+			</span>
+			commands
+		</button>
+	);
+};

--- a/source/gui/client/components/CommandPaletteRow.tsx
+++ b/source/gui/client/components/CommandPaletteRow.tsx
@@ -1,0 +1,114 @@
+import {GUI_THEME, TEXT} from '../lib/gui-theme';
+
+// The characters the query hit, marked in place. Ranges rather than one span
+// per character, so a run of matched letters underlines as one.
+const Highlighted = ({text, hits}: {text: string; hits: number[]}) => {
+	if (hits.length === 0) return <>{text}</>;
+
+	const marked = new Set(hits);
+
+	return (
+		<>
+			{[...text].map((character, index) =>
+				marked.has(index) ? (
+					<span key={index} style={{color: GUI_THEME.accent}}>
+						{character}
+					</span>
+				) : (
+					<span key={index}>{character}</span>
+				),
+			)}
+		</>
+	);
+};
+
+export const CommandPaletteRow = ({
+	title,
+	hits,
+	group,
+	reason,
+	hint,
+	color,
+	selected,
+	hasArguments,
+	onHover,
+	onRun,
+}: {
+	title: string;
+	hits: number[];
+	// The section this belongs to, shown right-aligned rather than as a header:
+	// the list reorders as you type, and headers over a moving list flicker.
+	group?: string;
+	// Why it cannot run; the row dims and says so instead of disappearing.
+	reason?: string | null;
+	hint?: string;
+	color?: string;
+	selected: boolean;
+	hasArguments?: boolean;
+	onHover: () => void;
+	onRun: () => void;
+}) => (
+	<button
+		type="button"
+		role="option"
+		aria-selected={selected}
+		aria-disabled={Boolean(reason)}
+		title={reason ?? undefined}
+		onMouseMove={onHover}
+		onClick={onRun}
+		style={{
+			display: 'flex',
+			alignItems: 'center',
+			gap: 8,
+			width: '100%',
+			textAlign: 'left',
+			background: selected ? GUI_THEME.hover : 'transparent',
+			border: 'none',
+			borderLeft: `2px solid ${selected ? GUI_THEME.accent : 'transparent'}`,
+			color: reason ? GUI_THEME.dim : GUI_THEME.primary,
+			fontSize: TEXT.ui,
+			fontFamily: 'inherit',
+			padding: '7px 12px',
+			cursor: reason ? 'default' : 'pointer',
+		}}
+	>
+		{color && (
+			<span
+				aria-hidden
+				style={{
+					width: 7,
+					height: 7,
+					borderRadius: 2,
+					background: color,
+					flexShrink: 0,
+					opacity: reason ? 0.4 : 1,
+				}}
+			/>
+		)}
+
+		<span
+			style={{
+				flex: 1,
+				overflow: 'hidden',
+				textOverflow: 'ellipsis',
+				whiteSpace: 'nowrap',
+			}}
+		>
+			<Highlighted text={title} hits={hits} />
+			{hasArguments && <span style={{color: GUI_THEME.dim}}> …</span>}
+		</span>
+
+		{/* The reason outranks the group: on a row that cannot run, what it
+		    belongs to is not what the reader needs to know. */}
+		<span
+			style={{
+				fontSize: TEXT.label,
+				color: GUI_THEME.dim,
+				flexShrink: 0,
+				whiteSpace: 'nowrap',
+			}}
+		>
+			{reason ?? hint ?? group}
+		</span>
+	</button>
+);

--- a/source/gui/client/components/Header.tsx
+++ b/source/gui/client/components/Header.tsx
@@ -2,6 +2,7 @@ import {GuiState} from '../lib/gui-state.model';
 import {GUI_THEME} from '../lib/gui-theme';
 import {SyncStatus} from '../lib/gui-sync-statusmodel';
 import {Button} from './Button';
+import {CommandPaletteHint} from './CommandPaletteHint';
 import {Panel} from './Panel';
 import {User} from './User';
 import {EPIQ_VERSION} from '../../../version.js';
@@ -14,6 +15,7 @@ type HeaderProps = {
 	onReconnect: () => void;
 	scrubbing: boolean;
 	syncStatus: SyncStatus;
+	onOpenCommands: () => void;
 };
 
 export const Header = ({
@@ -22,6 +24,7 @@ export const Header = ({
 	onReconnect,
 	scrubbing,
 	syncStatus,
+	onOpenCommands,
 }: HeaderProps) => {
 	const syncColor =
 		syncStatus.status === 'synced'
@@ -62,14 +65,18 @@ export const Header = ({
 					justifyContent: 'space-between',
 				}}
 			>
-				<div
-					style={{
-						color: GUI_THEME.accent,
-						fontSize: 12,
-						fontWeight: 700,
-					}}
-				>
-					:epiq
+				<div style={{display: 'flex', alignItems: 'center', gap: 14}}>
+					<div
+						style={{
+							color: GUI_THEME.accent,
+							fontSize: 12,
+							fontWeight: 700,
+						}}
+					>
+						:epiq
+					</div>
+
+					<CommandPaletteHint onOpen={onOpenCommands} />
 				</div>
 
 				<div

--- a/source/gui/client/lib/commands/command-match.test.ts
+++ b/source/gui/client/lib/commands/command-match.test.ts
@@ -1,0 +1,91 @@
+import {describe, expect, it} from 'vitest';
+import {matchItems, Matchable} from './command-match';
+
+const item = (id: string, title: string, keywords?: string[]): Matchable => ({
+	id,
+	title,
+	...(keywords ? {keywords} : {}),
+});
+
+const items = [
+	item('new', 'New ticket', ['create']),
+	item('comment', 'Comment on ticket'),
+	item('close', 'Close ticket', ['done']),
+	item('sync', 'Sync with the remote', ['push', 'pull']),
+];
+
+const titles = (matches: {item: Matchable}[]) =>
+	matches.map(match => match.item.title);
+
+describe('matchItems', () => {
+	it('keeps the declared order when nothing is typed', () => {
+		expect(titles(matchItems(items, ''))).toEqual([
+			'New ticket',
+			'Comment on ticket',
+			'Close ticket',
+			'Sync with the remote',
+		]);
+	});
+
+	// The palette's resting state: what you reached for last is what you are
+	// most likely reaching for now.
+	it('leads with the recent ones, most recent first', () => {
+		expect(
+			titles(matchItems(items, '', {recentIds: ['sync', 'close']})),
+		).toEqual([
+			'Sync with the remote',
+			'Close ticket',
+			'New ticket',
+			'Comment on ticket',
+		]);
+	});
+
+	it('ignores a recent id that is no longer a command', () => {
+		expect(
+			titles(matchItems(items, '', {recentIds: ['config', 'close']})),
+		).toEqual([
+			'Close ticket',
+			'New ticket',
+			'Comment on ticket',
+			'Sync with the remote',
+		]);
+	});
+
+	// Loose on purpose, the way a fuzzy palette is: `cmt` also runs through
+	// "Syn(c) with the re(m)o(t)e". What matters is which one leads.
+	it('matches a subsequence, not just a substring', () => {
+		expect(titles(matchItems(items, 'cmt'))[0]).toBe('Comment on ticket');
+	});
+
+	it('reports where it hit, so the row can mark it', () => {
+		const [match] = matchItems(items, 'new');
+
+		expect(match?.hits).toEqual([0, 1, 2]);
+	});
+
+	it('prefers a prefix to a hit further in', () => {
+		expect(titles(matchItems(items, 'c')).slice(0, 2)).toEqual([
+			'Comment on ticket',
+			'Close ticket',
+		]);
+	});
+
+	// The TUI keyword is what somebody who learned the other surface will type.
+	it('finds a command by a keyword the title never says', () => {
+		expect(titles(matchItems(items, 'push'))).toEqual(['Sync with the remote']);
+	});
+
+	it('drops what matches nowhere', () => {
+		expect(matchItems(items, 'zzz')).toEqual([]);
+	});
+
+	// What keeps unavailable commands listed but last, rather than hidden.
+	it('orders by rank before score', () => {
+		const rank = (candidate: Matchable) => (candidate.id === 'comment' ? 1 : 0);
+		const ranked = titles(matchItems(items, 'c', {rank}));
+
+		// Its score would have led; its rank puts it last instead.
+		expect(ranked[0]).toBe('Close ticket');
+		expect(ranked.at(-1)).toBe('Comment on ticket');
+	});
+});

--- a/source/gui/client/lib/commands/command-match.test.ts
+++ b/source/gui/client/lib/commands/command-match.test.ts
@@ -75,6 +75,38 @@ describe('matchItems', () => {
 		expect(titles(matchItems(items, 'push'))).toEqual(['Sync with the remote']);
 	});
 
+	// A project can hold thousands of tickets and the list is a picker: every
+	// row returned becomes a DOM node behind a window showing eight.
+	describe('the cap', () => {
+		const many = Array.from({length: 5_000}, (_, index) =>
+			item(`t${index}`, `Ticket number ${index}`),
+		);
+
+		it('returns no more than the limit from a query that matches everything', () => {
+			expect(matchItems(many, 'ticket', {limit: 10})).toHaveLength(10);
+		});
+
+		// The one wanted is last in the input, so a cap applied while scanning
+		// would have thrown it away before ever reaching it.
+		it('keeps the best of the whole set, not the first it scanned', () => {
+			const capped = matchItems(many, 'ticket number 4999', {limit: 10});
+
+			expect(capped[0]?.item.title).toBe('Ticket number 4999');
+		});
+
+		it('caps the resting list too, where nothing has been typed', () => {
+			expect(matchItems(many, '', {limit: 10})).toHaveLength(10);
+		});
+
+		it('leaves the list whole when no cap is asked for', () => {
+			expect(matchItems(items, '')).toHaveLength(items.length);
+		});
+
+		it('caps to what matched, not to the limit', () => {
+			expect(matchItems(items, 'sync', {limit: 10}).length).toBeLessThan(10);
+		});
+	});
+
 	it('drops what matches nowhere', () => {
 		expect(matchItems(items, 'zzz')).toEqual([]);
 	});

--- a/source/gui/client/lib/commands/command-match.ts
+++ b/source/gui/client/lib/commands/command-match.ts
@@ -62,17 +62,27 @@ const scoreHits = (text: string, query: string, hits: number[]): number => {
 export const matchItems = <T extends Matchable>(
 	items: readonly T[],
 	query: string,
-	options: {recentIds?: readonly string[]; rank?: (item: T) => number} = {},
+	options: {
+		recentIds?: readonly string[];
+		rank?: (item: T) => number;
+		// Kept after ranking, so what survives is the best of the whole set and
+		// not the first N it happened to scan. A project can hold thousands of
+		// tickets and the list is a picker: nobody reads past the top of it, and
+		// a row that is never read still costs a DOM node to build.
+		limit?: number;
+	} = {},
 ): Match<T>[] => {
-	const {recentIds = [], rank = () => 0} = options;
+	const {recentIds = [], rank = () => 0, limit} = options;
 	const normalized = query.trim().toLowerCase();
+	const cap = <R>(matches: R[]): R[] =>
+		limit === undefined ? matches : matches.slice(0, limit);
 
 	if (!normalized) {
 		const recency = new Map(
 			recentIds.map((id, index) => [id, recentIds.length - index]),
 		);
 
-		return [...items]
+		const ordered = [...items]
 			.map((item, index) => ({item, hits: [], score: 0, index}))
 			.sort((a, b) => {
 				const byRank = rank(a.item) - rank(b.item);
@@ -83,36 +93,40 @@ export const matchItems = <T extends Matchable>(
 				if (byRecency !== 0) return byRecency;
 
 				return a.index - b.index;
-			})
-			.map(({item, hits, score}) => ({item, hits, score}));
+			});
+
+		return cap(ordered.map(({item, hits, score}) => ({item, hits, score})));
 	}
 
-	return items
-		.flatMap(item => {
-			const titleHits = subsequenceHits(item.title, normalized);
+	const scored = items.flatMap(item => {
+		const titleHits = subsequenceHits(item.title, normalized);
 
-			if (titleHits) {
-				return [
-					{
-						item,
-						hits: titleHits,
-						score: scoreHits(item.title, normalized, titleHits),
-					},
-				];
-			}
+		if (titleHits) {
+			return [
+				{
+					item,
+					hits: titleHits,
+					score: scoreHits(item.title, normalized, titleHits),
+				},
+			];
+		}
 
-			// The keywords carry the TUI spelling, so `:tag` finds "Add a tag" even
-			// though the title says neither. No hits: nothing in the title to mark.
-			const byKeyword = [item.id, ...(item.keywords ?? [])].some(keyword =>
-				keyword.toLowerCase().includes(normalized),
-			);
+		// The keywords carry the TUI spelling and a ticket's ref, so `:tag` finds
+		// "Add a tag" and `ABC1234` finds the ticket it names. No hits: nothing in
+		// the title to mark.
+		const byKeyword = [item.id, ...(item.keywords ?? [])].some(keyword =>
+			keyword.toLowerCase().includes(normalized),
+		);
 
-			return byKeyword ? [{item, hits: [], score: 0}] : [];
-		})
-		.sort((a, b) => {
+		return byKeyword ? [{item, hits: [], score: 0}] : [];
+	});
+
+	return cap(
+		scored.sort((a, b) => {
 			const byRank = rank(a.item) - rank(b.item);
 			if (byRank !== 0) return byRank;
 
 			return b.score - a.score;
-		});
+		}),
+	);
 };

--- a/source/gui/client/lib/commands/command-match.ts
+++ b/source/gui/client/lib/commands/command-match.ts
@@ -1,0 +1,118 @@
+// Matching and ranking for the palette, over commands and over the arguments of
+// a two-stage one alike — both are "a label, maybe some extra words to find it
+// by", so both go through here.
+
+export type Matchable = {
+	id: string;
+	title: string;
+	keywords?: string[];
+};
+
+export type Match<T> = {
+	item: T;
+	// Indices into the title that the query hit, for the row to highlight. Empty
+	// where the match came from a keyword rather than the title itself.
+	hits: number[];
+	score: number;
+};
+
+// A subsequence rather than a substring: "cmt" finds "Comment on ticket", which
+// is what anyone typing quickly expects. Returns where it matched, so the row
+// can mark the same characters the reader aimed at.
+const subsequenceHits = (text: string, query: string): number[] | null => {
+	const lowerText = text.toLowerCase();
+	const hits: number[] = [];
+	let at = 0;
+
+	for (const character of query) {
+		const found = lowerText.indexOf(character, at);
+		if (found === -1) return null;
+
+		hits.push(found);
+		at = found + 1;
+	}
+
+	return hits;
+};
+
+// Higher is better. Three things earn points, in the order a reader would rank
+// them: the query is a prefix of what they are looking at, the match is
+// unbroken, and it starts early.
+const scoreHits = (text: string, query: string, hits: number[]): number => {
+	const prefix = text.toLowerCase().startsWith(query) ? 1000 : 0;
+
+	let contiguous = 0;
+	for (let index = 1; index < hits.length; index += 1) {
+		if (hits[index]! === hits[index - 1]! + 1) contiguous += 1;
+	}
+
+	return prefix + contiguous * 10 - (hits[0] ?? 0);
+};
+
+/**
+ * Ranks `items` against `query`.
+ *
+ * An empty query is the palette's resting state rather than a match of
+ * everything: `recentIds` leads, most recent first, and the rest keep the order
+ * they were declared in — which is grouped, and deliberate.
+ *
+ * `rank` orders within equal scores. It is what keeps unavailable commands last
+ * without hiding them, the way the TUI palette does.
+ */
+export const matchItems = <T extends Matchable>(
+	items: readonly T[],
+	query: string,
+	options: {recentIds?: readonly string[]; rank?: (item: T) => number} = {},
+): Match<T>[] => {
+	const {recentIds = [], rank = () => 0} = options;
+	const normalized = query.trim().toLowerCase();
+
+	if (!normalized) {
+		const recency = new Map(
+			recentIds.map((id, index) => [id, recentIds.length - index]),
+		);
+
+		return [...items]
+			.map((item, index) => ({item, hits: [], score: 0, index}))
+			.sort((a, b) => {
+				const byRank = rank(a.item) - rank(b.item);
+				if (byRank !== 0) return byRank;
+
+				const byRecency =
+					(recency.get(b.item.id) ?? 0) - (recency.get(a.item.id) ?? 0);
+				if (byRecency !== 0) return byRecency;
+
+				return a.index - b.index;
+			})
+			.map(({item, hits, score}) => ({item, hits, score}));
+	}
+
+	return items
+		.flatMap(item => {
+			const titleHits = subsequenceHits(item.title, normalized);
+
+			if (titleHits) {
+				return [
+					{
+						item,
+						hits: titleHits,
+						score: scoreHits(item.title, normalized, titleHits),
+					},
+				];
+			}
+
+			// The keywords carry the TUI spelling, so `:tag` finds "Add a tag" even
+			// though the title says neither. No hits: nothing in the title to mark.
+			const byKeyword = [item.id, ...(item.keywords ?? [])].some(keyword =>
+				keyword.toLowerCase().includes(normalized),
+			);
+
+			return byKeyword ? [{item, hits: [], score: 0}] : [];
+		})
+		.sort((a, b) => {
+			const byRank = rank(a.item) - rank(b.item);
+			if (byRank !== 0) return byRank;
+
+			return b.score - a.score;
+		});
+};

--- a/source/gui/client/lib/commands/command-recents.test.ts
+++ b/source/gui/client/lib/commands/command-recents.test.ts
@@ -1,0 +1,76 @@
+import {beforeAll, beforeEach, describe, expect, it, vi} from 'vitest';
+import {readRecentCommands, withCommandRemembered} from './command-recents';
+
+const STORAGE_KEY = 'epiq.gui.recentCommands';
+
+describe('recent commands', () => {
+	// No DOM under vitest here: the store only needs get/set/clear.
+	beforeAll(() => {
+		const store = new Map<string, string>();
+		vi.stubGlobal('localStorage', {
+			getItem: (key: string) => store.get(key) ?? null,
+			setItem: (key: string, value: string) => store.set(key, value),
+			clear: () => store.clear(),
+		});
+	});
+
+	beforeEach(() => {
+		localStorage.clear();
+	});
+
+	it('is empty before anything has been run', () => {
+		expect(readRecentCommands()).toEqual([]);
+	});
+
+	it('reads back what was stored', () => {
+		localStorage.setItem(STORAGE_KEY, JSON.stringify(['sync', 'new']));
+
+		expect(readRecentCommands()).toEqual(['sync', 'new']);
+	});
+
+	it('shrugs off anything that is not a list of strings', () => {
+		localStorage.setItem(STORAGE_KEY, '{not json');
+		expect(readRecentCommands()).toEqual([]);
+
+		localStorage.setItem(STORAGE_KEY, '{"sync":1}');
+		expect(readRecentCommands()).toEqual([]);
+
+		localStorage.setItem(STORAGE_KEY, JSON.stringify(['sync', 3, null]));
+		expect(readRecentCommands()).toEqual(['sync']);
+	});
+
+	it('puts the newest first', () => {
+		expect(withCommandRemembered(['new'], 'sync')).toEqual(['sync', 'new']);
+	});
+
+	// Running something already in the list promotes it; it does not appear twice.
+	it('promotes rather than duplicates', () => {
+		expect(withCommandRemembered(['new', 'sync', 'close'], 'sync')).toEqual([
+			'sync',
+			'new',
+			'close',
+		]);
+	});
+
+	it('keeps only the last six', () => {
+		const many = ['a', 'b', 'c', 'd', 'e', 'f'];
+
+		expect(withCommandRemembered(many, 'g')).toEqual([
+			'g',
+			'a',
+			'b',
+			'c',
+			'd',
+			'e',
+		]);
+	});
+
+	it('caps what it reads too, so a hand-grown list cannot fill the palette', () => {
+		localStorage.setItem(
+			STORAGE_KEY,
+			JSON.stringify(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']),
+		);
+
+		expect(readRecentCommands()).toHaveLength(6);
+	});
+});

--- a/source/gui/client/lib/commands/command-recents.ts
+++ b/source/gui/client/lib/commands/command-recents.ts
@@ -1,0 +1,65 @@
+import {useState} from 'react';
+
+/**
+ * The commands this reader reached for last, most recent first.
+ *
+ * Per browser rather than per board, like the reviewed-file ticks and the
+ * panel's dock: which commands somebody uses is a working habit, not a property
+ * of the work. Capped, because the palette shows them where an empty query
+ * would otherwise show the whole list in declaration order — a tail nobody
+ * remembers is not a shortcut.
+ */
+const STORAGE_KEY = 'epiq.gui.recentCommands';
+
+const CAP = 6;
+
+// Anything but a list of strings — a hand edit, an older shape — reads as no
+// history rather than a palette that will not open.
+export const readRecentCommands = (): string[] => {
+	try {
+		const parsed: unknown = JSON.parse(
+			localStorage.getItem(STORAGE_KEY) ?? '[]',
+		);
+
+		return Array.isArray(parsed)
+			? parsed
+					.filter((entry): entry is string => typeof entry === 'string')
+					.slice(0, CAP)
+			: [];
+	} catch {
+		return [];
+	}
+};
+
+// Moved to the front rather than appended, so running a command already in the
+// list promotes it instead of duplicating it.
+export const withCommandRemembered = (
+	recent: readonly string[],
+	id: string,
+): string[] => [id, ...recent.filter(entry => entry !== id)].slice(0, CAP);
+
+export type RecentCommands = {
+	ids: string[];
+	remember: (id: string) => void;
+};
+
+export const useRecentCommands = (): RecentCommands => {
+	const [ids, setIds] = useState(readRecentCommands);
+
+	return {
+		ids,
+		remember: (id: string) => {
+			setIds(previous => {
+				const next = withCommandRemembered(previous, id);
+
+				try {
+					localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+				} catch {
+					// Storage unavailable: the list still holds for this session.
+				}
+
+				return next;
+			});
+		},
+	};
+};

--- a/source/gui/client/lib/commands/command-registry.test.ts
+++ b/source/gui/client/lib/commands/command-registry.test.ts
@@ -6,6 +6,7 @@ import {GuiIssue} from '../gui-state.model';
 
 const handlers = (): CommandHandlers => ({
 	createIssue: vi.fn(),
+	openIssue: vi.fn(),
 	closeIssue: vi.fn(),
 	reopenIssue: vi.fn(),
 	addIssueTag: vi.fn(),
@@ -39,6 +40,7 @@ const context = (overrides: Partial<CommandContext> = {}): CommandContext => ({
 	scrubbing: false,
 	issue: issue(),
 	tags: [],
+	tickets: [],
 	contributors: [],
 	handlers: handlers(),
 	...overrides,
@@ -241,6 +243,67 @@ describe('the GUI command registry', () => {
 		it('does not invent an argument for the commands that cannot take one', () => {
 			expect(find(CmdKeywords.UNTAG).freeTextArgument).toBeUndefined();
 			expect(find(CmdKeywords.ASSIGN).freeTextArgument).toBeUndefined();
+		});
+
+		// Project-wide, not the board on screen: the point is to reach a ticket
+		// you cannot see from where you are standing.
+		it('searches every board, and opens what is picked', () => {
+			const searching = context({
+				tickets: [
+					{
+						id: 'i1',
+						ref: 'AAA1111',
+						title: 'Here',
+						boardTitle: 'Default',
+						boardRef: 'DEF1234',
+					},
+					{
+						id: 'i2',
+						ref: 'BBB2222',
+						title: 'Elsewhere',
+						boardTitle: 'Other',
+						boardRef: 'OTH5678',
+					},
+				],
+			});
+
+			const offered = find('gui:search').getArguments?.(searching);
+
+			expect(offered?.map(one => one.title)).toEqual(['Here', 'Elsewhere']);
+			// The ref is matchable, and the board says where you are being taken.
+			expect(offered?.[1]?.keywords).toEqual(['BBB2222']);
+			expect(offered?.[1]?.hint).toBe('Other · BBB2222');
+
+			// Taken to the board it is on, not the one being looked at.
+			find('gui:search').run(searching, offered![1]!);
+			expect(searching.handlers.openIssue).toHaveBeenCalledWith(
+				'i2',
+				'OTH5678',
+			);
+		});
+
+		it('says so rather than searching an empty project', () => {
+			expect(find('gui:search').unavailable(context())).toBe(
+				'No tickets to search',
+			);
+		});
+
+		// Reading what already arrived, so a dead socket and a board in the past
+		// are both fine.
+		it('searches offline and mid-scrub', () => {
+			const ticket = {
+				id: 'i1',
+				ref: 'AAA1111',
+				title: 'Here',
+				boardTitle: 'Default',
+				boardRef: 'DEF1234',
+			};
+
+			expect(
+				find('gui:search').unavailable(
+					context({tickets: [ticket], connected: false, scrubbing: true}),
+				),
+			).toBeNull();
 		});
 
 		// A stale second step: the ticket closed under it, or the palette was

--- a/source/gui/client/lib/commands/command-registry.test.ts
+++ b/source/gui/client/lib/commands/command-registry.test.ts
@@ -1,0 +1,267 @@
+import {describe, expect, it, vi} from 'vitest';
+import {CmdKeywords} from '../../../../lib/command-line/cmd-keywords.js';
+import {buildCommandRegistry, commandRank} from './command-registry';
+import {CommandContext, CommandHandlers} from './command.model';
+import {GuiIssue} from '../gui-state.model';
+
+const handlers = (): CommandHandlers => ({
+	createIssue: vi.fn(),
+	closeIssue: vi.fn(),
+	reopenIssue: vi.fn(),
+	addIssueTag: vi.fn(),
+	removeIssueTag: vi.fn(),
+	addIssueAssignee: vi.fn(),
+	removeIssueAssignee: vi.fn(),
+	commentOnIssue: vi.fn(),
+	copyRef: vi.fn(),
+	sync: vi.fn(),
+	startTheatre: vi.fn(),
+	returnToLive: vi.fn(),
+	toggleLog: vi.fn(),
+	createSwimlane: vi.fn(),
+});
+
+const issue = (overrides: Partial<GuiIssue> = {}): GuiIssue => ({
+	isClosed: false,
+	id: 'issue-1',
+	ref: 'ABC1234',
+	title: 'A ticket',
+	description: '',
+	createdAt: 0,
+	readonly: false,
+	tags: [],
+	assignees: [],
+	...overrides,
+});
+
+const context = (overrides: Partial<CommandContext> = {}): CommandContext => ({
+	connected: true,
+	scrubbing: false,
+	issue: issue(),
+	tags: [],
+	contributors: [],
+	handlers: handlers(),
+	...overrides,
+});
+
+const find = (id: string) => {
+	const command = buildCommandRegistry().find(entry => entry.id === id);
+	if (!command) throw new Error(`No command ${id}`);
+
+	return command;
+};
+
+describe('the GUI command registry', () => {
+	// What keeps "the same commands" honest: the GUI cannot import the TUI's
+	// command machinery, so only a test holds the two vocabularies together.
+	it('names every shared command after a TUI keyword', () => {
+		const keywords = new Set<string>(Object.values(CmdKeywords));
+
+		for (const command of buildCommandRegistry()) {
+			if (command.id.startsWith('gui:')) continue;
+
+			expect(keywords, `${command.id} is not a TUI keyword`).toContain(
+				command.id,
+			);
+		}
+	});
+
+	it('gives every command a title and a group', () => {
+		for (const command of buildCommandRegistry()) {
+			expect(command.title.length).toBeGreaterThan(0);
+			expect(command.group.length).toBeGreaterThan(0);
+		}
+	});
+
+	it('has no two commands under one id', () => {
+		const ids = buildCommandRegistry().map(command => command.id);
+
+		expect(new Set(ids).size).toBe(ids.length);
+	});
+
+	describe('availability', () => {
+		it('holds every write back while the board is in the past', () => {
+			const scrubbed = context({scrubbing: true});
+
+			expect(find(CmdKeywords.NEW).unavailable(scrubbed)).toBe(
+				'Read-only while viewing history',
+			);
+			expect(find(CmdKeywords.CLOSE_ISSUE).unavailable(scrubbed)).toBe(
+				'Read-only while viewing history',
+			);
+		});
+
+		it('holds every write back while the socket is down', () => {
+			expect(
+				find(CmdKeywords.NEW).unavailable(context({connected: false})),
+			).toBe('Not connected');
+		});
+
+		// Copying a ref asks the server for nothing, so a dropped socket is no
+		// reason to refuse it.
+		it('still copies a ref while offline', () => {
+			expect(
+				find(CmdKeywords.YANK).unavailable(context({connected: false})),
+			).toBeNull();
+		});
+
+		it('asks for a ticket where one is needed', () => {
+			expect(
+				find(CmdKeywords.COMMENT).unavailable(context({issue: null})),
+			).toBe('Open a ticket first');
+		});
+
+		it('will not close what is already closed, nor reopen what is open', () => {
+			const closed = context({issue: issue({isClosed: true})});
+
+			expect(find(CmdKeywords.CLOSE_ISSUE).unavailable(closed)).toBe(
+				'Already closed',
+			);
+			expect(find(CmdKeywords.RE_OPEN_ISSUE).unavailable(closed)).toBeNull();
+			expect(find(CmdKeywords.RE_OPEN_ISSUE).unavailable(context())).toBe(
+				'This ticket is open',
+			);
+		});
+
+		it('offers to return to live only from the past', () => {
+			expect(find('gui:live').unavailable(context())).toBe(
+				'The board is already live',
+			);
+			expect(
+				find('gui:live').unavailable(context({scrubbing: true})),
+			).toBeNull();
+		});
+
+		it('sorts what cannot run last', () => {
+			const rank = commandRank(context({issue: null}));
+
+			expect(rank(find(CmdKeywords.SYNC))).toBe(0);
+			expect(rank(find(CmdKeywords.COMMENT))).toBe(1);
+		});
+	});
+
+	describe('the two-stage commands', () => {
+		const tags = [
+			{id: 'tag-1', name: 'bug', color: '#f00'},
+			{id: 'tag-2', name: 'gui', color: '#0f0'},
+		];
+
+		it('offers only the tags the ticket does not already carry', () => {
+			const withOne = context({
+				tags,
+				issue: issue({tags: [tags[0]!]}),
+			});
+
+			expect(
+				find(CmdKeywords.TAG)
+					.getArguments?.(withOne)
+					.map(one => one.title),
+			).toEqual(['gui']);
+		});
+
+		it('offers only the tags it does carry, to remove', () => {
+			const withOne = context({tags, issue: issue({tags: [tags[0]!]})});
+
+			expect(
+				find(CmdKeywords.UNTAG)
+					.getArguments?.(withOne)
+					.map(one => one.title),
+			).toEqual(['bug']);
+		});
+
+		it('says so rather than opening an empty list', () => {
+			expect(find(CmdKeywords.UNTAG).unavailable(context({tags}))).toBe(
+				'This ticket has no tags',
+			);
+			expect(find(CmdKeywords.UNASSIGN).unavailable(context())).toBe(
+				'Nobody is assigned',
+			);
+		});
+
+		it('leaves out a removed contributor, and marks you', () => {
+			const withPeople = context({
+				contributors: [
+					{
+						id: 'u1',
+						name: 'jola',
+						color: '#00f',
+						isSelf: true,
+						isRemoved: false,
+						hasAuthoredAnywhere: true,
+					},
+					{
+						id: 'u2',
+						name: 'gone',
+						color: '#00f',
+						isSelf: false,
+						isRemoved: true,
+						hasAuthoredAnywhere: true,
+					},
+				],
+			});
+
+			const offered = find(CmdKeywords.ASSIGN).getArguments?.(withPeople);
+
+			expect(offered?.map(one => one.title)).toEqual(['jola']);
+			expect(offered?.[0]?.hint).toBe('you');
+		});
+
+		// The tag is applied by name, since that is what the mutation takes — a
+		// tag that does not exist yet is created by the same call.
+		it('applies a tag by name and removes one by id', () => {
+			const applying = context({tags});
+			find(CmdKeywords.TAG).run(applying, {id: 'tag-2', title: 'gui'});
+
+			expect(applying.handlers.addIssueTag).toHaveBeenCalledWith(
+				'issue-1',
+				'gui',
+			);
+
+			const removing = context({tags, issue: issue({tags: [tags[0]!]})});
+			find(CmdKeywords.UNTAG).run(removing, {id: 'tag-1', title: 'bug'});
+
+			expect(removing.handlers.removeIssueTag).toHaveBeenCalledWith(
+				'issue-1',
+				'tag-1',
+			);
+		});
+
+		// A board with no tags yet would otherwise offer an empty list and no way
+		// forward. The mutation creates the tag, so naming one is enough.
+		it('offers a tag name the board has never held', () => {
+			const tag = find(CmdKeywords.TAG);
+
+			expect(tag.freeTextArgument?.('urgent')?.title).toBe('urgent');
+			expect(tag.freeTextArgument?.('  spaced  ')?.title).toBe('spaced');
+			expect(tag.freeTextArgument?.('   ')).toBeNull();
+		});
+
+		// Only where the argument can be named into being: unassigning names
+		// somebody already on the ticket.
+		it('does not invent an argument for the commands that cannot take one', () => {
+			expect(find(CmdKeywords.UNTAG).freeTextArgument).toBeUndefined();
+			expect(find(CmdKeywords.ASSIGN).freeTextArgument).toBeUndefined();
+		});
+
+		// A stale second step: the ticket closed under it, or the palette was
+		// driven by a test. Nothing should fire without an argument.
+		it('does nothing when the argument is missing', () => {
+			const bare = context({tags});
+			find(CmdKeywords.TAG).run(bare);
+
+			expect(bare.handlers.addIssueTag).not.toHaveBeenCalled();
+		});
+	});
+
+	it('runs the plain commands against the ticket in hand', () => {
+		const running = context();
+
+		find(CmdKeywords.CLOSE_ISSUE).run(running);
+		find(CmdKeywords.YANK).run(running);
+		find(CmdKeywords.SYNC).run(running);
+
+		expect(running.handlers.closeIssue).toHaveBeenCalledWith('issue-1');
+		expect(running.handlers.copyRef).toHaveBeenCalledWith('ABC1234');
+		expect(running.handlers.sync).toHaveBeenCalled();
+	});
+});

--- a/source/gui/client/lib/commands/command-registry.ts
+++ b/source/gui/client/lib/commands/command-registry.ts
@@ -40,6 +40,36 @@ export const buildCommandRegistry = (): GuiCommand[] => [
 		run: context => context.handlers.createIssue(),
 	},
 	{
+		// `gui:` rather than the TUI's `filter`: that one narrows the board on
+		// screen, and this crosses every board in the project to open one ticket.
+		// Different enough that borrowing the name would misdescribe both.
+		id: 'gui:search',
+		title: 'Search all tickets',
+		group: 'Board',
+		keywords: ['search', 'find', 'goto', 'jump', 'filter'],
+		// Searches what has already arrived, so it works offline and in the past.
+		unavailable: context =>
+			context.tickets.length ? null : 'No tickets to search',
+		// The whole project, matched down by the second step's own query — which
+		// is what makes this a search rather than a list.
+		getArguments: context =>
+			context.tickets.map(ticket => ({
+				id: ticket.id,
+				title: ticket.title,
+				// The ref is what somebody types when they know it, and the board
+				// says which one they are about to be taken to.
+				keywords: [ticket.ref],
+				hint: `${ticket.boardTitle} · ${ticket.ref}`,
+			})),
+		// The board is read back off the ticket rather than carried on the
+		// argument: an argument is a label and an id, and this needs a route.
+		run: (context, argument) => {
+			const ticket = context.tickets.find(one => one.id === argument?.id);
+
+			if (ticket) context.handlers.openIssue(ticket.id, ticket.boardRef);
+		},
+	},
+	{
 		id: 'gui:swimlane',
 		title: 'New swimlane',
 		group: 'Board',

--- a/source/gui/client/lib/commands/command-registry.ts
+++ b/source/gui/client/lib/commands/command-registry.ts
@@ -1,0 +1,224 @@
+import {CmdKeywords} from '../../../../lib/command-line/cmd-keywords.js';
+import {CommandContext, GuiCommand} from './command.model';
+
+// The reasons a command cannot run, written once: every command that needs a
+// ticket says the same thing about not having one.
+const needsTicket = (context: CommandContext): string | null =>
+	context.issue ? null : 'Open a ticket first';
+
+const needsWrite = (context: CommandContext): string | null => {
+	if (!context.connected) return 'Not connected';
+	// The server refuses every mutation from a board checked out in the past, so
+	// the palette says so rather than firing into a 409.
+	if (context.scrubbing) return 'Read-only while viewing history';
+
+	return null;
+};
+
+const needsWritableTicket = (context: CommandContext): string | null =>
+	needsWrite(context) ?? needsTicket(context);
+
+/**
+ * Every command the GUI offers, in the order an empty palette lists them.
+ *
+ * Named after the TUI's keywords wherever the two surfaces mean the same thing,
+ * so what somebody learned in one works in the other. `gui:` ids are the ones a
+ * terminal has no equivalent for; the TUI-only commands (`init`, `config`,
+ * `exit`, `move`) are simply absent, since a browser has nothing to point them
+ * at.
+ *
+ * Built from handlers rather than reaching for them, so the whole registry is a
+ * value a test can construct.
+ */
+export const buildCommandRegistry = (): GuiCommand[] => [
+	{
+		id: CmdKeywords.NEW,
+		title: 'New ticket',
+		group: 'Board',
+		keywords: ['create', 'add', 'issue'],
+		unavailable: needsWrite,
+		run: context => context.handlers.createIssue(),
+	},
+	{
+		id: 'gui:swimlane',
+		title: 'New swimlane',
+		group: 'Board',
+		keywords: ['column', 'lane', 'create'],
+		unavailable: needsWrite,
+		run: context => context.handlers.createSwimlane(),
+	},
+	{
+		id: CmdKeywords.COMMENT,
+		title: 'Comment on ticket',
+		group: 'Ticket',
+		unavailable: needsWritableTicket,
+		run: context => {
+			if (context.issue) context.handlers.commentOnIssue(context.issue.id);
+		},
+	},
+	{
+		id: CmdKeywords.TAG,
+		title: 'Add a tag',
+		group: 'Ticket',
+		keywords: ['label'],
+		unavailable: needsWritableTicket,
+		// Only tags the ticket does not already carry: the second step should
+		// offer what it can actually do.
+		getArguments: context => {
+			const held = new Set(context.issue?.tags.map(tag => tag.id));
+
+			return context.tags
+				.filter(tag => !held.has(tag.id))
+				.map(tag => ({id: tag.id, title: tag.name, color: tag.color}));
+		},
+		// The mutation takes a name and creates the tag if it is new, which is
+		// what makes `:tag urgent` work on a board that has never had one.
+		freeTextArgument: query =>
+			query.trim() ? {id: `new:${query.trim()}`, title: query.trim()} : null,
+		run: (context, argument) => {
+			if (context.issue && argument) {
+				context.handlers.addIssueTag(context.issue.id, argument.title);
+			}
+		},
+	},
+	{
+		id: CmdKeywords.UNTAG,
+		title: 'Remove a tag',
+		group: 'Ticket',
+		keywords: ['label'],
+		unavailable: context =>
+			needsWritableTicket(context) ??
+			(context.issue?.tags.length ? null : 'This ticket has no tags'),
+		getArguments: context =>
+			(context.issue?.tags ?? []).map(tag => ({
+				id: tag.id,
+				title: tag.name,
+				color: tag.color,
+			})),
+		run: (context, argument) => {
+			if (context.issue && argument) {
+				context.handlers.removeIssueTag(context.issue.id, argument.id);
+			}
+		},
+	},
+	{
+		id: CmdKeywords.ASSIGN,
+		title: 'Assign someone',
+		group: 'Ticket',
+		keywords: ['owner', 'who'],
+		unavailable: needsWritableTicket,
+		getArguments: context => {
+			const assigned = new Set(context.issue?.assignees.map(user => user.id));
+
+			return context.contributors
+				.filter(person => !person.isRemoved && !assigned.has(person.id))
+				.map(person => ({
+					id: person.id,
+					title: person.name,
+					color: person.color,
+					hint: person.isSelf ? 'you' : undefined,
+				}));
+		},
+		run: (context, argument) => {
+			if (context.issue && argument) {
+				context.handlers.addIssueAssignee(context.issue.id, argument.id);
+			}
+		},
+	},
+	{
+		id: CmdKeywords.UNASSIGN,
+		title: 'Unassign someone',
+		group: 'Ticket',
+		unavailable: context =>
+			needsWritableTicket(context) ??
+			(context.issue?.assignees.length ? null : 'Nobody is assigned'),
+		getArguments: context =>
+			(context.issue?.assignees ?? []).map(user => ({
+				id: user.id,
+				title: user.name,
+				color: user.color,
+			})),
+		run: (context, argument) => {
+			if (context.issue && argument) {
+				context.handlers.removeIssueAssignee(context.issue.id, argument.id);
+			}
+		},
+	},
+	{
+		id: CmdKeywords.CLOSE_ISSUE,
+		title: 'Close ticket',
+		group: 'Ticket',
+		keywords: ['done', 'resolve'],
+		unavailable: context =>
+			needsWritableTicket(context) ??
+			(context.issue?.isClosed ? 'Already closed' : null),
+		run: context => {
+			if (context.issue) context.handlers.closeIssue(context.issue.id);
+		},
+	},
+	{
+		id: CmdKeywords.RE_OPEN_ISSUE,
+		title: 'Reopen ticket',
+		group: 'Ticket',
+		unavailable: context =>
+			needsWritableTicket(context) ??
+			(context.issue?.isClosed ? null : 'This ticket is open'),
+		run: context => {
+			if (context.issue) context.handlers.reopenIssue(context.issue.id);
+		},
+	},
+	{
+		// The TUI yanks a node's reference to the clipboard; the GUI's equivalent
+		// of "the thing you would paste" is the ticket ref.
+		id: CmdKeywords.YANK,
+		title: 'Copy ticket reference',
+		group: 'Ticket',
+		keywords: ['yank', 'clipboard', 'ref'],
+		unavailable: needsTicket,
+		run: context => {
+			if (context.issue) context.handlers.copyRef(context.issue.ref);
+		},
+	},
+	{
+		id: CmdKeywords.SYNC,
+		title: 'Sync with the remote',
+		group: 'Board',
+		keywords: ['push', 'pull', 'git'],
+		unavailable: context => (context.connected ? null : 'Not connected'),
+		run: context => context.handlers.sync(),
+	},
+	{
+		// The TUI replays the log into the terminal; here it is the player that
+		// already exists, over the window the scrubber is showing.
+		id: CmdKeywords.REPLAY,
+		title: 'Play the board back',
+		group: 'History',
+		keywords: ['replay', 'theatre', 'movie'],
+		unavailable: context => (context.connected ? null : 'Not connected'),
+		run: context => context.handlers.startTheatre(),
+	},
+	{
+		id: 'gui:live',
+		title: 'Return to live',
+		group: 'History',
+		keywords: ['now', 'present', 'exit history'],
+		unavailable: context =>
+			context.scrubbing ? null : 'The board is already live',
+		run: context => context.handlers.returnToLive(),
+	},
+	{
+		id: 'gui:log',
+		title: 'Toggle the event log',
+		group: 'View',
+		keywords: ['history', 'panel'],
+		unavailable: () => null,
+		run: context => context.handlers.toggleLog(),
+	},
+];
+
+// Unavailable last, available first — the TUI palette's rule, kept because
+// hiding a command teaches nobody that it exists.
+export const commandRank =
+	(context: CommandContext) =>
+	(command: GuiCommand): number =>
+		command.unavailable(context) === null ? 0 : 1;

--- a/source/gui/client/lib/commands/command.model.ts
+++ b/source/gui/client/lib/commands/command.model.ts
@@ -14,6 +14,9 @@ export type GuiCommandId = CmdKeyword | `gui:${string}`;
 export type CommandArgument = {
 	id: string;
 	title: string;
+	// Extra words this can be found by — a ticket's ref, which is what somebody
+	// types when they already know it.
+	keywords?: string[];
 	hint?: string;
 	color?: string;
 };
@@ -23,18 +26,35 @@ export type CommandGroup = 'Ticket' | 'Board' | 'View' | 'History';
 // Everything a command needs to decide whether it can run, and to run. Handlers
 // are passed in rather than reached for, so the registry is a value the tests
 // can build without a React tree.
+// One ticket anywhere in the project, flattened for the search command. A list
+// rather than the boards themselves, so the registry never has to know how a
+// board is shaped.
+export type SearchableTicket = {
+	id: string;
+	ref: string;
+	title: string;
+	boardTitle: string;
+	// The board's human-facing ref, which is what its route is keyed by: a
+	// project-wide search can land on a ticket that is not on the board being
+	// looked at, and opening it has to go there.
+	boardRef: string;
+};
+
 export type CommandContext = {
 	connected: boolean;
 	// The board is checked out in the past, where the server refuses writes.
 	scrubbing: boolean;
 	issue: GuiIssue | null;
 	tags: GuiTag[];
+	// Every ticket in every board, for the project-wide search.
+	tickets: SearchableTicket[];
 	contributors: GuiContributor[];
 	handlers: CommandHandlers;
 };
 
 export type CommandHandlers = {
 	createIssue: () => void;
+	openIssue: (issueId: string, boardRef: string) => void;
 	closeIssue: (issueId: string) => void;
 	reopenIssue: (issueId: string) => void;
 	addIssueTag: (issueId: string, tagName: string) => void;

--- a/source/gui/client/lib/commands/command.model.ts
+++ b/source/gui/client/lib/commands/command.model.ts
@@ -1,0 +1,73 @@
+import {CmdKeyword} from '../../../../lib/command-line/cmd-keywords.js';
+import {GuiContributor, GuiIssue, GuiTag} from '../gui-state.model';
+
+// Either one of the TUI's keywords — both surfaces name the same thing the same
+// way — or `gui:`-prefixed for what only a browser can do. A test holds the
+// first half to `CmdKeywords`, so the two vocabularies cannot drift apart
+// without saying so.
+export type GuiCommandId = CmdKeyword | `gui:${string}`;
+
+// What the second step of a two-stage command offers: a tag to apply, a person
+// to assign. `color` is drawn as a swatch where the thing has one. `title`
+// rather than `label` so an argument is `Matchable`, and one matcher ranks both
+// steps.
+export type CommandArgument = {
+	id: string;
+	title: string;
+	hint?: string;
+	color?: string;
+};
+
+export type CommandGroup = 'Ticket' | 'Board' | 'View' | 'History';
+
+// Everything a command needs to decide whether it can run, and to run. Handlers
+// are passed in rather than reached for, so the registry is a value the tests
+// can build without a React tree.
+export type CommandContext = {
+	connected: boolean;
+	// The board is checked out in the past, where the server refuses writes.
+	scrubbing: boolean;
+	issue: GuiIssue | null;
+	tags: GuiTag[];
+	contributors: GuiContributor[];
+	handlers: CommandHandlers;
+};
+
+export type CommandHandlers = {
+	createIssue: () => void;
+	closeIssue: (issueId: string) => void;
+	reopenIssue: (issueId: string) => void;
+	addIssueTag: (issueId: string, tagName: string) => void;
+	removeIssueTag: (issueId: string, tagId: string) => void;
+	addIssueAssignee: (issueId: string, assigneeId: string) => void;
+	removeIssueAssignee: (issueId: string, assigneeId: string) => void;
+	commentOnIssue: (issueId: string) => void;
+	copyRef: (ref: string) => void;
+	sync: () => void;
+	startTheatre: () => void;
+	returnToLive: () => void;
+	toggleLog: () => void;
+	createSwimlane: () => void;
+};
+
+export type GuiCommand = {
+	id: GuiCommandId;
+	title: string;
+	group: CommandGroup;
+	// Words the matcher accepts besides the title: what somebody would type
+	// looking for this, including the TUI keyword where the GUI title has
+	// drifted from it.
+	keywords?: string[];
+	// Null when it can run, otherwise why not — which the row shows rather than
+	// hiding, the way the TUI palette keeps unavailable commands listed.
+	unavailable: (context: CommandContext) => string | null;
+	// Only on the commands that take one. The palette pushes a second step over
+	// what this returns.
+	getArguments?: (context: CommandContext) => CommandArgument[];
+	// For a command whose argument need not already exist — `:tag urgent` names
+	// a tag into being in the TUI, and a board with no tags yet would otherwise
+	// offer an empty list and no way forward. Null where the query is not a
+	// usable one.
+	freeTextArgument?: (query: string) => CommandArgument | null;
+	run: (context: CommandContext, argument?: CommandArgument) => void;
+};

--- a/source/gui/client/lib/use-command-palette.ts
+++ b/source/gui/client/lib/use-command-palette.ts
@@ -1,0 +1,52 @@
+import {useEffect, useState} from 'react';
+
+/**
+ * Whether the palette is open, and the one key that opens it.
+ *
+ * `Cmd/Ctrl+K` throughout, which is what every other board has trained people
+ * to reach for. Registered on the document rather than on a container, since the
+ * point is that it works wherever the focus happens to be — and captured before
+ * the browser's own find-in-page binding on the same chord.
+ *
+ * Held out of a field: somebody typing a ticket title should get a `k`, not a
+ * palette over what they were writing.
+ */
+const isTypingTarget = (target: EventTarget | null): boolean => {
+	const element = target as HTMLElement | null;
+	if (!element) return false;
+
+	const tag = element.tagName;
+
+	return (
+		tag === 'INPUT' ||
+		tag === 'TEXTAREA' ||
+		tag === 'SELECT' ||
+		element.isContentEditable
+	);
+};
+
+export const useCommandPalette = (): {
+	open: boolean;
+	setOpen: (next: boolean) => void;
+} => {
+	const [open, setOpen] = useState(false);
+
+	useEffect(() => {
+		const onKeyDown = (event: KeyboardEvent) => {
+			if (event.key !== 'k' || !(event.metaKey || event.ctrlKey)) return;
+
+			// The palette's own input is a typing target, so closing on the same
+			// chord has to come before that check.
+			if (!open && isTypingTarget(event.target)) return;
+
+			event.preventDefault();
+			setOpen(!open);
+		};
+
+		document.addEventListener('keydown', onKeyDown);
+
+		return () => document.removeEventListener('keydown', onKeyDown);
+	}, [open]);
+
+	return {open, setOpen};
+};

--- a/source/gui/client/lib/use-command-palette.ts
+++ b/source/gui/client/lib/use-command-palette.ts
@@ -33,11 +33,26 @@ export const useCommandPalette = (): {
 
 	useEffect(() => {
 		const onKeyDown = (event: KeyboardEvent) => {
-			if (event.key !== 'k' || !(event.metaKey || event.ctrlKey)) return;
+			const chord = event.key === 'k' && (event.metaKey || event.ctrlKey);
+
+			// The TUI's own way in, carried across: `:` is how you reach every
+			// command there, and the palette is what it reaches here. Bare, so it
+			// only counts where nothing is being typed — which the check below is.
+			//
+			// `?` is deliberately not a second way in. It is the TUI's palette key,
+			// but on the web it means "show the keyboard shortcuts", and spending
+			// it on a door that `:` already opens would cost that and buy nothing.
+			const colon = event.key === ':' && !event.metaKey && !event.ctrlKey;
+
+			if (!chord && !colon) return;
 
 			// The palette's own input is a typing target, so closing on the same
 			// chord has to come before that check.
 			if (!open && isTypingTarget(event.target)) return;
+
+			// Only the chord toggles: `:` typed at an open palette is a character
+			// its own field should receive, and it never reaches here anyway.
+			if (open && !chord) return;
 
 			event.preventDefault();
 			setOpen(!open);

--- a/source/test/e2e-gui/command-palette.pw.ts
+++ b/source/test/e2e-gui/command-palette.pw.ts
@@ -38,6 +38,50 @@ test('it opens on the chord and leaves on escape', async ({
 	expect(pageErrors).toEqual([]);
 });
 
+// The TUI's own way in. Somebody who learned `:` there should not have to
+// learn a second key here.
+test('a bare colon opens it too, the way the TUI reaches a command', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	await page.keyboard.press(':');
+	await expect(palette(page)).toBeVisible();
+
+	// It types into the palette rather than closing it: only the chord toggles.
+	await page.keyboard.press(':');
+	await expect(palette(page)).toBeVisible();
+
+	await page.keyboard.press('Escape');
+	await expect(palette(page)).toBeHidden();
+
+	expect(pageErrors).toEqual([]);
+});
+
+// A colon belongs to whatever field is being typed in — a ticket title can
+// hold one, and stealing it would be worse than having no shortcut.
+test('a colon typed into a field stays in the field', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	await page.getByTitle('Add issue').first().click();
+	const field = page.getByPlaceholder('issue name');
+	await field.fill('Fix');
+	await field.press(':');
+
+	await expect(palette(page)).toBeHidden();
+	await expect(field).toHaveValue('Fix:');
+
+	expect(pageErrors).toEqual([]);
+});
+
 // The chord has to reach the board from wherever the pointer left the focus,
 // but not out of a field somebody is typing in.
 test('it stays out of the way while you are typing', async ({
@@ -162,6 +206,59 @@ test('backspace leaves the argument list without leaving the palette', async ({
 	await expect(
 		rows(page).filter({hasText: 'Sync with the remote'}),
 	).toHaveCount(1);
+
+	expect(pageErrors).toEqual([]);
+});
+
+// A shortcut nobody can discover is a shortcut nobody uses, so the topbar
+// carries the chord and opens the palette when clicked.
+test('the topbar hint opens the palette', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	const hint = page.getByTestId('command-palette-hint');
+	await expect(hint).toBeVisible();
+	await expect(hint).toContainText('commands');
+
+	await hint.click();
+	await expect(palette(page)).toBeVisible();
+
+	expect(pageErrors).toEqual([]);
+});
+
+// Project-wide rather than the board's own filter: it reaches a ticket by ref
+// or title and opens it.
+test('search reaches a ticket and opens it', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	const title = `Palette search ${Date.now()}`;
+	await addTicket(page, title);
+
+	// Off the ticket, so opening it is a visible change rather than a no-op.
+	await page.keyboard.press('Escape');
+
+	await openPalette(page);
+	await page.keyboard.type('search');
+	await expect(rows(page).first()).toContainText('Search all tickets');
+	await page.keyboard.press('Enter');
+
+	await expect(palette(page)).toBeVisible();
+	await page.keyboard.type(title);
+	await expect(rows(page).filter({hasText: title})).toHaveCount(1);
+	await page.keyboard.press('Enter');
+
+	await expect(palette(page)).toBeHidden();
+	await expect(page).toHaveURL(/\/issue\//);
+	await expect(page.locator('aside')).toContainText(title);
 
 	expect(pageErrors).toEqual([]);
 });

--- a/source/test/e2e-gui/command-palette.pw.ts
+++ b/source/test/e2e-gui/command-palette.pw.ts
@@ -1,0 +1,191 @@
+import type {Page} from '@playwright/test';
+import {expect, test} from './fixtures.js';
+
+// Ctrl rather than Meta: the handler takes either, and Ctrl is the one a
+// headless Chromium fires the same way on every platform.
+const openPalette = async (page: Page) => {
+	await page.keyboard.press('Control+k');
+	await expect(page.getByTestId('command-palette')).toBeVisible();
+};
+
+const palette = (page: Page) => page.getByTestId('command-palette');
+
+const rows = (page: Page) => palette(page).getByRole('option');
+
+const addTicket = async (page: Page, title: string) => {
+	await page.getByTitle('Add issue').first().click();
+	await page.getByPlaceholder('issue name').fill(title);
+	await page.getByPlaceholder('issue name').press('Enter');
+	await expect(page.locator('aside')).toContainText(title);
+};
+
+test('it opens on the chord and leaves on escape', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	await expect(palette(page)).toBeHidden();
+
+	await openPalette(page);
+	await expect(rows(page).first()).toBeVisible();
+
+	await page.keyboard.press('Escape');
+	await expect(palette(page)).toBeHidden();
+
+	expect(pageErrors).toEqual([]);
+});
+
+// The chord has to reach the board from wherever the pointer left the focus,
+// but not out of a field somebody is typing in.
+test('it stays out of the way while you are typing', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	await page.getByTitle('Add issue').first().click();
+	const field = page.getByPlaceholder('issue name');
+	await field.fill('Typing');
+	await field.press('Control+k');
+
+	await expect(palette(page)).toBeHidden();
+	await expect(field).toHaveValue('Typing');
+
+	expect(pageErrors).toEqual([]);
+});
+
+test('typing narrows the list, and enter runs what is left', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	await openPalette(page);
+	const before = await rows(page).count();
+
+	await page.keyboard.type('log');
+	await expect(rows(page).first()).toContainText('Toggle the event log');
+	expect(await rows(page).count()).toBeLessThan(before);
+
+	await page.keyboard.press('Enter');
+
+	// It ran: the palette closed and the log panel it names is on screen.
+	await expect(palette(page)).toBeHidden();
+	await expect(page.getByTestId('event-log')).toBeVisible();
+
+	expect(pageErrors).toEqual([]);
+});
+
+// A command nobody can run is listed with its reason rather than hidden, the
+// way the TUI palette keeps them — hiding one teaches nobody it exists.
+test('a command that cannot run says why, and sorts below the ones that can', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	await openPalette(page);
+	await page.keyboard.type('comment');
+
+	const comment = rows(page).filter({hasText: 'Comment on ticket'}).first();
+
+	await expect(comment).toBeVisible();
+	await expect(comment).toContainText('Open a ticket first');
+	await expect(comment).toHaveAttribute('aria-disabled', 'true');
+
+	expect(pageErrors).toEqual([]);
+});
+
+test('a command that takes an argument opens its list, and applies it', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	const title = `Palette tag ${Date.now()}`;
+	await addTicket(page, title);
+
+	await openPalette(page);
+	await page.keyboard.type('add a tag');
+	await expect(rows(page).first()).toContainText('Add a tag');
+	await page.keyboard.press('Enter');
+
+	// Still open, now on the second step: the command it is collecting for is
+	// named, and the rows are tags rather than commands.
+	await expect(palette(page)).toBeVisible();
+	await expect(palette(page)).toContainText('Add a tag');
+
+	// A name the board has never held: the step offers it rather than an empty
+	// list, the way `:tag urgent` names one into being in the TUI.
+	const tag = `palette-${Date.now()}`;
+	await page.keyboard.type(tag);
+	await expect(rows(page).filter({hasText: tag})).toHaveCount(1);
+	await page.keyboard.press('Enter');
+
+	await expect(palette(page)).toBeHidden();
+	await expect(page.locator('aside')).toContainText(tag);
+
+	expect(pageErrors).toEqual([]);
+});
+
+// Backspace on an empty query is the way back out of the second step, so the
+// return is where the finger already is.
+test('backspace leaves the argument list without leaving the palette', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	await addTicket(page, `Palette back ${Date.now()}`);
+
+	await openPalette(page);
+	await page.keyboard.type('add a tag');
+	await page.keyboard.press('Enter');
+	await expect(palette(page)).toContainText('Add a tag');
+
+	await page.keyboard.press('Backspace');
+
+	await expect(palette(page)).toBeVisible();
+	await expect(
+		rows(page).filter({hasText: 'Sync with the remote'}),
+	).toHaveCount(1);
+
+	expect(pageErrors).toEqual([]);
+});
+
+// The whole point of remembering: what you reached for last is at hand next
+// time, across a reload rather than only within a session.
+test('what was run last leads the list, and survives a reload', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	await openPalette(page);
+	await page.keyboard.type('log');
+	await page.keyboard.press('Enter');
+	await expect(palette(page)).toBeHidden();
+
+	await page.reload();
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	await openPalette(page);
+	await expect(rows(page).first()).toContainText('Toggle the event log');
+
+	expect(pageErrors).toEqual([]);
+});


### PR DESCRIPTION
The TUI has a command line and a `?` palette; the GUI had none, so every action was reachable only by finding the right button. This adds a general command layer — a declarative registry and a dispatcher — with a palette as the first surface over it.

`Cmd/Ctrl+K` opens it. Fuzzy subsequence match, keyboard-first, recent commands remembered in localStorage.

### Sharing with the TUI: the vocabulary, not the machinery

`cmd-keywords.ts` was the one module pure enough for the client — zero imports. Everything else in `command-line/` reaches `state/state.js` → `project-setup.ts` → `node:fs`, which fails `build:gui:types` under the client's DOM-only tsconfig; `commands.ts` also imports `export/export.js`, which imports `ink`.

So the GUI names its commands after `CmdKeywords` and writes its own implementations. A unit test fails if any non-`gui:` command id is not a real keyword — that is what keeps the two surfaces from drifting without coupling them.

The TUI palette itself was not a model to copy: it builds virtual `NavNode`s against `nodeRepo`, which the GUI has no equivalent of. What carried across is its behaviour — unavailable commands listed with a reason rather than hidden, since hiding one teaches nobody it exists.

### Shape

`lib/commands/` holds the registry, independent of React so the tests construct it directly: `{id, title, group, unavailable(ctx), run(ctx)}` plus an optional `getArguments(ctx)`. Matching and ranking are pure (`command-match.ts`), as is the recents list (`command-recents.ts`, capped at six, promoted rather than duplicated, a corrupt value reading as no history).

**Two-stage commands** are where a palette earns its keep: `tag`, `untag`, `assign` and `unassign` push a second step through the same matcher. `Escape` and `Backspace`-on-empty each pop one step.

### Commands

Direct from the TUI: `new`, `comment`, `tag`, `untag`, `assign`, `unassign`, `close`, `reopen`, `yank` (copies the ref), `sync`, `replay` (opens the existing Theatre player). GUI-native: new swimlane, return to live, toggle the event log.

Two deliberate omissions. **`delete` is absent** — the GUI has no `issue:delete` message at all, and inventing a destructive path with no confirmation UI was not in scope. `init`, `config`, `exit` and `move` are dropped as meaningless in a browser.

### One thing found by the tests

"Add a tag" on a board with no tags opened an empty list with no way forward. Since `addIssueTag` creates by name — which is how `:tag urgent` works in the TUI — the second step now offers a name the board has never held. That is slightly beyond the original scope; happy to drop it.

### Reuse

`useIssueMutations`, `useSwimlaneEditing`, `useTheatrePlayback` and `sendSocketJson` are called, not reimplemented. The overlay follows `CreateNodeModal`; localStorage follows the `reviewed-files` conventions; availability keys off the same time-travel state the rest of the board does, so a command does not fire into a 409.

Nothing under `source/lib` changed, so the TUI is untouched — confirmed by the container suites, not assumed.

### Testing

Full gate green: lint, typecheck, **1329 unit** (110 files), build, containers (17 e2e, 15 collaboration), **144 GUI browser** — 7 of them new, covering the chord, staying out of a field being typed in, filtering, running, the unavailable reason, both steps of a two-stage command, backspace out of one, and a recent command surviving a reload.

Closes `XDWJY08`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Vuz7fJrAAc5jn53RsYhdX
