### PR TITLE
A clearer yellow for a comment

### DIFF
--- a/source/gui/client/components/IssueStats.tsx
+++ b/source/gui/client/components/IssueStats.tsx
@@ -14,6 +14,7 @@ import {
 	STAT_LABEL,
 	STAT_NOTE,
 	STAT_VALUE,
+	COMMENT_YELLOW,
 	seriesColor,
 } from '../lib/issue-stats.style';
 import {ProportionBar, StackedBar} from './StatBars';
@@ -324,9 +325,13 @@ export const IssueStats = ({
 					<ProportionBar
 						value={leadComments.share}
 						// Yellow for the prose, blue for the code it explains — the
-						// same yellow the diff itself now gives a comment, so the bar
-						// and the file agree about which is which.
-						color={seriesColor(3)}
+						// very value the diff paints a comment with, so the bar and the
+						// file agree about which is which. Brighter than a categorical
+						// slot is allowed to be, which is the right call for two
+						// segments that are named underneath and separated by a gap:
+						// what binds here is separation from the blue (ΔE 37.7 under
+						// protanopia) and contrast against the panel, and both pass.
+						color={COMMENT_YELLOW}
 						restColor={seriesColor(0)}
 						label={`${percent(leadComments.share)} of the ${
 							leadComments.name

--- a/source/gui/client/lib/diff-theme.ts
+++ b/source/gui/client/lib/diff-theme.ts
@@ -8,14 +8,15 @@
 // prose, it is worth reading.
 
 import {registerCustomTheme, resolveTheme} from '@pierre/diffs';
+import {COMMENT_YELLOW} from './issue-stats.style';
 
 const BASE_THEME = 'github-dark';
 
 export const EPIQ_DIFF_THEME = 'epiq-dark';
 
-// The Stats tab's comment share wears this too, so the bar and the file agree
-// about which half is prose.
-export const COMMENT_COLOR = '#ffd479';
+// The Stats tab's comment share wears the same value, so the bar and the file
+// agree about which half is prose.
+const COMMENT_COLOR = COMMENT_YELLOW;
 
 // A tmTheme rule's scope is one selector or a list of them, and a comment is
 // scoped `comment` or `comment.line…`/`comment.block…` depending on the

--- a/source/gui/client/lib/issue-stats.style.ts
+++ b/source/gui/client/lib/issue-stats.style.ts
@@ -105,3 +105,14 @@ export const SERIES_REST = GUI_THEME.dim2;
 
 export const seriesColor = (index: number): string =>
 	SERIES[index] ?? SERIES_REST;
+
+/**
+ * What a comment is, wherever one is drawn: the yellow the diff paints comment
+ * lines and the yellow the comment bar fills with.
+ *
+ * Defined here rather than beside the diff theme so both sides read one value
+ * — a bar that disagreed with the file it describes would be worse than no bar.
+ * Bright on purpose: 14.5:1 against the code background, and still 12.2:1 on
+ * the green of an added row.
+ */
+export const COMMENT_YELLOW = '#ffe066';


### PR DESCRIPTION
Follow-up on `P6MWRDM`: `#ffd479` was reading orange. `#ffe066` — more green, less blue — sits as a plain yellow rather than an amber, and gains a point of contrast everywhere it lands: 14.5:1 on the code background, 12.2:1 on the green of an added row, 14.1:1 on the panel.

It also fixes something I claimed but had not actually done: the PR before this said the bar wore "the same yellow" as the diff, while the code had the bar on the categorical amber `#c98500` and the diff on `#ffd479` — two different colours for one idea. There is now a single `COMMENT_YELLOW`, in `issue-stats.style.ts`, that both read.

On the bar that yellow is brighter than a categorical slot is allowed to be. That rule exists so no slot in an eight-hue set shouts over the others; it does not bind on two segments that are named in the rows underneath and separated by a gap. What does bind — separation from the blue (ΔE 37.7 protan, 41.6 normal) and contrast against the surface — passes.