### PR TITLE
Name a timeline actor out of the log, not out of the log's file name

### DIFF
--- a/source/mcp/timeline-index.ts
+++ b/source/mcp/timeline-index.ts
@@ -232,10 +232,11 @@ const describeTimelineEvent = (
 const identityFor = (
 	id: string | undefined,
 	names: Map<string, string>,
+	fallback?: string,
 ): EventIdentity | null => {
 	if (!id) return null;
 
-	const name = names.get(id) ?? id;
+	const name = names.get(id) ?? fallback ?? id;
 
 	return {id, name, color: getStringColor(name)};
 };
@@ -247,13 +248,15 @@ const identitiesFor = (
 	const payload = event.payload as {assignee?: string} | undefined;
 
 	return {
-		actor: event.userId
-			? {
-					id: event.userId,
-					name: event.userName ?? event.userId,
-					color: getStringColor(event.userName ?? event.userId),
-			  }
-			: null,
+		// Through the same name index the tag and the assignee go through. The
+		// name on a loaded event is not a name: it is parsed back out of the log
+		// file, which `sanitizeFilePart` lowercased and stripped, so an actor read
+		// straight off it turns up as `claude-adolph` beside the `claude/adolph`
+		// they are assigned under — in a different colour, since the colour is
+		// hashed from whichever spelling is in hand. The file's copy is the
+		// fallback and nothing more: an id the log has no `create.contributor`
+		// for, from a board written before renames were events.
+		actor: identityFor(event.userId, names, event.userName),
 		tag: identityFor(tagOf(event), names),
 		assignee: identityFor(payload?.assignee, names),
 	};

--- a/source/test/e2e-gui/contributor-filter.pw.ts
+++ b/source/test/e2e-gui/contributor-filter.pw.ts
@@ -57,3 +57,30 @@ test('the Contributors list narrows the board to who caused an event on a ticket
 
 	expect(pageErrors).toEqual([]);
 });
+
+test('lists a contributor under the name the board knows, not the log file', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	await page.getByRole('button', {name: 'Board events'}).click();
+	await page
+		.getByRole('button', {name: 'Pick which contributors to show'})
+		.click();
+
+	// The list is built from the window's events, whose author is reconstructed
+	// from the log's file name — and that has had the slash sanitised out of
+	// it. The board knows them as `claude/tester`, and so must this.
+	const list = page.getByRole('group', {name: 'Which contributors to show'});
+	await expect(
+		list.getByRole('checkbox', {name: 'claude/tester'}),
+	).toBeVisible();
+	await expect(list.getByRole('checkbox', {name: 'claude-tester'})).toHaveCount(
+		0,
+	);
+
+	expect(pageErrors).toEqual([]);
+});

--- a/source/test/e2e-gui/issue-history.pw.ts
+++ b/source/test/e2e-gui/issue-history.pw.ts
@@ -39,6 +39,12 @@ test('the log tab lists the ticket’s own events', async ({
 	// Phrased by the same formatter the TUI log uses.
 	await expect(history).toContainText(`Created with title "${title}"`);
 
+	// Under the name the board knows them by. The row shows an initial, so the
+	// name itself is on the avatar's title — and the log's file name, which has
+	// had the slash sanitised out of it, must not be what reaches it.
+	await expect(history.getByTitle('claude/tester').first()).toBeVisible();
+	await expect(history.getByTitle('claude-tester')).toHaveCount(0);
+
 	// A further change lands in the same list, newest first.
 	await page.getByRole('button', {name: 'Overview'}).click();
 	await page.getByRole('button', {name: 'close issue'}).click();

--- a/source/test/e2e-gui/seed-tui.ts
+++ b/source/test/e2e-gui/seed-tui.ts
@@ -104,7 +104,10 @@ export const seedProject = async (): Promise<string> => {
 	};
 
 	await tui.waitFor('choose your username');
-	await command(':config username test');
+	// A slash in it on purpose: the log's file name cannot hold one, so a name
+	// read back out of the file reads `claude-tester` where the registry says
+	// `claude/tester`. A fixture named `test` cannot tell the two apart.
+	await command(':config username claude/tester');
 
 	await tui.waitFor('pick your editor');
 	await command(':config editor vim');

--- a/source/test/timeline-index.test.ts
+++ b/source/test/timeline-index.test.ts
@@ -148,6 +148,63 @@ describe('timeline-index', () => {
 			);
 		});
 
+		// `userName` on a loaded event is parsed back out of the log's file name,
+		// which sanitizing lowercased and stripped — so the actor has to be
+		// named out of the registry the tag and the assignee are named out of,
+		// or the same person reads `claude-adolph` here and `claude/adolph`
+		// where they are assigned.
+		it('names an actor the way the log named them, not the way the file did', () => {
+			const entries = buildTimelineEntries([
+				{
+					id: ulid(baseTime),
+					action: 'create.contributor',
+					payload: {id: 'u-1', name: 'claude/adolph'},
+					userId: 'u-1',
+					userName: 'claude-adolph',
+				},
+				event(2, {userId: 'u-1', userName: 'claude-adolph'}),
+			] as never);
+
+			expect(entries.map(entry => entry.actor?.name)).toEqual([
+				'claude/adolph',
+				'claude/adolph',
+			]);
+		});
+
+		// The colour is hashed from the name, so a name read two ways is a
+		// person drawn in two colours.
+		it('gives an actor the colour their assigned self is drawn in', () => {
+			const entries = buildTimelineEntries([
+				{
+					id: ulid(baseTime),
+					action: 'create.contributor',
+					payload: {id: 'u-1', name: 'claude/adolph'},
+					userId: 'u-1',
+					userName: 'claude-adolph',
+				},
+				{
+					id: ulid(baseTime + 1000),
+					action: 'add.issue.assignee',
+					payload: {id: 'i1', assignee: 'u-1'},
+					userId: 'u-1',
+					userName: 'claude-adolph',
+				},
+			] as never);
+
+			const assigning = entries[1]!;
+			expect(assigning.actor?.color).toBe(assigning.assignee?.color);
+		});
+
+		// An id the log has no create event for keeps the file's copy: better a
+		// lowercased name than a raw ULID.
+		it('falls back to the file’s copy for an actor the log never named', () => {
+			const [entry] = buildTimelineEntries([
+				event(1, {userId: 'u-9', userName: 'someone-else'}),
+			] as never);
+
+			expect(entry!.actor?.name).toBe('someone-else');
+		});
+
 		// Resolved once at build time so a request can narrow to its own board
 		// over the window rather than walking the log again.
 		it('carries the board each event belongs to', () => {


### PR DESCRIPTION
`7NADZ9F`. A contributor showed as `claude-adolph` where they authored an event and `claude/adolph` where they were assigned. The slash is the real name; the dashed form is the storage encoding reaching the screen.

Nothing carries the name on an event — it is stripped before persisting — so `event.userName` is reconstructed from the log's own file name, which `sanitizeFilePart` lowercased and reduced to `[a-z0-9._-]`. That function's doc says as much: "Lossy on purpose: this is a storage encoding, never a display value... display names come from the contributor registry."

`timeline-index.ts` used it as a display value anyway: the actor was built straight from it, while the `tag` and `assignee` beside it went through the log's name index. That feeds the GUI's Contributors filter, the dot hints and the event log. The colour rode along — `getStringColor` hashes whichever spelling is in hand, so one person was drawn in two colours depending on which side of an event they were on.

The actor goes through the same index now, with the file's copy kept as the fallback for an id the log has no `create.contributor` for.

## Only one reader, not two

`getIssueHistory` looked like the same bug and is not: it reads `issue.log` off the materialized state, where the name survives. Confirmed by writing the raw `userName` out from inside the running server rather than reading the code again — a change "fixing" it would have been a no-op.

## The fixture could not see this

The browser suite seeded its user as `test`, which has no slash, so both spellings are identical and no test could tell them apart. It is `claude/tester` now. The Contributors list gained an assertion that the slashed name is what reaches the screen — red against the old code — and the Log tab has the same one, guarding a path that was already right.

## Checks

The full pre-push gate: typecheck, lint, prettier, 1304 unit tests, the container e2e and collaboration suites, and 139 browser tests. The unit tests covering the actor's name, its colour and the fallback are red against the old code.
