### PR TITLE
Mark each Stats section with its timeline colour

### DIFF
--- a/source/gui/client/components/IssueStats.tsx
+++ b/source/gui/client/components/IssueStats.tsx
@@ -23,6 +23,13 @@ import {BoardStats} from '../../../lib/stats/board-stats.js';
 import {Empty} from './FormPrimitives';
 import {Section} from './Section';
 
+// The timeline's own two series, so a colour means the same thing wherever it
+// appears: green is a commit, the accent is the board. A dot beside the
+// heading rather than a coloured figure — a number in green reads as a pass,
+// which is not what any of these say.
+const CODE_TONE = GUI_THEME.green;
+const BOARD_TONE = GUI_THEME.accent;
+
 // What the ticket's own code says about itself, read as an answer to one
 // question: how hard should somebody look at this diff, and where.
 //
@@ -183,7 +190,7 @@ const BoardSection = ({
 	first?: boolean;
 }) =>
 	boardStats ? (
-		<Section title="Board" first={first}>
+		<Section title="Board" first={first} tone={BOARD_TONE}>
 			<div style={statGrid(compact)}>
 				<Stat value={inDays(boardStats.ageMs)} label="Days old" />
 				<Stat
@@ -231,7 +238,7 @@ export const IssueStats = ({
 			<div style={{fontSize: TEXT.ui}}>
 				<BoardSection boardStats={boardStats} compact={compact} first />
 
-				<Section title="Code">
+				<Section title="Code" tone={CODE_TONE}>
 					<div style={LINE}>
 						No commit carries this ticket&rsquo;s ref, so there is no code to
 						measure. That is not the same as no work.
@@ -258,7 +265,7 @@ export const IssueStats = ({
 			    moving, or has been sent back twice already. */}
 			<BoardSection boardStats={boardStats} compact={compact} first />
 
-			<Section title="Code">
+			<Section title="Code" tone={CODE_TONE}>
 				<div style={statGrid(compact)}>
 					<Stat
 						value={String(shape.files)}
@@ -302,7 +309,7 @@ export const IssueStats = ({
 				</Note>
 			</Section>
 
-			<Section title="Tests">
+			<Section title="Tests" tone={CODE_TONE}>
 				<div style={statGrid(compact)}>
 					<Stat value={String(tests.testLinesAdded)} label="Test lines added" />
 					<Stat
@@ -345,7 +352,7 @@ export const IssueStats = ({
 				</Note>
 			</Section>
 
-			<Section title="Languages">
+			<Section title="Languages" tone={CODE_TONE}>
 				<StackedBar
 					segments={languages.languages.map((language, index) => ({
 						label: language.name,
@@ -369,7 +376,7 @@ export const IssueStats = ({
 				</Note>
 			</Section>
 
-			<Section title="Comments">
+			<Section title="Comments" tone={CODE_TONE}>
 				{/* One bar, for the language the ticket is mostly written in, with
 				    the repository's own share marked on it. A bar per language
 				    turned three true numbers into a wall of stripes, and the
@@ -426,7 +433,7 @@ export const IssueStats = ({
 				</Note>
 			</Section>
 
-			<Section title="Complexity">
+			<Section title="Complexity" tone={CODE_TONE}>
 				<Note when={flags.maxIndentLevels > 0}>
 					{`Nested ${flags.maxIndentLevels} levels deep at its deepest`}
 					{flags.deepestFile && (
@@ -450,7 +457,7 @@ export const IssueStats = ({
 			</Section>
 
 			{(flaggedFiles.length > 0 || shape.binaryFiles > 0) && (
-				<Section title="Worth a look">
+				<Section title="Worth a look" tone={CODE_TONE}>
 					{flaggedFiles.map(({file, what}) => (
 						<Row
 							key={`${what}:${file.path}`}

--- a/source/gui/client/components/Section.tsx
+++ b/source/gui/client/components/Section.tsx
@@ -6,11 +6,17 @@ export const Section = ({
 	action,
 	children,
 	first = false,
+	tone,
 }: {
 	first?: boolean;
 	title: string;
 	action?: React.ReactNode;
 	children: React.ReactNode;
+	// A series colour, when the section draws from one the rest of the app
+	// already colours — the timeline's green for commits, its accent for the
+	// board. Carried by a mark beside the title rather than by the title
+	// itself: a heading is text, and text wears ink.
+	tone?: string;
 }) => (
 	<section
 		style={{
@@ -28,12 +34,29 @@ export const Section = ({
 		>
 			<span
 				style={{
+					display: 'flex',
+					alignItems: 'center',
+					gap: 7,
 					color: GUI_THEME.secondary,
 					fontSize: TEXT.label,
 					textTransform: 'uppercase',
 					letterSpacing: '0.08em',
 				}}
 			>
+				{tone && (
+					<span
+						aria-hidden
+						style={{
+							// The event log's own dot, to the pixel: same size, same
+							// round, so a colour means the same thing in both places.
+							width: 5,
+							height: 5,
+							borderRadius: '50%',
+							background: tone,
+							flexShrink: 0,
+						}}
+					/>
+				)}
 				{title}
 			</span>
 


### PR DESCRIPTION
`SBHN63Q`. (Reopened: #272's branch was deleted before it merged; same commit, rebased.)

A dot before each section heading, in the colour the timeline already gives that series: green for everything read out of the commits, the accent for the board. Same 5px circle as the event log's own dot, so a colour means one thing wherever it appears.

Three versions were built and looked at before choosing.

**Colouring the figures** was the first idea and the one to reject: green on a number reads as a *pass*, and none of these is a pass or a fail — four files is not good or bad. It also could not be applied evenly, since the figures that could take a tone sat beside ones that could not (a percentage, a path), leaving half the page looking graded.

**Tinting the heading text** puts a series colour on type, which is the one place it should not go — identity belongs on a mark beside the words, not in them.

**A dot** says the same thing at a tenth of the volume, in a vocabulary the reader already has from the log and the scrubber.

`Section` grew an optional `tone`; without it nothing changes, which is every other section in the app.