### PR TITLE
BW34T5W / 5Y34ENG: the MCP name argument stops naming contributors it shouldn't

### DIFF
--- a/source/lib/config/actor-env.ts
+++ b/source/lib/config/actor-env.ts
@@ -126,7 +126,11 @@ export const applyActorNameArgument = (
 		);
 	}
 
-	env[ACTOR_NAME_ENV] = trimmed;
+	// Only when the variable is not already saying it. With `EPIQ_USER_ID`
+	// pinned, `resolveEnvActor` takes the display name from here verbatim, so
+	// writing the argument's casing over an agreeing variable renames that
+	// contributor on the board.
+	if (!fromEnv) env[ACTOR_NAME_ENV] = trimmed;
 
-	return succeeded('Applied actor name argument', trimmed);
+	return succeeded('Applied actor name argument', fromEnv || trimmed);
 };

--- a/source/mcp/args.ts
+++ b/source/mcp/args.ts
@@ -1,0 +1,55 @@
+import {EPIQ_VERSION} from '../version.js';
+
+const HELP = `epiq-mcp ${EPIQ_VERSION}
+
+Usage: epiq-mcp [name]
+
+  name  the board identity this server writes under, e.g. claude/peter
+        (equivalent to setting EPIQ_USER_NAME)
+
+Options:
+  -v, --version  print the version
+  -h, --help     print this help
+`;
+
+export type McpArgs =
+	| {kind: 'none'}
+	| {kind: 'name'; name: string}
+	| {kind: 'print'; text: string}
+	| {kind: 'error'; message: string};
+
+/**
+ * A flag is never a name. `isValidUserName` only measures length, so an
+ * unchecked argument means `epiq-mcp --version` starts the server under the
+ * identity `--version`, and the first write makes that a contributor the board
+ * cannot be rid of.
+ */
+export const parseMcpArgs = (args: string[]): McpArgs => {
+	if (args.length > 1) {
+		return {
+			kind: 'error',
+			message: `Expected at most one name argument, got ${args.length}`,
+		};
+	}
+
+	const argument = args[0];
+
+	if (argument === undefined) return {kind: 'none'};
+
+	if (argument === '--version' || argument === '-v') {
+		return {kind: 'print', text: `${EPIQ_VERSION}\n`};
+	}
+
+	if (argument === '--help' || argument === '-h') {
+		return {kind: 'print', text: HELP};
+	}
+
+	if (argument.startsWith('-')) {
+		return {
+			kind: 'error',
+			message: `Unknown option ${argument}; expected a name, e.g. epiq-mcp claude/peter`,
+		};
+	}
+
+	return {kind: 'name', name: argument};
+};

--- a/source/mcp/index.ts
+++ b/source/mcp/index.ts
@@ -9,15 +9,22 @@ console.warn = console.error;
 // server, saving every client config an `env` block for the common case.
 const {applyActorNameArgument} = await import('../lib/config/actor-env.js');
 const {isFail} = await import('../lib/model/result-types.js');
-const args = process.argv.slice(2);
+const {parseMcpArgs} = await import('./args.js');
+const parsed = parseMcpArgs(process.argv.slice(2));
 
-if (args.length > 1) {
-	console.error(`Expected at most one name argument, got ${args.length}`);
+if (parsed.kind === 'error') {
+	console.error(parsed.message);
 	process.exit(1);
 }
 
-if (args[0] !== undefined) {
-	const applied = applyActorNameArgument(args[0], 'The name argument');
+// `console.log` is stderr here, and a version is worth piping.
+if (parsed.kind === 'print') {
+	process.stdout.write(parsed.text);
+	process.exit(0);
+}
+
+if (parsed.kind === 'name') {
+	const applied = applyActorNameArgument(parsed.name, 'The name argument');
 
 	if (isFail(applied)) {
 		console.error(applied.message);

--- a/source/test/actor-env.test.ts
+++ b/source/test/actor-env.test.ts
@@ -180,6 +180,18 @@ describe('applyActorNameArgument', () => {
 
 		expect(isFail(applyActorNameArgument('claude', '--as', env))).toBe(false);
 	});
+
+	// The unpinned path normalizes and hides this: only a pinned id carries the
+	// variable's casing through to the display name.
+	it('keeps the environment casing when a pinned actor already agrees', () => {
+		const env = {[ACTOR_NAME_ENV]: 'Claude', [ACTOR_ID_ENV]: PINNED_ID};
+
+		expect(applyActorNameArgument('claude', '--as', env).value).toBe('Claude');
+		expect(resolveEnvActor(CONFIGURED, env).value).toEqual({
+			userId: PINNED_ID,
+			userName: 'Claude',
+		});
+	});
 });
 
 describe('loadSettingsFromConfig', () => {

--- a/source/test/mcp-args.test.ts
+++ b/source/test/mcp-args.test.ts
@@ -1,0 +1,50 @@
+import {describe, expect, it} from 'vitest';
+import {parseMcpArgs} from '../mcp/args.js';
+import {EPIQ_VERSION} from '../version.js';
+
+describe('parseMcpArgs', () => {
+	it('reads a bare argument as the name to write under', () => {
+		expect(parseMcpArgs(['claude/peter'])).toEqual({
+			kind: 'name',
+			name: 'claude/peter',
+		});
+	});
+
+	it('asks for nothing when there is no argument', () => {
+		expect(parseMcpArgs([])).toEqual({kind: 'none'});
+	});
+
+	// The first write under a flag-shaped name registers a contributor the
+	// board can never be rid of.
+	it.each(['--version', '-v', '--help', '-h', '--unknown', '-x'])(
+		'never takes %s as a name',
+		flag => {
+			expect(parseMcpArgs([flag]).kind).not.toBe('name');
+		},
+	);
+
+	it('prints the version', () => {
+		expect(parseMcpArgs(['--version'])).toEqual({
+			kind: 'print',
+			text: `${EPIQ_VERSION}\n`,
+		});
+	});
+
+	it('prints help naming the argument', () => {
+		const parsed = parseMcpArgs(['--help']);
+
+		expect(parsed.kind).toBe('print');
+		expect(parsed.kind === 'print' && parsed.text).toContain('claude/peter');
+	});
+
+	it('refuses an unknown option rather than guessing', () => {
+		const parsed = parseMcpArgs(['--as']);
+
+		expect(parsed.kind).toBe('error');
+		expect(parsed.kind === 'error' && parsed.message).toContain('--as');
+	});
+
+	it('refuses more than one argument', () => {
+		expect(parseMcpArgs(['a', 'b']).kind).toBe('error');
+	});
+});


### PR DESCRIPTION
Two bugs from the review of FKJRG4M (PR #172), both in how a launch-time name argument reaches the board.

**BW34T5W** — `isValidUserName` only measures length, so `epiq-mcp --version` started the server silently under the identity `--version`; the first write would make that a permanent contributor `tombstoneContributor` then refuses to remove. Argument parsing moves to `source/mcp/args.ts`: `--version`/`-v` print the version, `--help`/`-h` print usage, any other `-`-prefixed argument is refused, and only a bare argument is read as a name.

**5Y34ENG** — `applyActorNameArgument` wrote the argument's casing into `EPIQ_USER_NAME` even when the variable already agreed case-insensitively. With `EPIQ_USER_ID` pinned, `resolveEnvActor` takes the display name from there verbatim, so `--as claude` alongside `EPIQ_USER_NAME=Claude` renamed that contributor on the board at the first write. The variable is now left in place when it already names the actor.

Tests: new `mcp-args.test.ts`; a pinned-id case added to `actor-env.test.ts`, verified red without the fix. Unit gate and GUI e2e green.