### PR TITLE
Read the board before the code: the Board section goes first

### DIFF
--- a/source/gui/client/components/IssueStats.tsx
+++ b/source/gui/client/components/IssueStats.tsx
@@ -253,7 +253,12 @@ export const IssueStats = ({
 
 	return (
 		<div style={{fontSize: TEXT.ui}}>
-			<Section title="Code" first>
+			{/* First: what the board has done with a ticket is the frame the
+			    code is read in — whether this change is a week old and still
+			    moving, or has been sent back twice already. */}
+			<BoardSection boardStats={boardStats} compact={compact} first />
+
+			<Section title="Code">
 				<div style={statGrid(compact)}>
 					<Stat
 						value={String(shape.files)}
@@ -459,9 +464,6 @@ export const IssueStats = ({
 					</Note>
 				</Section>
 			)}
-
-			{/* Last, because it is the only section that is not about the diff. */}
-			<BoardSection boardStats={boardStats} compact={compact} />
 		</div>
 	);
 };


### PR DESCRIPTION
A follow-up on `B48G3QV`, folded into that ticket rather than a new one.

I had the Board section last, on the reasoning that it is the only section not about the diff. That has it backwards: what the board has done with a ticket is the frame the code is read in. Whether a change is a week old and still moving, or has been sent back twice already, is what decides how hard to look at the diff underneath it — reading that afterwards is reading it too late.

It also matches what the tab already did for a ticket with no commits, where the board figures were the only thing on the page.