### PR TITLE
Hardening: a frame ceiling, a private temp dir, and two rebase failures told apart

### DIFF
--- a/source/git/git-utils.ts
+++ b/source/git/git-utils.ts
@@ -583,6 +583,51 @@ const rebaseInProgress = async (cwd: string): Promise<boolean> => {
 	);
 };
 
+/**
+ * The rebase, re-attempted while the only thing that stopped it was a race it
+ * can win next time.
+ *
+ * `rebase.autoStash` reverts the working copy and puts it back, but the moment
+ * between the stash and the checkout is not covered: nothing holds a lock on
+ * the *write* path, so a GUI, an MCP server and a TUI all append to this
+ * directory while one of them syncs. An append landing inside that moment
+ * leaves the log dirty again and git refuses to detach HEAD — the sync fails
+ * having done nothing, over a condition that is gone milliseconds later.
+ *
+ * The two failures are told apart structurally rather than by reading git's
+ * message, whose wording follows `LANG`. A rebase that *started* and stopped on
+ * a conflict left its state directory behind, and replaying it would land in
+ * the same place; one that never started left nothing, and the next attempt is
+ * a fresh throw against a window a few milliseconds wide.
+ *
+ * That same test is what keeps the slow timeout from multiplying: a rebase
+ * SIGTERMed at the 120s cap leaves `rebase-merge` behind like any interrupted
+ * one, so it is read as started and not re-attempted. Only a rebase that cost
+ * nothing is paid for again.
+ */
+const REBASE_ATTEMPTS = 3;
+const REBASE_RETRY_DELAY_MS = 120;
+
+const delay = (ms: number): Promise<void> =>
+	new Promise(resolve => setTimeout(resolve, ms));
+
+const rebaseWithRetry = async (
+	cwd: string,
+	ref: string,
+): Promise<Result<GitExecResult>> => {
+	let result = await git.rebaseOnto({cwd, ref});
+
+	for (let attempt = 1; attempt < REBASE_ATTEMPTS; attempt += 1) {
+		if (!isFail(result)) return result;
+		if (await rebaseInProgress(cwd)) return result;
+
+		await delay(REBASE_RETRY_DELAY_MS);
+		result = await git.rebaseOnto({cwd, ref});
+	}
+
+	return result;
+};
+
 export const abortRebaseIfPresent = async (
 	cwd: string,
 ): Promise<Result<boolean>> => {
@@ -662,10 +707,7 @@ export const pullBranchRebaseIfPresent = async ({
 		return failed(`Failed to fetch ${branch}\n${fetchResult.message}`);
 	}
 
-	const rebaseResult = await git.rebaseOnto({
-		cwd,
-		ref: `${ORIGIN}/${branch}`,
-	});
+	const rebaseResult = await rebaseWithRetry(cwd, `${ORIGIN}/${branch}`);
 
 	if (isFail(rebaseResult)) {
 		return failed(`Failed during rebase\n${rebaseResult.message}`);

--- a/source/git/git-utils.ts
+++ b/source/git/git-utils.ts
@@ -549,19 +549,63 @@ export const getShortHeadSha = async (
 export const isNonFastForward = (message: string): boolean =>
 	message.includes('fetch first') || message.includes('non-fast-forward');
 
+/**
+ * Whether a rebase is actually in progress.
+ *
+ * Asked of git rather than inferred from the exit code of `rebase --abort`,
+ * which is non-zero both when there was nothing to abort and when there was one
+ * it could not unwind — two states that want opposite responses. Asked
+ * structurally rather than by matching git's message, too: the environment
+ * these commands run in inherits `LANG`, so the wording is not ours to rely on.
+ *
+ * `--git-path` is what resolves this correctly inside a linked worktree, where
+ * the state sits under `.git/worktrees/<name>/` rather than beside HEAD.
+ */
+const rebaseInProgress = async (cwd: string): Promise<boolean> => {
+	// One spawn, not one per state directory: autosync runs this every few
+	// seconds and the answer is almost always "no rebase", so the common case
+	// should cost a single `rev-parse` and two `existsSync` calls.
+	const result = await execGitAllowFail({
+		cwd,
+		args: ['rev-parse', '--absolute-git-dir'],
+	});
+
+	if (result.exitCode !== 0) return false;
+
+	const gitDir = result.stdout.trim();
+	if (!gitDir) return false;
+
+	// `rebase-merge` is the interactive and merge backend, `rebase-apply` the
+	// am-based one. Either means a rebase is in progress.
+	return (
+		fs.existsSync(path.join(gitDir, 'rebase-merge')) ||
+		fs.existsSync(path.join(gitDir, 'rebase-apply'))
+	);
+};
+
 export const abortRebaseIfPresent = async (
 	cwd: string,
 ): Promise<Result<boolean>> => {
+	if (!(await rebaseInProgress(cwd))) {
+		return succeeded('No rebase to abort', false);
+	}
+
 	const result = await execGitAllowFail({
 		cwd,
 		args: ['rebase', '--abort'],
 	});
 
-	if (result.exitCode === 0) {
-		return succeeded('Aborted stale rebase', true);
+	// A rebase that is present and will not unwind. Returned as a failure rather
+	// than swallowed as "nothing to do": the caller's next move is to start a
+	// second rebase over the stuck one, and the error it then reports names the
+	// new rebase while the cause sits underneath it.
+	if (result.exitCode !== 0) {
+		return failed(
+			`Failed to abort the rebase in progress at ${cwd}\n${result.stderr.trim()}`,
+		);
 	}
 
-	return succeeded('No rebase to abort', false);
+	return succeeded('Aborted stale rebase', true);
 };
 
 const readHeadSha = async (cwd: string): Promise<string | null> => {

--- a/source/gui/api/lib/socket-frame-limit.test.ts
+++ b/source/gui/api/lib/socket-frame-limit.test.ts
@@ -1,0 +1,34 @@
+import {describe, expect, it} from 'vitest';
+import {
+	MAX_COMMENT_LENGTH,
+	MAX_DESCRIPTION_LENGTH,
+	MAX_TITLE_LENGTH,
+} from '../../../lib/utils/text.limits.js';
+import {MAX_SOCKET_FRAME_BYTES} from './websocket.js';
+
+// A character can reach four bytes as UTF-8, and JSON escaping can grow it
+// further; the frame also carries the envelope around the field.
+const worstCaseBytes = (characters: number) => characters * 6 + 1024;
+
+describe('the websocket frame ceiling', () => {
+	// The risk of setting a ceiling at all: it must never be the thing that
+	// stops a legitimate save. Every field this socket carries has a cap of its
+	// own, and the frame has to clear the largest of them with room to spare.
+	it('clears the largest message the socket legitimately carries', () => {
+		const largest = Math.max(
+			MAX_DESCRIPTION_LENGTH,
+			MAX_COMMENT_LENGTH,
+			MAX_TITLE_LENGTH,
+		);
+
+		expect(MAX_SOCKET_FRAME_BYTES).toBeGreaterThan(worstCaseBytes(largest));
+	});
+
+	// And the reason it exists: `ws` defaults to 100 MiB, which is buffered and
+	// parsed before any handler — so before the caps above get a say.
+	it('is far below what ws would otherwise allow', () => {
+		const WS_DEFAULT_MAX_PAYLOAD = 100 * 1024 * 1024;
+
+		expect(MAX_SOCKET_FRAME_BYTES).toBeLessThan(WS_DEFAULT_MAX_PAYLOAD / 10);
+	});
+});

--- a/source/gui/api/lib/websocket.ts
+++ b/source/gui/api/lib/websocket.ts
@@ -58,6 +58,17 @@ import {isForeignOrigin} from './origin-guard.js';
 import {parseGuiMessage} from './websocket.schema.js';
 import {issueDetail, slimStateResult} from './slim-state.js';
 
+/**
+ * The ceiling on one websocket frame.
+ *
+ * `MAX_DESCRIPTION_LENGTH` is the longest field this socket carries, and a
+ * character can reach four bytes as UTF-8, so this is that with room for the
+ * envelope and then an order of magnitude over — generous enough that no real
+ * message meets it, small enough that a hostile one cannot make the server hold
+ * a hundred megabytes while it finds out the field is too long anyway.
+ */
+export const MAX_SOCKET_FRAME_BYTES = 1024 * 1024;
+
 // Derives rather than boots, so a live re-materialize can't stomp a checkout.
 const broadcastDerivedState = () => {
 	broadcastGuiMessage({
@@ -149,6 +160,15 @@ export const setupWebsocket = (
 	const wss = new WebSocketServer({
 		server,
 		path: '/ws',
+		// A frame is buffered whole and then parsed before any handler sees it, so
+		// without a ceiling the size checks the API applies — a 300-character
+		// title, a 20,000-character description — only get their say after the
+		// whole thing is in memory twice over. `ws` defaults to 100 MiB.
+		//
+		// Well clear of anything legitimate: the largest message this socket
+		// carries is a description at 20,000 characters, and attachments go over
+		// HTTP rather than through here.
+		maxPayload: MAX_SOCKET_FRAME_BYTES,
 		// A handshake is not bound by the same-origin policy, so without this any
 		// page the user has open reaches every message below — including `sync`,
 		// which pushes to the shared remote.

--- a/source/lib/storage/private-temp-dir.test.ts
+++ b/source/lib/storage/private-temp-dir.test.ts
@@ -2,8 +2,8 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
-import {isFail, isSuccess, Result} from '../lib/model/result-types.js';
-import {privateTempDir} from './epiq-time-travel.js';
+import {isFail, isSuccess, Result} from '../model/result-types.js';
+import {privateTempDir} from './private-temp-dir.js';
 
 // A temp root of this test's own, so the assertions are about directories this
 // test created rather than whatever the developer's real one already holds.

--- a/source/lib/storage/private-temp-dir.ts
+++ b/source/lib/storage/private-temp-dir.ts
@@ -1,0 +1,39 @@
+import {chmodSync, existsSync, lstatSync, mkdirSync} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {failed, Result, succeeded} from '../model/result-types.js';
+
+/**
+ * A directory under the system temp dir that only this user can enter.
+ *
+ * `os.tmpdir()` is per-user on macOS but shared on Linux, where the default
+ * 0755 left whatever epiq wrote there — a private repository's diffs — readable
+ * by every local account, and let one of them pre-create a path as a symlink so
+ * the write landed on a file of their choosing.
+ *
+ * The mode is set on creation *and* on a directory that was already there: an
+ * older build made these 0755, and `mkdirSync` leaves an existing directory's
+ * permissions alone, so the loose one would have outlived the fix. A symlink is
+ * refused outright rather than chmod-ed — following one is the thing being
+ * prevented.
+ */
+export const privateTempDir = (...segments: string[]): Result<string> => {
+	const dir = path.join(os.tmpdir(), 'epiq', ...segments);
+
+	try {
+		if (existsSync(dir) && lstatSync(dir).isSymbolicLink()) {
+			return failed(`Refusing to write through a symlink at ${dir}`);
+		}
+
+		mkdirSync(dir, {recursive: true, mode: 0o700});
+		chmodSync(dir, 0o700);
+
+		return succeeded('Prepared private temp dir', dir);
+	} catch (error) {
+		return failed(
+			`Unable to prepare ${dir}: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+	}
+};

--- a/source/mcp/epiq-time-travel.ts
+++ b/source/mcp/epiq-time-travel.ts
@@ -1,6 +1,5 @@
 import {existsSync} from 'node:fs';
 import {chmod} from 'node:fs/promises';
-import os from 'node:os';
 import path from 'node:path';
 import {getStateBranchRoot} from '../git/git-storage.js';
 import {execGit, readGitBlobsBatch} from '../git/git-utils.js';

--- a/source/mcp/epiq-time-travel.ts
+++ b/source/mcp/epiq-time-travel.ts
@@ -1,4 +1,4 @@
-import {existsSync} from 'node:fs';
+import {existsSync, lstatSync, mkdirSync, chmodSync} from 'node:fs';
 import {chmod} from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -386,6 +386,40 @@ export const getCommitsForRef = async (
 // as a flag. Argument injection, not shell injection.
 const isPlausibleSha = (sha: string): boolean => /^[0-9a-f]{7,40}$/i.test(sha);
 
+/**
+ * A directory under the system temp dir that only this user can enter.
+ *
+ * `os.tmpdir()` is per-user on macOS but shared on Linux, where the default
+ * 0755 left a private repository's diffs readable by every local account — and,
+ * worse, let one of them pre-create a path here as a symlink so the write
+ * landed on a file of their choosing.
+ *
+ * The mode is set on creation *and* on a directory that was already there: an
+ * older build made these 0755, and `mkdirSync` leaves an existing directory's
+ * permissions alone. A symlink is refused outright rather than chmod-ed, since
+ * following one is the thing being prevented.
+ */
+export const privateTempDir = (...segments: string[]): Result<string> => {
+	const dir = path.join(os.tmpdir(), 'epiq', ...segments);
+
+	try {
+		if (existsSync(dir) && lstatSync(dir).isSymbolicLink()) {
+			return failed(`Refusing to write diffs through a symlink at ${dir}`);
+		}
+
+		mkdirSync(dir, {recursive: true, mode: 0o700});
+		chmodSync(dir, 0o700);
+
+		return succeeded('Prepared private temp dir', dir);
+	} catch (error) {
+		return failed(
+			`Unable to prepare ${dir}: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+	}
+};
+
 // Fallback: editors highlight the +/- lines but not the code's own language.
 const openCommitAsUnifiedDiff = async (
 	repoRoot: string,
@@ -394,10 +428,10 @@ const openCommitAsUnifiedDiff = async (
 	const showResult = await execGit({cwd: repoRoot, args: ['show', sha]});
 	if (isFail(showResult)) return failed(showResult.message);
 
-	const tmpDir = path.join(os.tmpdir(), 'epiq', 'commit-diffs');
-	fileManager.mkDir(tmpDir);
+	const tmpDirResult = privateTempDir('commit-diffs');
+	if (isFail(tmpDirResult)) return failed(tmpDirResult.message);
 
-	const tmpPath = path.join(tmpDir, `${sha}.diff`);
+	const tmpPath = path.join(tmpDirResult.value, `${sha}.diff`);
 
 	// Already chmod 0o444 after the first write, so re-writing would fail EACCES.
 	if (!existsSync(tmpPath)) {
@@ -472,7 +506,12 @@ const openCommitAsSideBySideDiffs = async (
 		);
 	}
 
-	const tmpDir = path.join(os.tmpdir(), 'epiq', 'commit-diffs', sha);
+	// Locks the whole `epiq/commit-diffs` chain down, so the per-file
+	// directories written under it below inherit a parent nobody else can enter.
+	const tmpDirResult = privateTempDir('commit-diffs', sha);
+	if (isFail(tmpDirResult)) return failed(tmpDirResult.message);
+
+	const tmpDir = tmpDirResult.value;
 
 	const preparedFiles = await Promise.all(
 		filePaths.map(async (filePath, index) => {

--- a/source/mcp/epiq-time-travel.ts
+++ b/source/mcp/epiq-time-travel.ts
@@ -1,4 +1,4 @@
-import {existsSync, lstatSync, mkdirSync, chmodSync} from 'node:fs';
+import {existsSync} from 'node:fs';
 import {chmod} from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -24,6 +24,7 @@ import {
 import {failed, isFail, Result, succeeded} from '../lib/model/result-types.js';
 import {readProjectFile} from '../lib/project-setup/project-setup.js';
 import {fileManager} from '../lib/storage/file-manager.js';
+import {privateTempDir} from '../lib/storage/private-temp-dir.js';
 import {resolveClosestEpiqProjectRoot} from '../lib/storage/paths.js';
 import {
 	getState,
@@ -385,40 +386,6 @@ export const getCommitsForRef = async (
 // `sha` reaches a `git show <sha>` argv slot, where a leading `-` would be read
 // as a flag. Argument injection, not shell injection.
 const isPlausibleSha = (sha: string): boolean => /^[0-9a-f]{7,40}$/i.test(sha);
-
-/**
- * A directory under the system temp dir that only this user can enter.
- *
- * `os.tmpdir()` is per-user on macOS but shared on Linux, where the default
- * 0755 left a private repository's diffs readable by every local account — and,
- * worse, let one of them pre-create a path here as a symlink so the write
- * landed on a file of their choosing.
- *
- * The mode is set on creation *and* on a directory that was already there: an
- * older build made these 0755, and `mkdirSync` leaves an existing directory's
- * permissions alone. A symlink is refused outright rather than chmod-ed, since
- * following one is the thing being prevented.
- */
-export const privateTempDir = (...segments: string[]): Result<string> => {
-	const dir = path.join(os.tmpdir(), 'epiq', ...segments);
-
-	try {
-		if (existsSync(dir) && lstatSync(dir).isSymbolicLink()) {
-			return failed(`Refusing to write diffs through a symlink at ${dir}`);
-		}
-
-		mkdirSync(dir, {recursive: true, mode: 0o700});
-		chmodSync(dir, 0o700);
-
-		return succeeded('Prepared private temp dir', dir);
-	} catch (error) {
-		return failed(
-			`Unable to prepare ${dir}: ${
-				error instanceof Error ? error.message : String(error)
-			}`,
-		);
-	}
-};
 
 // Fallback: editors highlight the +/- lines but not the code's own language.
 const openCommitAsUnifiedDiff = async (

--- a/source/mcp/private-temp-dir.test.ts
+++ b/source/mcp/private-temp-dir.test.ts
@@ -1,0 +1,82 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {isFail, isSuccess, Result} from '../lib/model/result-types.js';
+import {privateTempDir} from './epiq-time-travel.js';
+
+// A temp root of this test's own, so the assertions are about directories this
+// test created rather than whatever the developer's real one already holds.
+let root: string;
+
+// `isSuccess` is what narrows the value off null; `isFail` alone leaves it.
+const unwrap = <T>(result: Result<T>): T => {
+	if (!isSuccess(result)) throw new Error(result.message);
+	return result.value;
+};
+
+const modeOf = (dir: string) => fs.statSync(dir).mode & 0o777;
+
+describe('privateTempDir', () => {
+	beforeEach(() => {
+		root = fs.mkdtempSync(path.join(os.tmpdir(), 'epiq-tmpdir-test-'));
+		vi.spyOn(os, 'tmpdir').mockReturnValue(root);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		fs.rmSync(root, {recursive: true, force: true});
+	});
+
+	it('creates the directory it names', () => {
+		const dir = unwrap(privateTempDir('commit-diffs'));
+
+		expect(dir).toBe(path.join(root, 'epiq', 'commit-diffs'));
+		expect(fs.existsSync(dir)).toBe(true);
+	});
+
+	// The whole point: on Linux `os.tmpdir()` is shared, and 0755 left a private
+	// repository's diffs readable by every local account.
+	it('is private, and so is every directory it created on the way', () => {
+		const dir = unwrap(privateTempDir('commit-diffs', 'abc123'));
+
+		expect(modeOf(dir)).toBe(0o700);
+		expect(modeOf(path.join(root, 'epiq', 'commit-diffs'))).toBe(0o700);
+		expect(modeOf(path.join(root, 'epiq'))).toBe(0o700);
+	});
+
+	// `mkdirSync` leaves an existing directory's permissions alone, so an older
+	// build's 0755 would have survived every later run.
+	it('tightens a directory that was already there and loose', () => {
+		const existing = path.join(root, 'epiq', 'commit-diffs');
+		fs.mkdirSync(existing, {recursive: true, mode: 0o755});
+		fs.chmodSync(existing, 0o755);
+		expect(modeOf(existing)).toBe(0o755);
+
+		unwrap(privateTempDir('commit-diffs'));
+
+		expect(modeOf(existing)).toBe(0o700);
+	});
+
+	// The attack this is for: a neighbour pre-creates the path as a symlink so
+	// the diff is written through it, onto a file of their choosing.
+	it('refuses to write through a symlink', () => {
+		const elsewhere = path.join(root, 'elsewhere');
+		fs.mkdirSync(elsewhere);
+		fs.mkdirSync(path.join(root, 'epiq'), {recursive: true});
+		fs.symlinkSync(elsewhere, path.join(root, 'epiq', 'commit-diffs'));
+
+		const result = privateTempDir('commit-diffs');
+
+		expect(isFail(result)).toBe(true);
+		expect(result.message).toContain('symlink');
+	});
+
+	it('is safe to call again over a directory it already prepared', () => {
+		const first = unwrap(privateTempDir('commit-diffs'));
+		const second = unwrap(privateTempDir('commit-diffs'));
+
+		expect(second).toBe(first);
+		expect(modeOf(second)).toBe(0o700);
+	});
+});

--- a/source/test/epiq-time-travel.test.ts
+++ b/source/test/epiq-time-travel.test.ts
@@ -61,6 +61,18 @@ vi.mock('node:fs', () => ({
 	existsSync: vi.fn(),
 }));
 
+// Mocked as a unit rather than by widening the `node:fs` mock above: the
+// directory it prepares is a real one with real permissions, which is its own
+// test's business (lib/storage/private-temp-dir.test.ts). Here it only has to
+// name a path for the diff assertions to match against.
+vi.mock('../lib/storage/private-temp-dir.js', () => ({
+	privateTempDir: (...segments: string[]) => ({
+		status: 'success',
+		message: 'Prepared private temp dir',
+		value: ['/tmp/epiq', ...segments].join('/'),
+	}),
+}));
+
 vi.mock('node:fs/promises', () => ({
 	chmod: vi.fn(),
 }));


### PR DESCRIPTION
An adversarial pass over the architecture, and the fixes that survived verification.

Worth saying plainly: **most of what I first suspected turned out to be already defended**, and two findings I filed were withdrawn after tracing them properly. What is here is what held up.

### `61HAR6S` — cap a websocket frame

`WebSocketServer` was constructed without `maxPayload`, so `ws` allowed its default 100 MiB. A frame that size is buffered whole and `JSON.parse`d *before* any handler — and therefore before the API's own length checks (`text.limits.ts`: title 300, description 20,000, comment 4,000) get a say.

The ceiling is 1 MiB, sized against `MAX_DESCRIPTION_LENGTH` at worst-case UTF-8 with room for the envelope. The test asserts that margin rather than testing `ws` internals — the risk of adding a ceiling at all is that it strangles a legitimate save.

### `QMGGEES` — a temp directory only this user can enter

Commit diffs were written to `os.tmpdir()/epiq/commit-diffs/<sha>.diff` at the default 0755. On Linux, where `/tmp` is shared, that left a private repository's diffs readable by every local account and let one of them pre-create the path as a symlink so the write landed elsewhere.

`privateTempDir` creates at 0700, **chmods a directory that was already there** (an older build's 0755 would otherwise have outlived the fix, since `mkdirSync` leaves existing permissions alone), and **refuses a symlink** rather than chmod-ing it.

It lives in `lib/storage/` rather than beside its caller: a private temp directory is a storage question. That placement came out of the review — the first version sat in `epiq-time-travel.ts` and broke 9 existing tests by widening that module's `node:fs` surface past what the test mocked. Moving it made both tests simpler and dropped its own from 3.4s to 106ms.

### `Y3ZKM2D` — ask git whether a rebase is in progress

`abortRebaseIfPresent` read only the exit code of `git rebase --abort`: zero meant "aborted", anything else meant "nothing to abort". Those are not the same — the command also fails when there *was* a rebase it could not unwind, and the caller then started a second rebase over the stuck one and reported the new one's error.

Asked structurally (`rev-parse --absolute-git-dir`, then `rebase-merge`/`rebase-apply`) rather than by matching git's message: `gitEnv` inherits `LANG`, so the wording is not ours to rely on. One spawn, not two — autosync runs this every few seconds and the answer is almost always "no".

Verified against real git: `--absolute-git-dir` returns the per-worktree dir, a conflicted rebase creates `rebase-merge`, an abort removes it.

### `V8TZ5CD` — retry a rebase that never started

**Pre-existing on main, and CI could not see it.** `write-during-sync.test.ts` failed deterministically; reverting `git-utils.ts` to main's version left it failing identically, so it was not caused by the work above.

`rebase.autoStash` reverts the working copy and puts it back, but the moment between the stash and the checkout is uncovered. Nothing locks the *write* path, so a GUI beside an MCP server beside a TUI all append while one of them syncs; an append landing in that moment leaves the log dirty and git refuses to detach HEAD. The sync fails having done nothing, over a condition gone milliseconds later.

The fix reuses `Y3ZKM2D`'s discrimination: a rebase that *stopped on a conflict* left state behind and replaying it lands in the same place; one that *never started* left nothing and the next attempt is a fresh throw. Three attempts, 120ms apart.

That same test keeps the slow timeout from multiplying: a rebase SIGTERMed at the 120s cap leaves `rebase-merge` like any interrupted one, so it reads as started and is not re-attempted. Only a rebase that cost nothing is paid for again.

Correctness was never at risk — `withEventLogsIntact` and `assertLogOnlyGrew` prevent loss either way. This is liveness: the board stops publishing while another tool is writing.

**Still open on `V8TZ5CD`:** CI runs `lint`, `build`, `test`, `test:e2e:ci`, `test:gui:ci` — never `test:collab`. The collaboration suite exists only as a local push blocker, which is why this sat broken invisibly. Whether CI should run it is a cost decision, left on the ticket.

### Testing

Full gate green on the rebased base: lint, typecheck, **1368 unit**, containers (**17 e2e, 15 collaboration** — up from 14/15), **150 GUI browser**.

The collab suite is the regression test for `V8TZ5CD`: red twice without the fix, green with it, and the run dropped from 154s to 85s as fewer sync rounds fail. `QMGGEES` has 5 unit tests, 4 verified red without the fix.

Closes `61HAR6S`, `QMGGEES`, `Y3ZKM2D`. Part-closes `V8TZ5CD`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Vuz7fJrAAc5jn53RsYhdX
