### PR TITLE
Board stats, a diff that stops re-rendering on every sync, and a styling pass

### DIFF
--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -47,6 +47,7 @@ import {useAsideDock} from './lib/aside-dock';
 import {moveIssue} from './lib/gui-move-issue';
 import {moveSwimlane} from './lib/gui-move-swimlane';
 import {DropTarget} from './lib/gui-result.model';
+import {deriveBoardStats} from '../../lib/stats/board-stats.js';
 import {nodeRef} from '../../lib/utils/node-ref.js';
 import {issueMatchesText} from '../../lib/utils/text-match.js';
 import {commitTicketRef} from '../../lib/utils/commit-ref.js';
@@ -388,6 +389,33 @@ export const App = () => {
 
 		loadIssueStats(selectedIssue.id, statsSignature);
 	}, [selectedTab, selectedIssue?.id, statsSignature, loadIssueStats]);
+
+	// The board's own half of the Stats tab, derived here because this is where
+	// the lanes are: "backwards" is a fact about their order, and the panel
+	// below is handed the answer rather than the board to work it out from.
+	const boardStats = useMemo(() => {
+		if (!selectedIssue || !state) return null;
+
+		const board = state.boards.find(candidate =>
+			candidate.swimlanes.some(lane =>
+				lane.issues.some(issue => issue.id === selectedIssue.id),
+			),
+		);
+		const lane = board?.swimlanes.find(candidate =>
+			candidate.issues.some(issue => issue.id === selectedIssue.id),
+		);
+
+		if (!board || !lane) return null;
+
+		return deriveBoardStats({
+			createdAt: selectedIssue.createdAt,
+			now: Date.now(),
+			history:
+				issueDetail?.issueId === selectedIssue.id ? issueDetail.history : [],
+			lanes: board.swimlanes,
+			currentLaneId: lane.id,
+		});
+	}, [selectedIssue?.id, state, issueDetail]);
 
 	// Typed into the box beside the board switcher; hides cards whose ref and
 	// title both miss it. Not part of the URL selection: it is a passing
@@ -1698,6 +1726,7 @@ export const App = () => {
 										: true
 								}
 								onOpenStatsFile={openStatsFile}
+								boardStats={boardStats}
 								statsError={
 									issueStats?.issueId === selectedIssue.id
 										? issueStats.error

--- a/source/gui/client/components/DiffPanel.tsx
+++ b/source/gui/client/components/DiffPanel.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {memo, useState} from 'react';
 import {
 	DiffFileInput,
 	DiffLineAnnotation,
@@ -55,7 +55,7 @@ export const DIFF_BOX_STYLE: React.CSSProperties = {
 	overflow: 'clip',
 };
 
-export const FileDiffView = <LAnnotation = undefined,>({
+const FileDiffViewInner = <LAnnotation = undefined,>({
 	file,
 	diffStyle,
 	selectedLines,
@@ -78,6 +78,18 @@ export const FileDiffView = <LAnnotation = undefined,>({
 	// Replaces the highlighter's own file header (name, change icon, counts)
 	// with the caller's, in the same sticky slot.
 	renderCustomHeader?: (fileDiff: FileDiffMetadata) => React.ReactNode;
+	/**
+	 * Everything the two render props above close over, as a string.
+	 *
+	 * This component is memoized, and a render prop is a closure: skipping a
+	 * re-render would otherwise leave the header and the annotations drawn from
+	 * whatever state they captured last. The caller says here what they depend
+	 * on — a file's expanded and reviewed flags, the note being typed — and a
+	 * change to it is what lets the re-render through. Omitted, the diff never
+	 * re-renders for anything but its own data, which is right for a caller
+	 * whose render props close over nothing.
+	 */
+	renderKey?: string;
 }) => (
 	<div style={DIFF_BOX_STYLE}>
 		<MultiFileDiff
@@ -105,6 +117,65 @@ export const FileDiffView = <LAnnotation = undefined,>({
 		/>
 	</div>
 );
+
+// What a selection is, for comparison: two line numbers and the sides they
+// belong to. Compared by value because it is rebuilt from URL params on every
+// render, so its identity means nothing.
+const sameSelection = (
+	a: SelectedLineRange | null | undefined,
+	b: SelectedLineRange | null | undefined,
+): boolean =>
+	a === b ||
+	(!!a &&
+		!!b &&
+		a.start === b.start &&
+		a.end === b.end &&
+		a.side === b.side &&
+		a.endSide === b.endSide);
+
+// An annotation is a place plus a thing to draw there. The metadata is
+// deliberately not compared: what it holds is the caller's, and `renderKey` is
+// where the caller declares that it changed.
+const sameAnnotations = <L,>(
+	a: DiffLineAnnotation<L>[] | undefined,
+	b: DiffLineAnnotation<L>[] | undefined,
+): boolean => {
+	if (a === b) return true;
+	if (!a || !b || a.length !== b.length) return false;
+
+	return a.every(
+		(annotation, index) =>
+			annotation.side === b[index]?.side &&
+			annotation.lineNumber === b[index]?.lineNumber,
+	);
+};
+
+/**
+ * Memoized, because this is the expensive boundary in the whole client: below
+ * it sits the syntax highlighter and one DOM node per line of the file.
+ *
+ * The board broadcasts its whole state on every sync, and a sync that changed
+ * nothing about this ticket still rebuilt the arrays this tree is drawn from —
+ * measured at four full re-renders of every open file per broadcast, for a
+ * board that had not changed. None of the props that matter had changed; only
+ * their identities had.
+ *
+ * So the comparison is by value, and `renderKey` carries what the render props
+ * close over. Without that key a memo here would be quietly wrong rather than
+ * merely useless: the header and the composer are closures, and skipping their
+ * re-render would freeze them.
+ */
+export const FileDiffView = memo(FileDiffViewInner, (previous, next) => {
+	return (
+		previous.file === next.file &&
+		previous.diffStyle === next.diffStyle &&
+		previous.renderKey === next.renderKey &&
+		sameSelection(previous.selectedLines, next.selectedLines) &&
+		sameAnnotations(previous.lineAnnotations, next.lineAnnotations)
+	);
+	// A generic component loses its type parameter through `memo`; the cast
+	// hands it back, so callers still infer their own annotation metadata.
+}) as typeof FileDiffViewInner;
 
 // This panel has no per-file disclosure to hide behind — it opens every file
 // of a commit at once — so a lockfile here stalls the view with no action from

--- a/source/gui/client/components/FileRow.tsx
+++ b/source/gui/client/components/FileRow.tsx
@@ -292,6 +292,20 @@ export const FileRow = ({
 		});
 	}
 
+	// Everything the two render props below read that is not handed to them by
+	// the diff itself. FileDiffView is memoized on this, so a value the header
+	// or the composer draws from and that is missing here would freeze on
+	// screen — see its own note.
+	const renderKey = [
+		expanded,
+		reviewed,
+		fileComments.length,
+		note,
+		selection ? `${selection.start}-${selection.end}` : '',
+		hoveredRange ? `${hoveredRange.start}-${hoveredRange.end}` : '',
+		ticketTitle,
+	].join('|');
+
 	const header = () => (
 		<FileHeader
 			file={file}
@@ -310,6 +324,7 @@ export const FileRow = ({
 					<FileDiffView
 						file={file}
 						diffStyle={diffStyle}
+						renderKey={renderKey}
 						selectedLines={hoveredRange ?? selection}
 						onSelectionEnd={setSelection}
 						lineAnnotations={lineAnnotations}

--- a/source/gui/client/components/IssueDetails.tsx
+++ b/source/gui/client/components/IssueDetails.tsx
@@ -77,6 +77,11 @@ const LANE_SHARES = {
 type LaneKey = keyof typeof LANE_SHARES;
 const LANE_KEYS = Object.keys(LANE_SHARES) as LaneKey[];
 
+// Below this the five tabs and their counts no longer fit on one line, and
+// each label wraps under its own number. Measured against the longest set the
+// panel has — Overview, Comments, Commits, Stats, Log — rather than guessed.
+const TAB_COUNTS_WIDTH = 430;
+
 // Wide enough for the upright label and a comfortable click target.
 const COLLAPSED_LANE_WIDTH = 28;
 // Long enough to read as a movement, short enough not to be waited on.
@@ -974,6 +979,7 @@ export const IssueDetails = ({
 						error={statsError}
 						onOpenFile={onOpenStatsFile}
 						boardStats={boardStats}
+						compact={panelWidth < TAB_COUNTS_WIDTH}
 					/>
 				);
 
@@ -1163,6 +1169,7 @@ export const IssueDetails = ({
 											tabs={tabs}
 											activeTab={activeTab}
 											onChange={onChangeTab}
+											showCounts={panelWidth >= TAB_COUNTS_WIDTH}
 										/>
 										{activeTab === 'overview' && overviewPane}
 										{activeTab === 'comments' && commentsPane}

--- a/source/gui/client/components/IssueDetails.tsx
+++ b/source/gui/client/components/IssueDetails.tsx
@@ -50,6 +50,7 @@ import {Section} from './Section';
 import {Tabs, TabItem} from './Tabs';
 import {IssueStats} from './IssueStats';
 import {IssueStats as IssueStatsPayload} from '../../../lib/stats/issue-stats.model.js';
+import {BoardStats} from '../../../lib/stats/board-stats.js';
 import {IssueHistory} from './IssueHistory';
 import {formatAbsolute, timeAgo} from '../lib/gui-format.helper';
 import {usePersistedFlag} from '../lib/use-persisted-flag';
@@ -283,6 +284,7 @@ export const IssueDetails = ({
 	statsLoading,
 	statsError,
 	onOpenStatsFile,
+	boardStats,
 	knownTags: tags,
 	knownAssignees: assignees,
 	onOpenAssigneePicker,
@@ -337,6 +339,9 @@ export const IssueDetails = ({
 	statsError: string | null;
 	// Following a file from the Stats tab into its diff on the Commits tab.
 	onOpenStatsFile?: (file: {sha: string; path: string}) => void;
+	// The board half of the Stats tab, worked out by the caller: what counts as
+	// backwards is a fact about lane order, which lives up there.
+	boardStats: BoardStats | null;
 	knownTags: GuiTag[];
 	knownAssignees: GuiContributor[];
 	// Fired when the picker opens, so the caller can fetch the list only then.
@@ -968,6 +973,7 @@ export const IssueDetails = ({
 						loading={statsLoading}
 						error={statsError}
 						onOpenFile={onOpenStatsFile}
+						boardStats={boardStats}
 					/>
 				);
 

--- a/source/gui/client/components/IssueStats.tsx
+++ b/source/gui/client/components/IssueStats.tsx
@@ -15,9 +15,11 @@ import {
 	STAT_NOTE,
 	STAT_VALUE,
 	COMMENT_YELLOW,
+	inDays,
 	seriesColor,
 } from '../lib/issue-stats.style';
 import {ProportionBar, StackedBar} from './StatBars';
+import {BoardStats} from '../../../lib/stats/board-stats.js';
 import {Empty} from './FormPrimitives';
 import {Section} from './Section';
 
@@ -151,11 +153,44 @@ const Row = ({
 const Note = ({when, children}: {when: boolean; children: React.ReactNode}) =>
 	when ? <div style={LINE}>{children}</div> : null;
 
+/**
+ * The other half of a ticket: not what the code says, but what the board has
+ * done with it. A ticket can be old because it is hard or because nobody
+ * looked at it, and the third figure — how long it has sat where it is now —
+ * is what separates the two.
+ *
+ * Its own component because it is the one section that still means something
+ * for a ticket with no code at all. That is, in fact, when it means most.
+ */
+const BoardSection = ({
+	boardStats,
+	first = false,
+}: {
+	boardStats: BoardStats | null;
+	first?: boolean;
+}) =>
+	boardStats ? (
+		<Section title="Board" first={first}>
+			<div style={STAT_GRID}>
+				<Stat value={inDays(boardStats.ageMs)} label="Days old" />
+				<Stat
+					value={String(boardStats.timesSentBack)}
+					label="Times sent back"
+				/>
+				<Stat
+					value={inDays(boardStats.inLaneMs)}
+					label={`Days in ${boardStats.laneTitle}`}
+				/>
+			</div>
+		</Section>
+	) : null;
+
 export const IssueStats = ({
 	stats,
 	loading,
 	error,
 	onOpenFile,
+	boardStats,
 }: {
 	stats: Stats | null;
 	loading: boolean;
@@ -163,6 +198,8 @@ export const IssueStats = ({
 	// Opens a file's diff on the Commits tab. Absent on a readonly board, where
 	// there is still everything to read and nowhere to click to.
 	onOpenFile?: (file: FilePointer) => void;
+	// Null while the board has yet to arrive, or for a ticket no lane holds.
+	boardStats: BoardStats | null;
 }) => {
 	if (error) return <Empty>{error}</Empty>;
 	if (loading || !stats)
@@ -170,12 +207,21 @@ export const IssueStats = ({
 
 	const {shape, languages, tests, comments, flags} = stats;
 
+	// No code yet is not nothing to say: how long a ticket has been open, and
+	// how long it has sat where it is, is the whole story of one that has not
+	// been started.
 	if (shape.commits === 0) {
 		return (
-			<Empty>
-				No commit carries this ticket&rsquo;s ref, so there is no code to
-				measure. That is not the same as no work.
-			</Empty>
+			<div style={{fontSize: TEXT.ui}}>
+				<BoardSection boardStats={boardStats} first />
+
+				<Section title="Code">
+					<div style={LINE}>
+						No commit carries this ticket&rsquo;s ref, so there is no code to
+						measure. That is not the same as no work.
+					</div>
+				</Section>
+			</div>
 		);
 	}
 
@@ -206,11 +252,7 @@ export const IssueStats = ({
 							.filter(Boolean)
 							.join(' · ')}
 					/>
-					<Stat
-						value={String(shape.directories)}
-						label="Directories"
-						note={plural(shape.commits, 'commit')}
-					/>
+					<Stat value={String(shape.directories)} label="Directories" />
 					<Stat
 						value={percent(shape.concentration)}
 						label="In one file"
@@ -226,7 +268,6 @@ export const IssueStats = ({
 					<Stat
 						value={String(shape.authors.length)}
 						label={shape.authors.length === 1 ? 'Author' : 'Authors'}
-						note={shape.authors.join(', ')}
 					/>
 				</div>
 
@@ -242,15 +283,7 @@ export const IssueStats = ({
 
 			<Section title="Tests">
 				<div style={STAT_GRID}>
-					<Stat
-						value={String(tests.testLinesAdded)}
-						label="Test lines added"
-						note={
-							tests.addedTestFiles.length > 0
-								? plural(tests.addedTestFiles.length, 'new file')
-								: 'in files that already existed'
-						}
-					/>
+					<Stat value={String(tests.testLinesAdded)} label="Test lines added" />
 					<Stat
 						value={String(tests.addedTestFiles.length)}
 						label={
@@ -410,6 +443,9 @@ export const IssueStats = ({
 					</Note>
 				</Section>
 			)}
+
+			{/* Last, because it is the only section that is not about the diff. */}
+			<BoardSection boardStats={boardStats} />
 		</div>
 	);
 };

--- a/source/gui/client/components/IssueStats.tsx
+++ b/source/gui/client/components/IssueStats.tsx
@@ -10,7 +10,7 @@ import {
 	ROW,
 	shortPath,
 	STAT_CELL,
-	STAT_GRID,
+	statGrid,
 	STAT_LABEL,
 	STAT_NOTE,
 	STAT_VALUE,
@@ -94,7 +94,18 @@ const Stat = ({
 	label: string;
 	note?: React.ReactNode;
 }) => (
-	<div style={STAT_CELL}>
+	<div
+		style={STAT_CELL}
+		// The same lift every hoverable surface in the app takes, so a figure
+		// under the pointer separates from the four beside it — and a path in
+		// the note below reads as part of that block rather than as loose text.
+		onMouseEnter={event => {
+			event.currentTarget.style.background = GUI_THEME.hover;
+		}}
+		onMouseLeave={event => {
+			event.currentTarget.style.background = 'transparent';
+		}}
+	>
 		<div style={STAT_VALUE}>{value}</div>
 		<div style={STAT_LABEL}>{label}</div>
 		{note && <div style={STAT_NOTE}>{note}</div>}
@@ -164,14 +175,16 @@ const Note = ({when, children}: {when: boolean; children: React.ReactNode}) =>
  */
 const BoardSection = ({
 	boardStats,
+	compact,
 	first = false,
 }: {
 	boardStats: BoardStats | null;
+	compact: boolean;
 	first?: boolean;
 }) =>
 	boardStats ? (
 		<Section title="Board" first={first}>
-			<div style={STAT_GRID}>
+			<div style={statGrid(compact)}>
 				<Stat value={inDays(boardStats.ageMs)} label="Days old" />
 				<Stat
 					value={String(boardStats.timesSentBack)}
@@ -191,6 +204,7 @@ export const IssueStats = ({
 	error,
 	onOpenFile,
 	boardStats,
+	compact = false,
 }: {
 	stats: Stats | null;
 	loading: boolean;
@@ -200,6 +214,8 @@ export const IssueStats = ({
 	onOpenFile?: (file: FilePointer) => void;
 	// Null while the board has yet to arrive, or for a ticket no lane holds.
 	boardStats: BoardStats | null;
+	// The panel is too narrow for four figures across.
+	compact?: boolean;
 }) => {
 	if (error) return <Empty>{error}</Empty>;
 	if (loading || !stats)
@@ -213,7 +229,7 @@ export const IssueStats = ({
 	if (shape.commits === 0) {
 		return (
 			<div style={{fontSize: TEXT.ui}}>
-				<BoardSection boardStats={boardStats} first />
+				<BoardSection boardStats={boardStats} compact={compact} first />
 
 				<Section title="Code">
 					<div style={LINE}>
@@ -238,7 +254,7 @@ export const IssueStats = ({
 	return (
 		<div style={{fontSize: TEXT.ui}}>
 			<Section title="Code" first>
-				<div style={STAT_GRID}>
+				<div style={statGrid(compact)}>
 					<Stat
 						value={String(shape.files)}
 						label="Files"
@@ -282,7 +298,7 @@ export const IssueStats = ({
 			</Section>
 
 			<Section title="Tests">
-				<div style={STAT_GRID}>
+				<div style={statGrid(compact)}>
 					<Stat value={String(tests.testLinesAdded)} label="Test lines added" />
 					<Stat
 						value={String(tests.addedTestFiles.length)}
@@ -445,7 +461,7 @@ export const IssueStats = ({
 			)}
 
 			{/* Last, because it is the only section that is not about the diff. */}
-			<BoardSection boardStats={boardStats} />
+			<BoardSection boardStats={boardStats} compact={compact} />
 		</div>
 	);
 };

--- a/source/gui/client/components/StatBars.tsx
+++ b/source/gui/client/components/StatBars.tsx
@@ -2,13 +2,14 @@ import {GUI_THEME} from '../lib/gui-theme';
 
 // The two bars the Stats tab draws, and the only colour on it.
 //
-// Both are the same 8px mark: thin, rounded at the ends of the whole bar and
-// square where segments meet, with a 2px gap in the panel colour doing the
-// separating rather than a stroke. Neither carries a legend of its own — the
-// rows underneath name every segment and repeat its colour, so identity is
-// never colour alone.
+// Both are the same 4px mark: thin enough to read as a measure beside the
+// figures rather than as a block competing with them. Rounded at the ends of
+// the whole bar, square where segments meet, with a 2px gap in the panel
+// colour doing the separating rather than a stroke. Neither carries a legend
+// of its own — the rows underneath name every segment and repeat its colour,
+// so identity is never colour alone.
 
-const BAR_HEIGHT = 8;
+const BAR_HEIGHT = 4;
 const SEGMENT_GAP = 2;
 
 export type BarSegment = {

--- a/source/gui/client/components/Tabs.tsx
+++ b/source/gui/client/components/Tabs.tsx
@@ -10,12 +10,17 @@ type Props<T extends string> = {
 	activeTab: T;
 	tabs: TabItem<T>[];
 	onChange: (tab: T) => void;
+	// False in a panel too narrow to hold five tabs and their counts on one
+	// line. The count is the first thing to go: a tab whose name has wrapped
+	// under its own number is harder to read than one without the number.
+	showCounts?: boolean;
 };
 
 export const Tabs = <T extends string>({
 	activeTab,
 	tabs,
 	onChange,
+	showCounts = true,
 }: Props<T>) => (
 	<div
 		style={{
@@ -48,7 +53,7 @@ export const Tabs = <T extends string>({
 					}}
 				>
 					{tab.label}
-					{typeof tab.count === 'number' && (
+					{showCounts && typeof tab.count === 'number' && (
 						<span
 							style={{color: tab.count ? GUI_THEME.secondary : GUI_THEME.dim}}
 						>

--- a/source/gui/client/lib/gui-state.model.ts
+++ b/source/gui/client/lib/gui-state.model.ts
@@ -66,6 +66,9 @@ export type GuiIssueHistoryEntry = {
 	action: string;
 	label: string;
 	actor: GuiUser;
+	// Which lane a move put the ticket in — moves only. What the Stats tab
+	// counts to say a ticket has gone backwards.
+	parentId?: string;
 };
 
 export type GuiTimeTravelStatus = {

--- a/source/gui/client/lib/issue-stats.style.ts
+++ b/source/gui/client/lib/issue-stats.style.ts
@@ -9,28 +9,39 @@
 
 import {GUI_THEME} from './gui-theme';
 
-export const STAT_GRID: React.CSSProperties = {
+/**
+ * Four across where there is room, two by two where there is not.
+ *
+ * Explicit rather than auto-fit: left to itself the grid drops to three
+ * columns first, which puts one stat of four alone on a second row and reads
+ * as a mistake. Two by two is a layout.
+ */
+export const statGrid = (compact: boolean): React.CSSProperties => ({
 	display: 'grid',
-	// Narrow enough that four stats still sit on one row in the panel at its
-	// default width — one of four wrapping onto a line of its own reads as a
-	// mistake rather than as a layout. Labels wrap instead, which reads fine.
-	gridTemplateColumns: 'repeat(auto-fit, minmax(82px, 1fr))',
+	gridTemplateColumns: compact
+		? 'repeat(2, 1fr)'
+		: 'repeat(auto-fit, minmax(82px, 1fr))',
 	gap: 16,
 	marginTop: 14,
-};
+});
 
 export const STAT_CELL: React.CSSProperties = {
 	display: 'flex',
 	flexDirection: 'column',
 	alignItems: 'center',
 	textAlign: 'center',
-	gap: 3,
+	gap: 4,
 	minWidth: 0,
+	// Room for the hover ground to sit around the figure rather than against
+	// it, and a shape for it to be.
+	padding: '6px 4px',
+	borderRadius: 6,
+	transition: 'background 120ms ease',
 };
 
 export const STAT_VALUE: React.CSSProperties = {
 	color: GUI_THEME.primary,
-	fontSize: 30,
+	fontSize: 38,
 	lineHeight: 1,
 	// Tabular-ish spacing: a column of figures that shifts as it updates reads
 	// as movement rather than as a number.

--- a/source/gui/client/lib/issue-stats.style.ts
+++ b/source/gui/client/lib/issue-stats.style.ts
@@ -72,6 +72,14 @@ export const percent = (value: number): string => `${Math.round(value * 100)}%`;
 export const plural = (count: number, noun: string): string =>
 	`${count} ${noun}${count === 1 ? '' : 's'}`;
 
+// Whole days, and never "0": a ticket filed this morning has been open for
+// less than a day, which is a different statement from none at all.
+export const inDays = (ms: number): string => {
+	const days = Math.floor(ms / 86_400_000);
+
+	return days < 1 ? '<1' : String(days);
+};
+
 // Only ever the last two segments: the full path is a paragraph in a column
 // this narrow, and the tail is what identifies a file to somebody who knows
 // the repo. The whole path rides along as a title attribute.

--- a/source/lib/stats/board-stats.ts
+++ b/source/lib/stats/board-stats.ts
@@ -1,0 +1,93 @@
+// What the board says about a ticket, as against what its code says.
+//
+// Three facts, all of them from the ticket's own event log: how long it has
+// existed, how often it has gone backwards through the lanes, and how long it
+// has sat where it is now. None of them is a verdict either — a ticket can be
+// old because it is hard, or because nobody looked at it, and the difference is
+// exactly what the third number is for.
+//
+// Types only in, numbers out, no imports: the caller hands over the history it
+// already has, so this costs no read of its own and the GUI, the TUI and the
+// MCP can each derive the same answer from their own copy.
+
+export type BoardMove = {
+	// Epoch ms.
+	t: number;
+	action: string;
+	// The lane the move put the ticket in. Absent on every event that is not a
+	// move, and on a move whose destination the log did not record.
+	parentId?: string;
+};
+
+export type BoardLane = {
+	id: string;
+	title: string;
+};
+
+export type BoardStats = {
+	ageMs: number;
+	// Moves to a lane earlier in the board's order than the one the ticket was
+	// in. Rework, in the only form a board can see it.
+	timesSentBack: number;
+	// Since the move that put it where it is, or since it was filed if it has
+	// never moved.
+	inLaneMs: number;
+	laneTitle: string;
+};
+
+const MOVE = 'move.node';
+
+/**
+ * `lanes` in board order, which is what makes "backwards" mean anything. A
+ * move to a lane the board does not list — the Closed board's own lane, most
+ * often — is counted as neither forwards nor back: it left the board rather
+ * than moving within it.
+ */
+export const deriveBoardStats = ({
+	createdAt,
+	now,
+	history,
+	lanes,
+	currentLaneId,
+}: {
+	createdAt: number;
+	now: number;
+	// Oldest first, as the ticket's log is kept.
+	history: BoardMove[];
+	lanes: BoardLane[];
+	currentLaneId: string;
+}): BoardStats => {
+	const orderById = new Map(lanes.map((lane, index) => [lane.id, index]));
+
+	let timesSentBack = 0;
+	let landedInCurrentAt: number | null = null;
+
+	// Walked forwards, carrying where the ticket was. A ticket is filed into
+	// the board's first lane, so that is where the first move is measured
+	// from; the log records where each move went, never where it came from.
+	let previousIndex: number | null = 0;
+
+	for (const event of history) {
+		if (event.action !== MOVE || !event.parentId) continue;
+
+		const index = orderById.get(event.parentId);
+
+		if (
+			index !== undefined &&
+			previousIndex !== null &&
+			index < previousIndex
+		) {
+			timesSentBack++;
+		}
+
+		if (event.parentId === currentLaneId) landedInCurrentAt = event.t;
+		if (index !== undefined) previousIndex = index;
+	}
+
+	return {
+		ageMs: Math.max(0, now - createdAt),
+		timesSentBack,
+		inLaneMs: Math.max(0, now - (landedInCurrentAt ?? createdAt)),
+		laneTitle: lanes.find(lane => lane.id === currentLaneId)?.title ?? '',
+	};
+};

--- a/source/mcp/api-state.model.ts
+++ b/source/mcp/api-state.model.ts
@@ -76,6 +76,10 @@ export type ApiIssueHistoryEntry = {
 	action: string;
 	label: string;
 	actor: {id: string; name: string; color: string};
+	// Where a move put the ticket, for the move events only. The label already
+	// says it in prose; this says it in a form something can count — which lane
+	// a ticket went to, and so whether it went forwards or back.
+	parentId?: string;
 };
 
 export type ApiBoard = {

--- a/source/mcp/api/issues.ts
+++ b/source/mcp/api/issues.ts
@@ -622,6 +622,9 @@ export const getIssueHistory = (
 			t: ulidTimeMs(event.id),
 			action: event.action,
 			label: describeEvent(event),
+			...(event.action === 'move.node'
+				? {parentId: (event.payload as {parent?: string}).parent}
+				: {}),
 			actor: {
 				id: event.userId,
 				name: event.userName,

--- a/source/test/board-stats.test.ts
+++ b/source/test/board-stats.test.ts
@@ -1,0 +1,128 @@
+import {describe, expect, it} from 'vitest';
+import {deriveBoardStats} from '../lib/stats/board-stats.js';
+
+const DAY = 86_400_000;
+const NOW = 10 * DAY;
+
+const lanes = [
+	{id: 'backlog', title: 'Backlog'},
+	{id: 'ongoing', title: 'Ongoing'},
+	{id: 'review', title: 'Review'},
+	{id: 'done', title: 'Done'},
+];
+
+const moved = (t: number, parentId: string) => ({
+	t,
+	action: 'move.node',
+	parentId,
+});
+
+describe('deriveBoardStats', () => {
+	it('ages a ticket from when it was filed', () => {
+		const stats = deriveBoardStats({
+			createdAt: NOW - 3 * DAY,
+			now: NOW,
+			history: [],
+			lanes,
+			currentLaneId: 'backlog',
+		});
+
+		expect(stats.ageMs).toBe(3 * DAY);
+		expect(stats.laneTitle).toBe('Backlog');
+	});
+
+	// A ticket that has never moved has been in its lane for as long as it has
+	// existed — not for no time at all.
+	it('measures time in lane from filing when nothing has moved', () => {
+		const stats = deriveBoardStats({
+			createdAt: NOW - 3 * DAY,
+			now: NOW,
+			history: [],
+			lanes,
+			currentLaneId: 'backlog',
+		});
+
+		expect(stats.inLaneMs).toBe(3 * DAY);
+	});
+
+	it('measures time in lane from the move that put it there', () => {
+		const stats = deriveBoardStats({
+			createdAt: NOW - 8 * DAY,
+			now: NOW,
+			history: [
+				moved(NOW - 6 * DAY, 'ongoing'),
+				moved(NOW - 2 * DAY, 'review'),
+			],
+			lanes,
+			currentLaneId: 'review',
+		});
+
+		expect(stats.inLaneMs).toBe(2 * DAY);
+		expect(stats.laneTitle).toBe('Review');
+	});
+
+	it('counts a move to an earlier lane, and only that', () => {
+		const stats = deriveBoardStats({
+			createdAt: NOW - 8 * DAY,
+			now: NOW,
+			history: [
+				moved(NOW - 7 * DAY, 'ongoing'),
+				moved(NOW - 6 * DAY, 'review'),
+				// Back to Ongoing: rework.
+				moved(NOW - 5 * DAY, 'ongoing'),
+				moved(NOW - 4 * DAY, 'review'),
+				// And again.
+				moved(NOW - 3 * DAY, 'backlog'),
+			],
+			lanes,
+			currentLaneId: 'backlog',
+		});
+
+		expect(stats.timesSentBack).toBe(2);
+	});
+
+	it('does not count going forwards, however far', () => {
+		const stats = deriveBoardStats({
+			createdAt: NOW - 2 * DAY,
+			now: NOW,
+			history: [moved(NOW - DAY, 'done')],
+			lanes,
+			currentLaneId: 'done',
+		});
+
+		expect(stats.timesSentBack).toBe(0);
+	});
+
+	// Closing a ticket moves it to a lane on another board entirely. That is
+	// leaving, not going backwards.
+	it('ignores a move to a lane this board does not have', () => {
+		const stats = deriveBoardStats({
+			createdAt: NOW - 4 * DAY,
+			now: NOW,
+			history: [
+				moved(NOW - 3 * DAY, 'review'),
+				moved(NOW - DAY, 'closed-lane'),
+			],
+			lanes,
+			currentLaneId: 'review',
+		});
+
+		expect(stats.timesSentBack).toBe(0);
+	});
+
+	it('ignores every event that is not a move', () => {
+		const stats = deriveBoardStats({
+			createdAt: NOW - 4 * DAY,
+			now: NOW,
+			history: [
+				{t: NOW - 3 * DAY, action: 'add.comment'},
+				{t: NOW - 2 * DAY, action: 'edit.title'},
+			],
+			lanes,
+			currentLaneId: 'backlog',
+		});
+
+		expect(stats.timesSentBack).toBe(0);
+		expect(stats.inLaneMs).toBe(4 * DAY);
+	});
+});

--- a/source/test/e2e-gui/issue-stats.pw.ts
+++ b/source/test/e2e-gui/issue-stats.pw.ts
@@ -63,10 +63,10 @@ test('the Stats tab measures the ticket own commits', async ({
 	// its own share.
 	await expect(page.getByTitle(/^TypeScript — \d+%$/)).toBeVisible();
 
-	// The contributor count comes off the commits, so the seeded repo's own
-	// git author is the one named — never the board's assignees.
+	// One author, counted off the commits rather than off the board — the
+	// ticket has no assignee at all, so a board-sourced count would be zero.
+	// The name itself is not shown; the singular label is what says it is one.
 	await expect(page.getByText('Author', {exact: true})).toBeVisible();
-	await expect(page.getByText('e2e', {exact: true})).toBeVisible();
 
 	expect(pageErrors).toEqual([]);
 });
@@ -107,7 +107,9 @@ test('a file named on the Stats tab opens its own diff', async ({
 	expect(pageErrors).toEqual([]);
 });
 
-test('a ticket with no commits says so rather than reporting a change of nothing', async ({
+// A ticket nobody has started is exactly when how long it has been sitting is
+// the whole story, so the board figures stay even with no code to measure.
+test('a ticket with no commits still says how long it has been sitting', async ({
 	page,
 	pageErrors,
 }) => {
@@ -116,5 +118,11 @@ test('a ticket with no commits says so rather than reporting a change of nothing
 	await page.getByRole('button', {name: /^Stats/}).click();
 
 	await expect(page.getByText(/No commit carries this ticket/)).toBeVisible();
+
+	await expect(page.getByText('Days old')).toBeVisible();
+	await expect(page.getByText('Times sent back')).toBeVisible();
+	// The lane the seeded board files a new ticket into, named in the label.
+	await expect(page.getByText(/^Days in /)).toBeVisible();
+
 	expect(pageErrors).toEqual([]);
 });


### PR DESCRIPTION
Three tickets on the Stats tab and its neighbours.

**`B48G3QV` — a Board section.** Days old, times sent back, days in the lane it is in now: the first of `WF435EW`'s Tier 1 to land. Derived in `lib/stats/board-stats.ts`, pure, from the ticket's own history — types in, numbers out, so the TUI and MCP can derive the same answer from their own copy of the log. "Sent back" needed the log to say *where* a move went, which it only said in prose, so `ApiIssueHistoryEntry` now carries `parentId` on moves; the count is moves to a lane earlier in the board's order, and a move to a lane this board does not have (closing a ticket) is neither forwards nor back.

It is also the one section that survives a ticket with no commits. That case used to render nothing at all, which was backwards — how long a ticket has sat is the whole story of one nobody has started.

Notes removed where the label already said it, and the bars go 8px → 4px.

**`HT6AR78` — the diff stops re-rendering on every sync.** Measured first, with a probe and a scripted broadcast that changed nothing about the open ticket: opening a three-file commit rendered 3 times (right), and one unrelated broadcast rendered it **12** times — four full passes per open file. `FileDiffView` is now memoized by value.

The part worth reviewing is `renderKey`. Two props are render *props*, closures over `FileRow`'s state; a memo that ignored them would be quietly wrong rather than merely useless — the reviewed checkbox, the composer's textarea and the hovered range would freeze at whatever they last captured. The caller declares what its closures read, and a change to it lets the render through. After: 3 to open, **0** on a broadcast. All 139 GUI browser tests pass, which is what covers those interactions.

**`H09HCX0` — styling.** Figures 30px → 38px; a hover ground per stat block; the stat grid explicit (four across, or two by two — auto-fit dropped to three first, stranding one of four on its own row); and below 430px the tabs drop their counts rather than wrapping each label under its own number.