### PR TITLE
3E7QF7A / F2RWXD0 / GCYVZR3 / Z486QVM: four small backlog tickets

### DIFF
--- a/source/gui/client/components/Button.tsx
+++ b/source/gui/client/components/Button.tsx
@@ -34,7 +34,7 @@ export const Button = ({
 						? 'rgb(41, 44, 57)'
 						: GUI_THEME.tertiary
 					: hovered
-					? 'rgba(255,255,255,0.04)'
+					? GUI_THEME.hover
 					: 'transparent',
 				color: GUI_THEME.secondary,
 				border: isPrimary

--- a/source/gui/client/components/CommitRow.tsx
+++ b/source/gui/client/components/CommitRow.tsx
@@ -9,11 +9,7 @@ import {Empty} from './FormPrimitives';
 import {IconChevronDown} from './IconChevronDown';
 import {IconChevronRight} from './IconChevronRight';
 import {FileTicketParams, CommitFocus} from '../lib/diff-selection';
-import {
-	COMMIT_HEADER_PADDING,
-	disclosureStyle,
-	DISCLOSURE_HOVER_BG,
-} from '../lib/commit-row.style';
+import {COMMIT_HEADER_PADDING, disclosureStyle} from '../lib/commit-row.style';
 import {DiffStat} from './DiffStat';
 import {FileRow} from './FileRow';
 import {CommitDiffState} from '../lib/use-issue-detail';
@@ -100,7 +96,7 @@ export const CommitRow = ({
 				style={{
 					...disclosureStyle,
 					padding: `${COMMIT_HEADER_PADDING}px 14px`,
-					background: revealed ? DISCLOSURE_HOVER_BG : 'transparent',
+					background: revealed ? GUI_THEME.hover : 'transparent',
 				}}
 			>
 				{/* The caret leads, as it does on the file rows, so a row reads as

--- a/source/gui/client/components/CopyShaButton.tsx
+++ b/source/gui/client/components/CopyShaButton.tsx
@@ -50,7 +50,7 @@ export const CopyShaButton = ({sha}: {sha: string}) => {
 				transition: 'color 120ms ease, background 120ms ease',
 			}}
 			onMouseEnter={event => {
-				event.currentTarget.style.background = 'rgba(255,255,255,0.04)';
+				event.currentTarget.style.background = GUI_THEME.hover;
 				if (!copied) event.currentTarget.style.color = GUI_THEME.accent;
 			}}
 			onMouseLeave={event => {

--- a/source/gui/client/components/DiffPanel.tsx
+++ b/source/gui/client/components/DiffPanel.tsx
@@ -8,7 +8,7 @@ import {
 	SelectedLineRange,
 } from '@pierre/diffs/react';
 import {GUI_THEME} from '../lib/gui-theme';
-import {CODE_TEXT_VARS} from '../lib/code-text.style';
+import {CODE_FONT, CODE_TEXT_VARS} from '../lib/code-text.style';
 import {GuiCommitDiffFile} from '../lib/gui-state.model';
 import {diffLineCount, isLargeDiff} from '../../../lib/utils/diff-size.js';
 import {Button} from './Button';
@@ -212,7 +212,7 @@ const PanelFile = ({
 		>
 			<span
 				style={{
-					fontFamily: 'ui-monospace, monospace',
+					fontFamily: CODE_FONT,
 					overflow: 'hidden',
 					textOverflow: 'ellipsis',
 					whiteSpace: 'nowrap',

--- a/source/gui/client/components/DiffStat.tsx
+++ b/source/gui/client/components/DiffStat.tsx
@@ -1,4 +1,5 @@
 import {GUI_THEME, TEXT} from '../lib/gui-theme';
+import {CODE_FONT} from '../lib/code-text.style';
 
 // A rounded pill rather than GitHub's five solid squares — matches the
 // rest of the app's soft, rounded chrome instead of copying its exact look.
@@ -21,7 +22,7 @@ export const DiffStat = ({
 				alignItems: 'center',
 				gap: 6,
 				flexShrink: 0,
-				fontFamily: 'ui-monospace, monospace',
+				fontFamily: CODE_FONT,
 				fontSize: TEXT.meta,
 			}}
 		>

--- a/source/gui/client/components/DockButtons.tsx
+++ b/source/gui/client/components/DockButtons.tsx
@@ -38,8 +38,7 @@ const DockButton = ({
 				// row of dim ones says which it is without adding a frame the rest
 				// of this header does not have.
 				color: active ? GUI_THEME.accent : GUI_THEME.dim,
-				background:
-					active || hovered ? 'rgba(255,255,255,0.04)' : 'transparent',
+				background: active || hovered ? GUI_THEME.hover : 'transparent',
 				transition: 'color 120ms ease, background 120ms ease',
 			}}
 		>

--- a/source/gui/client/components/FileRow.tsx
+++ b/source/gui/client/components/FileRow.tsx
@@ -19,7 +19,8 @@ import {
 	findDiffCommentsForFile,
 	FileTicketParams,
 } from '../lib/diff-selection';
-import {disclosureStyle, DISCLOSURE_HOVER_BG} from '../lib/commit-row.style';
+import {disclosureStyle} from '../lib/commit-row.style';
+import {CODE_FONT} from '../lib/code-text.style';
 import {DiffStat} from './DiffStat';
 import {SelectionComposer} from './SelectionComposer';
 
@@ -126,7 +127,7 @@ const FileHeader = ({
 					width: 'auto',
 					color: GUI_THEME.secondary,
 					padding: '4px 6px',
-					background: lit ? DISCLOSURE_HOVER_BG : 'transparent',
+					background: lit ? GUI_THEME.hover : 'transparent',
 				}}
 			>
 				{expanded ? (
@@ -136,7 +137,7 @@ const FileHeader = ({
 				)}
 				<span
 					style={{
-						fontFamily: 'ui-monospace, monospace',
+						fontFamily: CODE_FONT,
 						overflow: 'hidden',
 						textOverflow: 'ellipsis',
 						whiteSpace: 'nowrap',

--- a/source/gui/client/components/FullscreenToggleButton.tsx
+++ b/source/gui/client/components/FullscreenToggleButton.tsx
@@ -28,7 +28,7 @@ export const FullscreenToggleButton = ({
 			transition: 'color 120ms ease, background 120ms ease',
 		}}
 		onMouseEnter={event => {
-			event.currentTarget.style.background = 'rgba(255,255,255,0.04)';
+			event.currentTarget.style.background = GUI_THEME.hover;
 			event.currentTarget.style.color = GUI_THEME.accent;
 		}}
 		onMouseLeave={event => {

--- a/source/gui/client/components/IssueDetails.tsx
+++ b/source/gui/client/components/IssueDetails.tsx
@@ -129,7 +129,7 @@ const LaneIconButton = ({
 			...style,
 		}}
 		onMouseEnter={event => {
-			event.currentTarget.style.background = 'rgba(255,255,255,0.04)';
+			event.currentTarget.style.background = GUI_THEME.hover;
 			event.currentTarget.style.color = GUI_THEME.accent;
 		}}
 		onMouseLeave={event => {

--- a/source/gui/client/components/KebabMenu.tsx
+++ b/source/gui/client/components/KebabMenu.tsx
@@ -63,7 +63,7 @@ export const KebabMenu = ({
 				style={{
 					appearance: 'none',
 					WebkitAppearance: 'none',
-					background: hovered ? 'rgba(255,255,255,0.04)' : 'transparent',
+					background: hovered ? GUI_THEME.hover : 'transparent',
 					border: `1px solid ${
 						open || hovered ? GUI_THEME.line : 'transparent'
 					}`,

--- a/source/gui/client/lib/commit-row.style.ts
+++ b/source/gui/client/lib/commit-row.style.ts
@@ -27,6 +27,3 @@ export const disclosureStyle: React.CSSProperties = {
 	fontSize: TEXT.ui,
 	transition: 'background 120ms ease',
 };
-
-// Says "this opens" before it is clicked.
-export const DISCLOSURE_HOVER_BG = 'rgba(255,255,255,0.04)';

--- a/source/gui/client/lib/scrubber.test.ts
+++ b/source/gui/client/lib/scrubber.test.ts
@@ -32,6 +32,7 @@ import {
 	hourFractionForTime,
 	isScope,
 	populatedRange,
+	scopeButtonLabel,
 	SCOPES,
 	SCRUBBER_KEYFRAMES,
 	segmentAt,
@@ -799,6 +800,28 @@ describe('identity views', () => {
 	});
 });
 
+// Filed as Z486QVM: the step from a month to a year was the widest gap in the
+// row, so a half-year sits between them.
+describe('halfyear scope', () => {
+	it('sits between the month and the year', () => {
+		expect(SCOPES[4]).toBe('halfyear');
+		expect(isScope('halfyear')).toBe(true);
+	});
+
+	it('spans six of the month scope, not half of the year', () => {
+		const range = getPeriodRange('halfyear', 0);
+
+		expect(range!.end - range!.start).toBe(180 * DAY);
+	});
+
+	it('names itself in months, since capitalizing its id would not', () => {
+		expect(scopeButtonLabel('halfyear')).toBe('6 months');
+		expect(
+			formatPeriodLabel('halfyear', 0, getPeriodRange('halfyear', 0)),
+		).toBe('Last 180 days');
+	});
+});
+
 describe('day scope', () => {
 	it('sits directly under the hour', () => {
 		expect(SCOPES[1]).toBe('day');
@@ -1157,6 +1180,7 @@ describe('hour scope', () => {
 			'day',
 			'week',
 			'month',
+			'halfyear',
 			'year',
 			'all',
 		]);

--- a/source/gui/client/lib/scrubber/time.ts
+++ b/source/gui/client/lib/scrubber/time.ts
@@ -125,7 +125,14 @@ export const formatInterval = (start: number, end: number): string => {
 
 // --------------------------------------------------------------------- scope
 
-export type Scope = 'all' | 'hour' | 'day' | 'week' | 'month' | 'year';
+export type Scope =
+	| 'all'
+	| 'hour'
+	| 'day'
+	| 'week'
+	| 'month'
+	| 'halfyear'
+	| 'year';
 
 export type PeriodRange = {start: number; end: number};
 
@@ -134,15 +141,19 @@ export const SCOPES: readonly Scope[] = [
 	'day',
 	'week',
 	'month',
+	'halfyear',
 	'year',
 	'all',
 ];
 
+// Six of the month above rather than half of the year below, so stepping the
+// pager by a half-year lands on month boundaries the month scope also uses.
 const SCOPE_DURATION_MS: Record<Exclude<Scope, 'all'>, number> = {
 	hour: 60 * 60 * 1000,
 	day: 24 * 60 * 60 * 1000,
 	week: 7 * 24 * 60 * 60 * 1000,
 	month: 30 * 24 * 60 * 60 * 1000,
+	halfyear: 180 * 24 * 60 * 60 * 1000,
 	year: 365 * 24 * 60 * 60 * 1000,
 };
 
@@ -153,6 +164,7 @@ const SCOPE_RECENT_LABELS: Record<Exclude<Scope, 'all'>, string> = {
 	day: 'Last 24 hours',
 	week: 'Last 7 days',
 	month: 'Last 30 days',
+	halfyear: 'Last 180 days',
 	year: 'Last 365 days',
 };
 
@@ -204,7 +216,12 @@ export const formatPeriodLabel = (
 	return compactRangeLabel(range);
 };
 
+// Every other scope names its own period, so capitalizing the id is the label.
 export const scopeButtonLabel = (scope: Scope): string =>
-	scope === 'all' ? 'All' : scope[0]!.toUpperCase() + scope.slice(1);
+	scope === 'all'
+		? 'All'
+		: scope === 'halfyear'
+		? '6 months'
+		: scope[0]!.toUpperCase() + scope.slice(1);
 
 // ---------------------------------------------------------------- animations

--- a/source/lib/event/event-load.ts
+++ b/source/lib/event/event-load.ts
@@ -384,13 +384,6 @@ function loadAllPersistedEvents(
 	return succeeded('All events loaded', sorted);
 }
 
-// What the last full load found. Held here rather than in `AppState` because
-// `resetState()` wipes that, and the paths that rebuild live state after a
-// checkout have to re-apply the locks on the other side of exactly that reset.
-let lastUnreadable: UnreadableEvent[] = [];
-
-export const getLastUnreadableEvents = (): UnreadableEvent[] => lastUnreadable;
-
 // Boot paths use this to lock where history is unreadable; readers wanting
 // only the events use `loadMergedEvents`.
 export function loadMergedEventsWithUnreadable(
@@ -405,8 +398,6 @@ export function loadMergedEventsWithUnreadable(
 
 	const decoded = decodeReconstructedEvents(allEvents.value, unreadable);
 	if (isFail(decoded)) return failed(decoded.message);
-
-	lastUnreadable = unreadable;
 
 	return succeeded('Loaded merged events', {events: decoded.value, unreadable});
 }

--- a/source/test/e2e-gui/fullscreen-lanes.pw.ts
+++ b/source/test/e2e-gui/fullscreen-lanes.pw.ts
@@ -120,9 +120,15 @@ test('the lanes open every commit and file, ready to read', async ({
 
 	// Tabbed: collapsed, as before.
 	await page.getByRole('button', {name: /^Commits/}).click();
-	await expect(
-		page.getByRole('button', {name: 'add notes +3 -0'}),
-	).toHaveAttribute('aria-expanded', 'false');
+
+	// A budget each, because these are two arrivals: the row comes with the
+	// commit, its diff stat only once git has been asked for one. Sharing a
+	// single 10s timeout between them is what made this flake on a busy
+	// machine — and said "element not found" for whichever half was late.
+	const commitRow = page.getByRole('button', {name: /^add notes/});
+	await expect(commitRow).toBeVisible();
+	await expect(commitRow).toHaveAccessibleName('add notes +3 -0');
+	await expect(commitRow).toHaveAttribute('aria-expanded', 'false');
 	await expect(page.locator('[data-line]')).toHaveCount(0);
 
 	// Lanes: the diffs are simply there.

--- a/source/test/epiq-time-travel.test.ts
+++ b/source/test/epiq-time-travel.test.ts
@@ -18,7 +18,6 @@ vi.mock('../lib/event/event-load.js', () => ({
 	loadEffectiveEventTimes: vi.fn(),
 	loadMergedEvents: vi.fn(),
 	loadMergedEventsBefore: vi.fn(),
-	getLastUnreadableEvents: vi.fn(() => []),
 }));
 
 vi.mock('../lib/event/event-materialize.js', async () => ({

--- a/source/test/peek.cmd.test.ts
+++ b/source/test/peek.cmd.test.ts
@@ -15,7 +15,6 @@ vi.mock('../lib/event/event-load.js', () => ({
 	loadEffectiveEventTimes: vi.fn(),
 	loadMergedEvents: vi.fn(),
 	loadMergedEventsBefore: vi.fn(),
-	getLastUnreadableEvents: vi.fn(() => []),
 }));
 
 vi.mock('../lib/event/event-materialize.js', async () => ({


### PR DESCRIPTION
Four independent backlog tickets, one commit each so the ticket↔commit linking still resolves them separately.

**3E7QF7A** — `lastUnreadable` and `getLastUnreadableEvents` in `event-load.ts` had no production caller; the only references were two test mocks both returning `[]`. Its comment described `relockUnreadableEvents` and the return-to-live paths, none of which survive `S1WEPQG` — a reader would take it as a live constraint. Variable, getter, write and comment deleted, and the two mocks dropped. The `unreadable` array `loadMergedEventsWithUnreadable` returns is untouched.

**F2RWXD0** — `DISCLOSURE_HOVER_BG` was byte-identical to `GUI_THEME.hover`, and the same literal was inlined in six components; `'ui-monospace, monospace'` was hardcoded in three while `CODE_FONT` exists. All now read the token. On the near-misses the ticket asked about: `TicketCard`'s 0.035 and `CodeSnippet`'s 0.03 are **resting** grounds, not hover states (the chip's hover is an accent tint), so they are deliberately not `hover` and are left alone.

**GCYVZR3** — `fullscreen-lanes.pw.ts` gave one 10s budget to both the commit row appearing and its diff stat arriving from git, and reported "element not found" for whichever half was late. Now the row is waited for by subject, then its accessible name, then `aria-expanded` — a budget each. 18/18 green under `--repeat-each=6 --workers=4`.

**Z486QVM** — a `halfyear` scope between `month` and `year`, 180 days (six of the month scope, not half of the year, so paging lands on the same boundaries). Labelled "6 months" rather than the capitalized id every other scope gets.

Unit gate, GUI e2e and the pre-push gate all green.