### PR TITLE
5DZMA7T: a lint rule for raw control characters

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,6 @@
 import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
+import {epiqPlugin} from './source/scripts/eslint-rules.mjs';
 
 export default tseslint.config(
 	{
@@ -24,7 +25,9 @@ export default tseslint.config(
 				tsconfigRootDir: import.meta.dirname,
 			},
 		},
+		plugins: {epiq: epiqPlugin},
 		rules: {
+			'epiq/no-raw-control-characters': 'error',
 			'no-control-regex': 'off',
 			'no-useless-assignment': 'off',
 			'no-case-declarations': 'off',

--- a/source/mcp/test/epiq-api.test.ts
+++ b/source/mcp/test/epiq-api.test.ts
@@ -974,7 +974,7 @@ describe('mcp tools', () => {
 		it('sanitizes the title, like every other title path does', async () => {
 			const result = await tools.createIssue({
 				repoRoot: '/repo',
-				title: 'Broken\ntitle\twith control',
+				title: 'Broken\ntitle\twith\x00control',
 				parentId: 'swimlane-1',
 			});
 
@@ -986,7 +986,7 @@ describe('mcp tools', () => {
 		it('refuses a title that is nothing but control characters', async () => {
 			const result = await tools.createIssue({
 				repoRoot: '/repo',
-				title: '\n\t  ',
+				title: '\n\t \x00',
 				parentId: 'swimlane-1',
 			});
 

--- a/source/scripts/eslint-rules.d.mts
+++ b/source/scripts/eslint-rules.d.mts
@@ -1,0 +1,3 @@
+import type {ESLint} from 'eslint';
+
+export declare const epiqPlugin: ESLint.Plugin;

--- a/source/scripts/eslint-rules.mjs
+++ b/source/scripts/eslint-rules.mjs
@@ -1,0 +1,60 @@
+// Local rules, kept here with the other tooling scripts rather than published
+// as a plugin: they exist for this repository's own hazards.
+
+// Tab and newline are the two that belong in source text. Everything else
+// below U+0020 is a byte somebody meant to write as an escape.
+const ALLOWED = new Set(['\t', '\n']);
+
+/**
+ * Git classifies a file holding a control character as binary: no diff, no
+ * blame, no review of it on GitHub, from then on. `grep` treats it as binary
+ * too and silently finds nothing, so searching for the line you are looking at
+ * reports it missing. Neither prettier nor tsc says a word, both being valid
+ * string contents — which is how one reached a pull request as
+ * `Bin 0 -> 3009 bytes`.
+ *
+ * Escapes (`\0`, `\x1e`) are ASCII in the file and unaffected; this is about
+ * the raw byte only. `no-control-regex` covers regexes, and
+ * `no-irregular-whitespace` its own list — neither covers source text.
+ */
+const noRawControlCharacters = {
+	meta: {
+		type: 'problem',
+		docs: {
+			description: 'Disallow raw control characters in source text',
+		},
+		schema: [],
+		messages: {
+			raw: 'Raw control character U+{{code}}. Write it as an escape ({{escape}}) — a file containing one is binary to git and to grep.',
+		},
+	},
+
+	create(context) {
+		return {
+			Program() {
+				const text = context.sourceCode.getText();
+
+				for (let index = 0; index < text.length; index++) {
+					const character = text[index];
+
+					if (character >= ' ' || ALLOWED.has(character)) continue;
+
+					const code = character.charCodeAt(0);
+
+					context.report({
+						loc: context.sourceCode.getLocFromIndex(index),
+						messageId: 'raw',
+						data: {
+							code: code.toString(16).toUpperCase().padStart(4, '0'),
+							escape: `\\x${code.toString(16).padStart(2, '0')}`,
+						},
+					});
+				}
+			},
+		};
+	},
+};
+
+export const epiqPlugin = {
+	rules: {'no-raw-control-characters': noRawControlCharacters},
+};

--- a/source/test/eslint-rules.test.ts
+++ b/source/test/eslint-rules.test.ts
@@ -1,0 +1,37 @@
+import {Linter} from 'eslint';
+import {describe, expect, it} from 'vitest';
+import {epiqPlugin} from '../scripts/eslint-rules.mjs';
+
+const lint = (code: string) =>
+	new Linter().verify(code, {
+		plugins: {epiq: epiqPlugin},
+		rules: {'epiq/no-raw-control-characters': 'error'},
+	});
+
+// Written as codePointAt-built strings rather than as literals: a raw control
+// character in this file would make it binary to git, which is the whole
+// point of the rule.
+const raw = (code: number) => String.fromCharCode(code);
+
+describe('no-raw-control-characters', () => {
+	it('reports a raw NUL, naming its escape', () => {
+		const messages = lint(`const a = "x${raw(0)}y";`);
+
+		expect(messages).toHaveLength(1);
+		expect(messages[0]!.message).toContain('U+0000');
+		expect(messages[0]!.message).toContain('\\x00');
+	});
+
+	it('reports every one of them, not just the first', () => {
+		expect(lint(`const a = "${raw(1)}${raw(0x1e)}";`)).toHaveLength(2);
+	});
+
+	// The escape is ASCII in the file, so it is not what the rule is about.
+	it('leaves an escape alone', () => {
+		expect(lint('const a = "x\\x00y\\u001ez";')).toHaveLength(0);
+	});
+
+	it('leaves tabs and newlines alone', () => {
+		expect(lint('const a = 1;\n\tconst b = 2;\n')).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
A raw control character in source makes the file **binary to git** — no diff, no blame, no GitHub review of it — and binary to `grep`, which then silently finds nothing in it. Neither prettier nor tsc says a word; both are valid string contents. `no-control-regex` covers regexes only, `no-irregular-whitespace` its own list.

`epiq/no-raw-control-characters` is a local flat-config plugin in `source/scripts/eslint-rules.mjs`: no character below U+0020 in the source text other than tab and newline. Escapes are ASCII in the file and unaffected. It runs under `npm run lint:err`, so it is already in the pre-push gate and in CI.

**It found two live ones on its first run** — `epiq-api.test.ts` had raw NULs at lines 977 and 989, deliberate hostile-payload inputs written as raw bytes. That file has been binary to git since; escaping them makes the diff readable again and the test's intent visible. The 94 tests in it still pass unchanged. Worth noting: the sweep I ran before writing the rule found nothing, because `grep` could not see into that file — the exact failure mode the ticket describes.

Tests: `source/test/eslint-rules.test.ts` drives the rule through `Linter`, covering a raw NUL, several in one file, escapes, and tab/newline.
