### PR TITLE
QRJDX9F: keep a write out of reach until the worktree is free

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,47 @@ jobs:
 
       - run: npm run test:gui:ci
 
+  # Its own job for the same reasons the GUI one is, plus a sharper one: until
+  # now this suite ran nowhere but the local pre-push hook. That made a failure
+  # invisible on every pull request and turned it into a block on whoever
+  # pushed next — `V8TZ5CD` sat broken on main exactly that way, and the person
+  # who found it was the person it stopped.
+  #
+  # This is the suite that says whether several epiq processes on one board
+  # still converge. Nothing else covers it: the unit suite never syncs, and the
+  # e2e suite drives one actor.
+  collaboration:
+    name: Collaboration
+    runs-on: ubuntu-latest
+    # Individual tests allow up to fifteen minutes each, deliberately — they
+    # race real syncs and a slow one is not a failed one. This is a bound on a
+    # job that has stopped making progress, not a target.
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      # Every actor is a real epiq process, and every one of them runs git.
+      - name: Configure Git
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+
+      - run: npm ci
+
+      # `test:collab` wraps this in the e2e docker image, which exists to give a
+      # developer's machine the disposable, read-only checkout a hosted runner
+      # already is. Same reason `test:e2e:ci` runs bare here.
+      #
+      # No build step: actors are spawned through the checkout's own `tsx`
+      # against the TypeScript sources, so `npm ci` is the whole preparation.
+      - run: npm run test:collab:ci
+
   release:
     name: Release ${{ matrix.artifact }}
     if: startsWith(github.ref, 'refs/tags/v')

--- a/source/git/git-storage.ts
+++ b/source/git/git-storage.ts
@@ -110,8 +110,33 @@ export const listEventFiles = (root: string): Result<string[]> => {
 // anything at the state branch root that is not `.epiq`.
 const EVENT_LOG_ATTRIBUTES = '*.jsonl merge=union\n';
 
+/**
+ * A pending log is protected by being untracked — git resets the files it
+ * tracks, and leaves the rest alone. Untracked is not the same as ignored,
+ * though: a bare `git add -A` in this worktree would stage one, and once
+ * committed it is tracked, and the protection is silently gone for good.
+ *
+ * Ignoring them makes that impossible rather than merely unlikely. Committed
+ * for the same reason the merge attribute is: a clone that has not seen this
+ * file yet does not have the rule.
+ */
+const EVENT_LOG_IGNORES = '*~pending*.jsonl\n';
+
 export const getRelativeEventAttributesPath = (): string =>
 	path.join(EPIQ_DIR_NAME, EVENTS_DIR_NAME, '.gitattributes');
+
+export const getRelativeEventIgnorePath = (): string =>
+	path.join(EPIQ_DIR_NAME, EVENTS_DIR_NAME, '.gitignore');
+
+const writeIfDifferent = (filePath: string, content: string): void => {
+	try {
+		if (fs.readFileSync(filePath, 'utf8') !== content) {
+			fs.writeFileSync(filePath, content);
+		}
+	} catch {
+		fs.writeFileSync(filePath, content);
+	}
+};
 
 export const ensureStateBranchLayout = (
 	repoRoot: string,
@@ -122,18 +147,15 @@ export const ensureStateBranchLayout = (
 		if (isFail(result)) return failed(result.message);
 	}
 
-	const attributesPath = path.join(
-		stateBranchRoot,
-		getRelativeEventAttributesPath(),
+	writeIfDifferent(
+		path.join(stateBranchRoot, getRelativeEventAttributesPath()),
+		EVENT_LOG_ATTRIBUTES,
 	);
 
-	try {
-		if (fs.readFileSync(attributesPath, 'utf8') !== EVENT_LOG_ATTRIBUTES) {
-			fs.writeFileSync(attributesPath, EVENT_LOG_ATTRIBUTES);
-		}
-	} catch {
-		fs.writeFileSync(attributesPath, EVENT_LOG_ATTRIBUTES);
-	}
+	writeIfDifferent(
+		path.join(stateBranchRoot, getRelativeEventIgnorePath()),
+		EVENT_LOG_IGNORES,
+	);
 
 	return succeeded('Ensured state branch', undefined);
 };

--- a/source/git/git-utils.ts
+++ b/source/git/git-utils.ts
@@ -587,18 +587,26 @@ const rebaseInProgress = async (cwd: string): Promise<boolean> => {
  * The rebase, re-attempted while the only thing that stopped it was a race it
  * can win next time.
  *
- * `rebase.autoStash` reverts the working copy and puts it back, but the moment
- * between the stash and the checkout is not covered: nothing holds a lock on
- * the *write* path, so a GUI, an MCP server and a TUI all append to this
- * directory while one of them syncs. An append landing inside that moment
- * leaves the log dirty again and git refuses to detach HEAD — the sync fails
- * having done nothing, over a condition that is gone milliseconds later.
+ * Nothing holds a lock on the *write* path, so a GUI, an MCP server and a TUI
+ * all append to this directory while one of them syncs. `rebase.autoStash`
+ * reverts the working copy and puts it back, but it does not exclude those
+ * writers, and an append that lands while git has the worktree leaves the log
+ * dirty under it.
+ *
+ * The exposed window is the *whole* rebase, not one gap inside it. Three
+ * different refusals have been seen from the same cause: "could not detach
+ * HEAD" before it starts, "cannot rebase: You have unstaged changes" at the
+ * pre-flight check, and "would be overwritten by merge" during the replay. So
+ * this narrows the odds rather than closing them — the sync that still loses
+ * fails as it did before, and the next autosync tries again. Closing it for
+ * real means excluding writers for the duration, which is a lock on the append
+ * path and a much larger change than this.
  *
  * The two failures are told apart structurally rather than by reading git's
  * message, whose wording follows `LANG`. A rebase that *started* and stopped on
  * a conflict left its state directory behind, and replaying it would land in
- * the same place; one that never started left nothing, and the next attempt is
- * a fresh throw against a window a few milliseconds wide.
+ * the same place; one that never started left nothing, so it is worth one more
+ * throw.
  *
  * That same test is what keeps the slow timeout from multiplying: a rebase
  * SIGTERMed at the 120s cap leaves `rebase-merge` behind like any interrupted

--- a/source/git/git.ts
+++ b/source/git/git.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import {hasPendingLines} from '../lib/event/pending-log.js';
 import {failed, isFail, Result, succeeded} from '../lib/model/result-types.js';
 import {logger} from '../logger.js';
 import {git} from './git-commands.js';
@@ -380,7 +381,9 @@ export const ensureStateBranchWorktree = async ({
 		const dirtyResult = await hasUncommittedChanges(existing);
 		if (isFail(dirtyResult)) return failed(dirtyResult.message);
 
-		if (dirtyResult.value) {
+		// Pending logs are ignored, so git does not count them — and on a live
+		// board they are where every unpublished line is.
+		if (dirtyResult.value || hasPendingLines(existing)) {
 			return failed(
 				[
 					`Refusing to move the state branch worktree away from ${existing}.`,

--- a/source/git/git.ts
+++ b/source/git/git.ts
@@ -11,6 +11,7 @@ import {
 	ensureStateBranchIsStorageOnly,
 	ensureWorktreesDir,
 	getRelativeEventAttributesPath,
+	getRelativeEventIgnorePath,
 	getRelativeEventFilePath,
 	getRelativeMediaDirPath,
 	removePath,
@@ -632,29 +633,35 @@ export const stageStateBranchMediaFiles = async ({
  * The merge attribute has to be committed on the state branch, or a clone that
  * has not seen it yet still conflicts on the logs.
  */
-export const stageStateBranchEventAttributes = async ({
+export const stageStateBranchEventConfig = async ({
 	stateBranchRoot,
 }: {
 	stateBranchRoot: string;
-}): Promise<Result<string | null>> => {
-	const relativePath = getRelativeEventAttributesPath();
+}): Promise<Result<string[]>> => {
+	// Both carry rules a clone needs before it can behave correctly: the merge
+	// attribute, without which concurrent logs conflict, and the ignore, without
+	// which a pending log can be staged and so stop being protected.
+	const relativePaths = [
+		getRelativeEventAttributesPath(),
+		getRelativeEventIgnorePath(),
+	].filter(relativePath =>
+		fs.existsSync(path.join(stateBranchRoot, relativePath)),
+	);
 
-	if (!fs.existsSync(path.join(stateBranchRoot, relativePath))) {
-		return succeeded('No event log attributes to stage', null);
+	if (relativePaths.length === 0) {
+		return succeeded('No event log config to stage', []);
 	}
 
 	const stageResult = await git.stage({
 		cwd: stateBranchRoot,
-		pathspec: [relativePath],
+		pathspec: relativePaths,
 	});
 
 	if (isFail(stageResult)) {
-		return failed(
-			`Failed to stage event log attributes\n${stageResult.message}`,
-		);
+		return failed(`Failed to stage event log config\n${stageResult.message}`);
 	}
 
-	return succeeded('Staged event log attributes', relativePath);
+	return succeeded('Staged event log config', relativePaths);
 };
 
 export const createStateBranchSyncCommit = async ({

--- a/source/git/log-integrity.ts
+++ b/source/git/log-integrity.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import {execGitAllowFail} from './git-utils.js';
 import {failed, Result, succeeded} from '../lib/model/result-types.js';
+import {isPendingFileName} from '../lib/event/pending-log.js';
 import {EPIQ_DIR_NAME, EVENTS_DIR_NAME} from '../lib/storage/paths.js';
 
 /**
@@ -84,6 +85,14 @@ export const snapshotEventLogs = (root: string): EventLogSnapshot => {
 
 		for (const name of fs.readdirSync(dir)) {
 			if (!name.endsWith('.jsonl')) continue;
+
+			// A pending log is untracked and ignored, so git has nothing to drop
+			// from it — protecting it is unnecessary, and worse than unnecessary:
+			// a sync folds one into the tracked log and deletes it, and a snapshot
+			// taken beforehand would read that as lines going missing and put the
+			// file back. The lines would then be in both, and the next flush would
+			// append them again, every sync, forever.
+			if (isPendingFileName(name)) continue;
 
 			snapshot.set(
 				name,

--- a/source/git/sync.ts
+++ b/source/git/sync.ts
@@ -359,16 +359,18 @@ const runSync = async ({
 		stateBranchRoot,
 	});
 
-	// Everything written since the last sync lives in pending files, which git
-	// does not track and therefore cannot reset out from under a writer. Folded
-	// in here: this process holds the worktree, and it is before the commit, so
-	// the lines go out with this sync rather than waiting for the next one.
+	// Everything this actor wrote since the last sync lives in a pending file,
+	// which git does not track and therefore cannot reset out from under a
+	// writer. Folded in here: this process holds the worktree, and it is before
+	// the commit, so the lines go out with this sync rather than waiting for the
+	// next one. Own file only — the commit below takes nothing else, and other
+	// actors' lines are safer left pending than dirty in a tracked file.
 	//
 	// Not fatal on its own. The lines are still on disk and the next sync will
 	// try again — refusing to sync at all would strand them further.
 	const flushResult = trace(
 		'flushPendingLogs',
-		flushPendingLogs(stateBranchRoot),
+		flushPendingLogs(stateBranchRoot, ownEventFileName),
 	);
 	if (isFail(flushResult)) {
 		logger.error(`[sync] ${flushResult.message}`);

--- a/source/git/sync.ts
+++ b/source/git/sync.ts
@@ -28,11 +28,12 @@ import {
 	bootstrapStateBranchStorage,
 	createStateBranchSyncCommit,
 	pushStateBranch,
-	stageStateBranchEventAttributes,
+	stageStateBranchEventConfig,
 	stageStateBranchMediaFiles,
 	stageStateBranchOwnEventFile,
 } from './git.js';
 import {restoreDroppedEventLines, snapshotEventLogs} from './log-integrity.js';
+import {flushPendingLogs} from '../lib/event/pending-log.js';
 import {withSyncLock} from './sync-lock.js';
 
 type SyncSummary = {
@@ -196,18 +197,18 @@ const commitOwnEventFileToStateBranch = async ({
 	);
 	if (isFail(stageMediaResult)) return failed(stageMediaResult.message);
 
-	const stageAttributesResult = trace(
-		'stageStateBranchEventAttributes',
-		await stageStateBranchEventAttributes({stateBranchRoot}),
+	const stageConfigResult = trace(
+		'stageStateBranchEventConfig',
+		await stageStateBranchEventConfig({stateBranchRoot}),
 	);
-	if (isFail(stageAttributesResult)) {
-		return failed(stageAttributesResult.message);
+	if (isFail(stageConfigResult)) {
+		return failed(stageConfigResult.message);
 	}
 
 	const pathspec = [
 		stageResult.value,
 		stageMediaResult.value,
-		stageAttributesResult.value,
+		...stageConfigResult.value,
 	].filter((entry): entry is string => entry !== null);
 
 	if (pathspec.length === 0) {
@@ -357,6 +358,21 @@ const runSync = async ({
 		stateBranch,
 		stateBranchRoot,
 	});
+
+	// Everything written since the last sync lives in pending files, which git
+	// does not track and therefore cannot reset out from under a writer. Folded
+	// in here: this process holds the worktree, and it is before the commit, so
+	// the lines go out with this sync rather than waiting for the next one.
+	//
+	// Not fatal on its own. The lines are still on disk and the next sync will
+	// try again — refusing to sync at all would strand them further.
+	const flushResult = trace(
+		'flushPendingLogs',
+		flushPendingLogs(stateBranchRoot),
+	);
+	if (isFail(flushResult)) {
+		logger.error(`[sync] ${flushResult.message}`);
+	}
 
 	const localCommitResult = trace(
 		'commitOwnEventFileToStateBranch',

--- a/source/lib/event/event-load.ts
+++ b/source/lib/event/event-load.ts
@@ -14,6 +14,7 @@ import {
 	PersistedEnvelope,
 } from './event-persist.js';
 import {parseEventPayload} from './event-payload.schema.js';
+import {stripPendingMarker} from './pending-log.js';
 
 const EventFileNameSchema = z.object({
 	userId: z.string().min(1).default('unknown'),
@@ -87,8 +88,12 @@ const parseEventFileActor = (
 	// contain any number of them ("J. Lampa" -> `<id>.j.-lampa`), while the id
 	// segment never can.
 	const separatorIndex = baseName.indexOf('.');
-	const userId =
-		separatorIndex === -1 ? baseName : baseName.slice(0, separatorIndex);
+	// The pending log's marker rides on the id segment, so it comes off here —
+	// the actor is the same one either way, and a line is not attributed
+	// differently for having been written while a sync held the worktree.
+	const userId = stripPendingMarker(
+		separatorIndex === -1 ? baseName : baseName.slice(0, separatorIndex),
+	);
 	// Undefined, not '', so the schema's 'unknown' default applies rather than
 	// tripping its min(1).
 	const userName =

--- a/source/lib/event/event-persist.ts
+++ b/source/lib/event/event-persist.ts
@@ -9,6 +9,7 @@ import {getSettingsState, User} from '../state/settings.state.js';
 import {ensureEventsDir, getEventsDirPath} from '../storage/paths.js';
 import {sanitizeFilePart} from '../utils/file-part.js';
 import {MAX_ULID_AHEAD_MS} from './date-utils.js';
+import {getPendingLogPath} from './pending-log.js';
 import {advanceEdgeRef, getEdgeRef} from './event-load.js';
 import {noteOwnAppend} from './log-signature.js';
 import {
@@ -255,11 +256,20 @@ export function persist({
 		const ensureEventsDirResult = ensureEventsDir(rootDir);
 		if (isFail(ensureEventsDirResult)) return ensureEventsDirResult;
 
-		const filePath = getEventLogPath(rootDir, {
+		// The tracked log's name is still what identifies this actor's file; the
+		// line itself goes to the pending one beside it, which git does not
+		// track and therefore cannot reset out from under a write. A sync folds
+		// it in once git is finished with the worktree.
+		const trackedPath = getEventLogPath(rootDir, {
 			userId: event.userId,
 			userName: event.userName,
 		});
-		if (isFail(filePath)) return filePath;
+		if (isFail(trackedPath)) return trackedPath;
+
+		const filePath = succeeded(
+			'Resolved pending event log path',
+			getPendingLogPath(rootDir, path.basename(trackedPath.value)),
+		);
 
 		const identity = id
 			? succeeded('Minted event id', id)

--- a/source/lib/event/event-persist.ts
+++ b/source/lib/event/event-persist.ts
@@ -1,4 +1,3 @@
-import fs from 'node:fs';
 import path from 'node:path';
 import {decodeTime, monotonicFactory} from 'ulid';
 import {z} from 'zod';
@@ -9,7 +8,7 @@ import {getSettingsState, User} from '../state/settings.state.js';
 import {ensureEventsDir, getEventsDirPath} from '../storage/paths.js';
 import {sanitizeFilePart} from '../utils/file-part.js';
 import {MAX_ULID_AHEAD_MS} from './date-utils.js';
-import {getPendingLogPath} from './pending-log.js';
+import {appendPendingLine, getPendingLogPath} from './pending-log.js';
 import {advanceEdgeRef, getEdgeRef} from './event-load.js';
 import {noteOwnAppend} from './log-signature.js';
 import {
@@ -282,11 +281,7 @@ export function persist({
 
 		if (isFail(entryResult)) return failed(entryResult.message);
 
-		fs.appendFileSync(
-			filePath.value,
-			`${JSON.stringify(entryResult.value)}\n`,
-			'utf8',
-		);
+		appendPendingLine(filePath.value, `${JSON.stringify(entryResult.value)}\n`);
 
 		// Advanced only after the line is on disk, so a failed persist leaves
 		// the cursor pointing at an event that exists.

--- a/source/lib/event/pending-log.test.ts
+++ b/source/lib/event/pending-log.test.ts
@@ -6,6 +6,7 @@ import {isSuccess, Result} from '../model/result-types.js';
 import {
 	appendPendingLine,
 	flushPendingLogs,
+	foldedBytesOf,
 	hasPendingLines,
 	isPendingFileName,
 	toPendingFileName,
@@ -40,6 +41,16 @@ const linesOf = (name: string): string[] => {
 };
 
 const namesIn = (): string[] => fs.readdirSync(eventsDir).sort();
+
+// A flush leaves the file it folded behind, renamed, for the next pass to
+// delete; these read past that so a test can say what the log holds now.
+const foldedNames = (): string[] =>
+	namesIn().filter(name => foldedBytesOf(name) !== null);
+
+const flushTwice = (): void => {
+	unwrap(flushPendingLogs(root, TRACKED));
+	unwrap(flushPendingLogs(root, TRACKED));
+};
 
 beforeEach(() => {
 	root = fs.mkdtempSync(path.join(os.tmpdir(), 'epiq-pending-'));
@@ -79,6 +90,16 @@ describe('the pending log name', () => {
 
 		expect(isPendingFileName(rotated)).toBe(true);
 		expect(trackedFileNameFor(rotated)).toBe(TRACKED);
+		expect(foldedBytesOf(rotated)).toBeNull();
+	});
+
+	it('recognises a folded file, and reads how much of it is folded', () => {
+		const folded = '01hzz~pending-01abc-f120.ana.jsonl';
+
+		expect(isPendingFileName(folded)).toBe(true);
+		expect(trackedFileNameFor(folded)).toBe(TRACKED);
+		expect(foldedBytesOf(folded)).toBe(120);
+		expect(foldedBytesOf(TRACKED)).toBeNull();
 	});
 
 	it('leaves an ordinary log alone', () => {
@@ -101,6 +122,53 @@ describe('flushing pending logs', () => {
 
 		expect(unwrap(flushPendingLogs(root, TRACKED))).toBe(2);
 		expect(linesOf(TRACKED)).toEqual(['a', 'b', 'c', 'd']);
+		expect(fs.existsSync(path.join(eventsDir, PENDING))).toBe(false);
+	});
+
+	// The file it read is renamed, not deleted: a writer can still reach it — one
+	// preempted between opening and writing, or one whose lookup of the live
+	// path resolved to the old inode after the rename. Deleting it now would
+	// take those lines with it. The next pass deletes it, once nothing can.
+	it('keeps the file it folded until the next pass, then deletes it', () => {
+		write(TRACKED, ['a']);
+		write(PENDING, ['b']);
+
+		unwrap(flushPendingLogs(root, TRACKED));
+
+		expect(foldedNames()).toHaveLength(1);
+		expect(linesOf(foldedNames()[0]!)).toEqual(['b']);
+
+		expect(unwrap(flushPendingLogs(root, TRACKED))).toBe(0);
+		expect(namesIn()).toEqual([TRACKED]);
+		expect(linesOf(TRACKED)).toEqual(['a', 'b']);
+	});
+
+	it('folds what arrived in the kept file after it was read', () => {
+		write(TRACKED, ['a']);
+		write(PENDING, ['b']);
+		unwrap(flushPendingLogs(root, TRACKED));
+
+		// A writer that still had the old file open, or reached it by a stale
+		// path, lands its line here rather than in the fresh live file.
+		fs.appendFileSync(path.join(eventsDir, foldedNames()[0]!), 'late\n');
+
+		expect(unwrap(flushPendingLogs(root, TRACKED))).toBe(1);
+		expect(linesOf(TRACKED)).toEqual(['a', 'b', 'late']);
+		expect(namesIn()).toEqual([TRACKED]);
+	});
+
+	it('leaves a trailing fragment for the next pass rather than splicing it', () => {
+		write(TRACKED, ['a']);
+		fs.writeFileSync(path.join(eventsDir, PENDING), 'b\n{"half');
+		unwrap(flushPendingLogs(root, TRACKED));
+
+		expect(linesOf(TRACKED)).toEqual(['a', 'b']);
+		expect(foldedBytesOf(foldedNames()[0]!)).toBe(2);
+
+		fs.appendFileSync(path.join(eventsDir, foldedNames()[0]!), '":1}\n');
+		unwrap(flushPendingLogs(root, TRACKED));
+
+		expect(linesOf(TRACKED)).toEqual(['a', 'b', '{"half":1}']);
 		expect(namesIn()).toEqual([TRACKED]);
 	});
 
@@ -112,15 +180,18 @@ describe('flushing pending logs', () => {
 		expect(linesOf(TRACKED)).toEqual(['a']);
 	});
 
-	// A crash between the append and the delete leaves a rotated file behind.
-	// The next flush has to find it — that is the whole reason it globs rather
-	// than looking only at the live name.
+	// A crash between the rename and the fold leaves a rotated file behind. The
+	// next flush has to find it — that is the whole reason it globs rather than
+	// looking only at the live name.
 	it('picks up a rotated file a crashed flush left behind', () => {
 		write(TRACKED, ['a']);
 		write('01hzz~pending-01abc.ana.jsonl', ['stranded']);
 
 		expect(unwrap(flushPendingLogs(root, TRACKED))).toBe(1);
 		expect(linesOf(TRACKED)).toEqual(['a', 'stranded']);
+		expect(foldedNames()).toEqual(['01hzz~pending-01abc-f9.ana.jsonl']);
+
+		unwrap(flushPendingLogs(root, TRACKED));
 		expect(namesIn()).toEqual([TRACKED]);
 	});
 
@@ -129,7 +200,7 @@ describe('flushing pending logs', () => {
 		write('01hzz~pending-01abc.ana.jsonl', ['stranded']);
 		write(PENDING, ['live']);
 
-		unwrap(flushPendingLogs(root, TRACKED));
+		flushTwice();
 
 		expect(linesOf(TRACKED).sort()).toEqual(['a', 'live', 'stranded']);
 		expect(namesIn()).toEqual([TRACKED]);
@@ -151,19 +222,23 @@ describe('flushing pending logs', () => {
 		expect(linesOf('02aaa~pending.bo.jsonl')).toEqual(['bo-2']);
 	});
 
-	// A line that is not newline-terminated would otherwise be joined to the
-	// first line of the tracked log's next append — two events lost, and union
-	// merge relies on every line standing alone.
-	it('terminates a final line the writer left unterminated', () => {
+	// A line that is not newline-terminated is a write still in flight on the
+	// first pass. By the file's last pass it is a remnant, and it goes in
+	// terminated rather than being joined to the tracked log's next append —
+	// two events lost, and union merge relies on every line standing alone.
+	it('terminates a final line the writer left unterminated, on the last pass', () => {
 		write(TRACKED, ['a']);
 		fs.writeFileSync(path.join(eventsDir, PENDING), 'b');
 
 		unwrap(flushPendingLogs(root, TRACKED));
+		expect(linesOf(TRACKED)).toEqual(['a']);
 
+		unwrap(flushPendingLogs(root, TRACKED));
 		expect(linesOf(TRACKED)).toEqual(['a', 'b']);
 		expect(fs.readFileSync(path.join(eventsDir, TRACKED), 'utf8')).toMatch(
 			/\n$/,
 		);
+		expect(namesIn()).toEqual([TRACKED]);
 	});
 
 	// The other side of the same splice: a tracked log that ends in a partial
@@ -184,6 +259,8 @@ describe('flushing pending logs', () => {
 
 		expect(unwrap(flushPendingLogs(root, TRACKED))).toBe(0);
 		expect(linesOf(TRACKED)).toEqual(['a']);
+
+		flushTwice();
 		expect(namesIn()).toEqual([TRACKED]);
 	});
 
@@ -233,6 +310,35 @@ describe('appending to a pending log', () => {
 		expect(linesOf(TRACKED)).toEqual(['before']);
 		expect(linesOf(PENDING)).toEqual(['during']);
 	});
+
+	// The same preempted writer, but another writer creates the next live file
+	// before it runs its check. On ext4 a deleted file's inode number goes to
+	// the very next file created, so the check would pass against the wrong
+	// file — which is why the flush must not have deleted the old one.
+	it('keeps the line when the next live file takes the old inode number', () => {
+		write(PENDING, ['before']);
+
+		const writeSync = fs.writeSync;
+		vi.spyOn(fs, 'writeSync').mockImplementationOnce(((
+			fd: number,
+			data: string,
+		) => {
+			unwrap(flushPendingLogs(root, TRACKED));
+			return writeSync(fd, data);
+		}) as typeof fs.writeSync);
+
+		const closeSync = fs.closeSync;
+		vi.spyOn(fs, 'closeSync').mockImplementationOnce((fd: number) => {
+			closeSync(fd);
+			fs.appendFileSync(path.join(eventsDir, PENDING), 'other\n');
+		});
+
+		appendPendingLine(path.join(eventsDir, PENDING), 'during\n');
+		flushTwice();
+
+		expect(linesOf(TRACKED)).toContain('during');
+		expect(linesOf(TRACKED)).toContain('other');
+	});
 });
 
 describe('whether pending lines are held', () => {
@@ -247,6 +353,19 @@ describe('whether pending lines are held', () => {
 	it("is true for any actor's pending lines, live or rotated", () => {
 		write('02aaa~pending-01abc.bo.jsonl', ['bo']);
 
+		expect(hasPendingLines(root)).toBe(true);
+	});
+
+	// A folded file's lines are in the tracked log already; only what arrived
+	// after the fold is unpublished.
+	it('counts only the unfolded tail of a folded file', () => {
+		write(TRACKED, ['a']);
+		write(PENDING, ['b']);
+		unwrap(flushPendingLogs(root, TRACKED));
+
+		expect(hasPendingLines(root)).toBe(false);
+
+		fs.appendFileSync(path.join(eventsDir, foldedNames()[0]!), 'late\n');
 		expect(hasPendingLines(root)).toBe(true);
 	});
 

--- a/source/lib/event/pending-log.test.ts
+++ b/source/lib/event/pending-log.test.ts
@@ -6,6 +6,7 @@ import {isSuccess, Result} from '../model/result-types.js';
 import {
 	appendPendingLine,
 	flushPendingLogs,
+	hasPendingLines,
 	isPendingFileName,
 	toPendingFileName,
 	trackedFileNameFor,
@@ -231,5 +232,27 @@ describe('appending to a pending log', () => {
 
 		expect(linesOf(TRACKED)).toEqual(['before']);
 		expect(linesOf(PENDING)).toEqual(['during']);
+	});
+});
+
+describe('whether pending lines are held', () => {
+	it('is false with no pending logs, or only empty ones', () => {
+		write(TRACKED, ['a']);
+		expect(hasPendingLines(root)).toBe(false);
+
+		fs.writeFileSync(path.join(eventsDir, PENDING), '');
+		expect(hasPendingLines(root)).toBe(false);
+	});
+
+	it("is true for any actor's pending lines, live or rotated", () => {
+		write('02aaa~pending-01abc.bo.jsonl', ['bo']);
+
+		expect(hasPendingLines(root)).toBe(true);
+	});
+
+	it('is false when the events directory does not exist', () => {
+		fs.rmSync(eventsDir, {recursive: true, force: true});
+
+		expect(hasPendingLines(root)).toBe(false);
 	});
 });

--- a/source/lib/event/pending-log.test.ts
+++ b/source/lib/event/pending-log.test.ts
@@ -1,0 +1,186 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {isSuccess, Result} from '../model/result-types.js';
+import {
+	flushPendingLogs,
+	isPendingFileName,
+	toPendingFileName,
+	trackedFileNameFor,
+} from './pending-log.js';
+
+const TRACKED = '01hzz.ana.jsonl';
+const PENDING = '01hzz~pending.ana.jsonl';
+
+let root: string;
+let eventsDir: string;
+
+const unwrap = <T>(result: Result<T>): T => {
+	if (!isSuccess(result)) throw new Error(result.message);
+	return result.value;
+};
+
+const write = (name: string, lines: string[]) =>
+	fs.writeFileSync(
+		path.join(eventsDir, name),
+		lines.map(line => `${line}\n`).join(''),
+	);
+
+const linesOf = (name: string): string[] => {
+	const filePath = path.join(eventsDir, name);
+	if (!fs.existsSync(filePath)) return [];
+
+	return fs
+		.readFileSync(filePath, 'utf8')
+		.split('\n')
+		.filter(line => line.trim().length > 0);
+};
+
+const namesIn = (): string[] => fs.readdirSync(eventsDir).sort();
+
+beforeEach(() => {
+	root = fs.mkdtempSync(path.join(os.tmpdir(), 'epiq-pending-'));
+	eventsDir = path.join(root, '.epiq', 'events');
+	fs.mkdirSync(eventsDir, {recursive: true});
+});
+
+afterEach(() => {
+	fs.rmSync(root, {recursive: true, force: true});
+});
+
+describe('the pending log name', () => {
+	it('marks the id segment, which is the one that cannot hold a dot', () => {
+		expect(toPendingFileName(TRACKED)).toBe(PENDING);
+		expect(trackedFileNameFor(PENDING)).toBe(TRACKED);
+	});
+
+	// The whole reason the marker is not a `.pending` suffix: a name may contain
+	// dots, so a contributor actually called "pending" would be unreadable from
+	// a real pending file.
+	it('does not mistake a contributor named "pending" for a pending file', () => {
+		expect(trackedFileNameFor('01hzz.pending.jsonl')).toBeNull();
+		expect(isPendingFileName('01hzz.pending.jsonl')).toBe(false);
+	});
+
+	it('survives a name that contains dots of its own', () => {
+		const tracked = '01hzz.j.-lampa.jsonl';
+
+		expect(trackedFileNameFor(toPendingFileName(tracked))).toBe(tracked);
+	});
+
+	// A rotated file is still read and still resolves to the same actor, so
+	// events stay visible while a flush is part-way through.
+	it('recognises a rotated file, and resolves it to the same log', () => {
+		const rotated = '01hzz~pending-01abc.ana.jsonl';
+
+		expect(isPendingFileName(rotated)).toBe(true);
+		expect(trackedFileNameFor(rotated)).toBe(TRACKED);
+	});
+
+	it('leaves an ordinary log alone', () => {
+		expect(trackedFileNameFor(TRACKED)).toBeNull();
+		expect(isPendingFileName(TRACKED)).toBe(false);
+	});
+});
+
+describe('flushing pending logs', () => {
+	it('does nothing when there is nothing pending', () => {
+		write(TRACKED, ['a']);
+
+		expect(unwrap(flushPendingLogs(root))).toBe(0);
+		expect(linesOf(TRACKED)).toEqual(['a']);
+	});
+
+	it('folds the pending lines onto the end of the tracked log', () => {
+		write(TRACKED, ['a', 'b']);
+		write(PENDING, ['c', 'd']);
+
+		expect(unwrap(flushPendingLogs(root))).toBe(2);
+		expect(linesOf(TRACKED)).toEqual(['a', 'b', 'c', 'd']);
+		expect(namesIn()).toEqual([TRACKED]);
+	});
+
+	it('creates the tracked log when the actor has only ever written pending', () => {
+		write(PENDING, ['a']);
+
+		unwrap(flushPendingLogs(root));
+
+		expect(linesOf(TRACKED)).toEqual(['a']);
+	});
+
+	// A crash between the append and the delete leaves a rotated file behind.
+	// The next flush has to find it — that is the whole reason it globs rather
+	// than looking only at the live name.
+	it('picks up a rotated file a crashed flush left behind', () => {
+		write(TRACKED, ['a']);
+		write('01hzz~pending-01abc.ana.jsonl', ['stranded']);
+
+		expect(unwrap(flushPendingLogs(root))).toBe(1);
+		expect(linesOf(TRACKED)).toEqual(['a', 'stranded']);
+		expect(namesIn()).toEqual([TRACKED]);
+	});
+
+	it('folds a stray and the live file in the same pass', () => {
+		write(TRACKED, ['a']);
+		write('01hzz~pending-01abc.ana.jsonl', ['stranded']);
+		write(PENDING, ['live']);
+
+		unwrap(flushPendingLogs(root));
+
+		expect(linesOf(TRACKED).sort()).toEqual(['a', 'live', 'stranded']);
+		expect(namesIn()).toEqual([TRACKED]);
+	});
+
+	it('keeps each actor with their own log', () => {
+		write('01hzz.ana.jsonl', ['ana-1']);
+		write('01hzz~pending.ana.jsonl', ['ana-2']);
+		write('02aaa.bo.jsonl', ['bo-1']);
+		write('02aaa~pending.bo.jsonl', ['bo-2']);
+
+		unwrap(flushPendingLogs(root));
+
+		expect(linesOf('01hzz.ana.jsonl')).toEqual(['ana-1', 'ana-2']);
+		expect(linesOf('02aaa.bo.jsonl')).toEqual(['bo-1', 'bo-2']);
+	});
+
+	// A line that is not newline-terminated would otherwise be joined to the
+	// first line of the tracked log's next append — two events lost, and union
+	// merge relies on every line standing alone.
+	it('terminates a final line the writer left unterminated', () => {
+		write(TRACKED, ['a']);
+		fs.writeFileSync(path.join(eventsDir, PENDING), 'b');
+
+		unwrap(flushPendingLogs(root));
+
+		expect(linesOf(TRACKED)).toEqual(['a', 'b']);
+		expect(fs.readFileSync(path.join(eventsDir, TRACKED), 'utf8')).toMatch(
+			/\n$/,
+		);
+	});
+
+	it('leaves an empty pending file behind no trace', () => {
+		write(TRACKED, ['a']);
+		fs.writeFileSync(path.join(eventsDir, PENDING), '');
+
+		expect(unwrap(flushPendingLogs(root))).toBe(0);
+		expect(linesOf(TRACKED)).toEqual(['a']);
+		expect(namesIn()).toEqual([TRACKED]);
+	});
+
+	it('is safe to run twice', () => {
+		write(TRACKED, ['a']);
+		write(PENDING, ['b']);
+
+		unwrap(flushPendingLogs(root));
+		unwrap(flushPendingLogs(root));
+
+		expect(linesOf(TRACKED)).toEqual(['a', 'b']);
+	});
+
+	it('shrugs off an events directory that is not there yet', () => {
+		fs.rmSync(eventsDir, {recursive: true, force: true});
+
+		expect(unwrap(flushPendingLogs(root))).toBe(0);
+	});
+});

--- a/source/lib/event/pending-log.test.ts
+++ b/source/lib/event/pending-log.test.ts
@@ -1,9 +1,10 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {isSuccess, Result} from '../model/result-types.js';
 import {
+	appendPendingLine,
 	flushPendingLogs,
 	isPendingFileName,
 	toPendingFileName,
@@ -46,6 +47,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+	vi.restoreAllMocks();
 	fs.rmSync(root, {recursive: true, force: true});
 });
 
@@ -198,5 +200,36 @@ describe('flushing pending logs', () => {
 		fs.rmSync(eventsDir, {recursive: true, force: true});
 
 		expect(unwrap(flushPendingLogs(root, TRACKED))).toBe(0);
+	});
+});
+
+describe('appending to a pending log', () => {
+	it('appends a line', () => {
+		appendPendingLine(path.join(eventsDir, PENDING), 'a\n');
+		appendPendingLine(path.join(eventsDir, PENDING), 'b\n');
+
+		expect(linesOf(PENDING)).toEqual(['a', 'b']);
+	});
+
+	// The writer opened the file, then a flush renamed it, read it and deleted
+	// it, and only then did the write happen. O_APPEND follows the inode, so
+	// the line went into the file that was just deleted. Reproduced exactly by
+	// running the flush between the open and the write.
+	it('keeps a line written into a file a flush rotated underneath it', () => {
+		write(PENDING, ['before']);
+
+		const writeSync = fs.writeSync;
+		vi.spyOn(fs, 'writeSync').mockImplementationOnce(((
+			fd: number,
+			data: string,
+		) => {
+			unwrap(flushPendingLogs(root, TRACKED));
+			return writeSync(fd, data);
+		}) as typeof fs.writeSync);
+
+		appendPendingLine(path.join(eventsDir, PENDING), 'during\n');
+
+		expect(linesOf(TRACKED)).toEqual(['before']);
+		expect(linesOf(PENDING)).toEqual(['during']);
 	});
 });

--- a/source/lib/event/pending-log.test.ts
+++ b/source/lib/event/pending-log.test.ts
@@ -163,6 +163,18 @@ describe('flushing pending logs', () => {
 		);
 	});
 
+	// The other side of the same splice: a tracked log that ends in a partial
+	// line — a crash mid-append, or a git truncation — must not have the first
+	// pending line glued onto it.
+	it('separates the pending lines from a partial tail in the tracked log', () => {
+		fs.writeFileSync(path.join(eventsDir, TRACKED), 'a\n{"id":["b",nu');
+		write(PENDING, ['c', 'd']);
+
+		unwrap(flushPendingLogs(root, TRACKED));
+
+		expect(linesOf(TRACKED)).toEqual(['a', '{"id":["b",nu', 'c', 'd']);
+	});
+
 	it('leaves an empty pending file behind no trace', () => {
 		write(TRACKED, ['a']);
 		fs.writeFileSync(path.join(eventsDir, PENDING), '');

--- a/source/lib/event/pending-log.test.ts
+++ b/source/lib/event/pending-log.test.ts
@@ -88,7 +88,7 @@ describe('flushing pending logs', () => {
 	it('does nothing when there is nothing pending', () => {
 		write(TRACKED, ['a']);
 
-		expect(unwrap(flushPendingLogs(root))).toBe(0);
+		expect(unwrap(flushPendingLogs(root, TRACKED))).toBe(0);
 		expect(linesOf(TRACKED)).toEqual(['a']);
 	});
 
@@ -96,7 +96,7 @@ describe('flushing pending logs', () => {
 		write(TRACKED, ['a', 'b']);
 		write(PENDING, ['c', 'd']);
 
-		expect(unwrap(flushPendingLogs(root))).toBe(2);
+		expect(unwrap(flushPendingLogs(root, TRACKED))).toBe(2);
 		expect(linesOf(TRACKED)).toEqual(['a', 'b', 'c', 'd']);
 		expect(namesIn()).toEqual([TRACKED]);
 	});
@@ -104,7 +104,7 @@ describe('flushing pending logs', () => {
 	it('creates the tracked log when the actor has only ever written pending', () => {
 		write(PENDING, ['a']);
 
-		unwrap(flushPendingLogs(root));
+		unwrap(flushPendingLogs(root, TRACKED));
 
 		expect(linesOf(TRACKED)).toEqual(['a']);
 	});
@@ -116,7 +116,7 @@ describe('flushing pending logs', () => {
 		write(TRACKED, ['a']);
 		write('01hzz~pending-01abc.ana.jsonl', ['stranded']);
 
-		expect(unwrap(flushPendingLogs(root))).toBe(1);
+		expect(unwrap(flushPendingLogs(root, TRACKED))).toBe(1);
 		expect(linesOf(TRACKED)).toEqual(['a', 'stranded']);
 		expect(namesIn()).toEqual([TRACKED]);
 	});
@@ -126,22 +126,26 @@ describe('flushing pending logs', () => {
 		write('01hzz~pending-01abc.ana.jsonl', ['stranded']);
 		write(PENDING, ['live']);
 
-		unwrap(flushPendingLogs(root));
+		unwrap(flushPendingLogs(root, TRACKED));
 
 		expect(linesOf(TRACKED).sort()).toEqual(['a', 'live', 'stranded']);
 		expect(namesIn()).toEqual([TRACKED]);
 	});
 
-	it('keeps each actor with their own log', () => {
+	// A sync commits only its own file. Folding another actor's pending lines
+	// would leave them dirty in a tracked file through the rebase, in no commit
+	// and no snapshot — so they stay where git cannot reach them.
+	it("leaves another actor's pending log where it is", () => {
 		write('01hzz.ana.jsonl', ['ana-1']);
 		write('01hzz~pending.ana.jsonl', ['ana-2']);
 		write('02aaa.bo.jsonl', ['bo-1']);
 		write('02aaa~pending.bo.jsonl', ['bo-2']);
 
-		unwrap(flushPendingLogs(root));
+		unwrap(flushPendingLogs(root, '01hzz.ana.jsonl'));
 
 		expect(linesOf('01hzz.ana.jsonl')).toEqual(['ana-1', 'ana-2']);
-		expect(linesOf('02aaa.bo.jsonl')).toEqual(['bo-1', 'bo-2']);
+		expect(linesOf('02aaa.bo.jsonl')).toEqual(['bo-1']);
+		expect(linesOf('02aaa~pending.bo.jsonl')).toEqual(['bo-2']);
 	});
 
 	// A line that is not newline-terminated would otherwise be joined to the
@@ -151,7 +155,7 @@ describe('flushing pending logs', () => {
 		write(TRACKED, ['a']);
 		fs.writeFileSync(path.join(eventsDir, PENDING), 'b');
 
-		unwrap(flushPendingLogs(root));
+		unwrap(flushPendingLogs(root, TRACKED));
 
 		expect(linesOf(TRACKED)).toEqual(['a', 'b']);
 		expect(fs.readFileSync(path.join(eventsDir, TRACKED), 'utf8')).toMatch(
@@ -163,7 +167,7 @@ describe('flushing pending logs', () => {
 		write(TRACKED, ['a']);
 		fs.writeFileSync(path.join(eventsDir, PENDING), '');
 
-		expect(unwrap(flushPendingLogs(root))).toBe(0);
+		expect(unwrap(flushPendingLogs(root, TRACKED))).toBe(0);
 		expect(linesOf(TRACKED)).toEqual(['a']);
 		expect(namesIn()).toEqual([TRACKED]);
 	});
@@ -172,8 +176,8 @@ describe('flushing pending logs', () => {
 		write(TRACKED, ['a']);
 		write(PENDING, ['b']);
 
-		unwrap(flushPendingLogs(root));
-		unwrap(flushPendingLogs(root));
+		unwrap(flushPendingLogs(root, TRACKED));
+		unwrap(flushPendingLogs(root, TRACKED));
 
 		expect(linesOf(TRACKED)).toEqual(['a', 'b']);
 	});
@@ -181,6 +185,6 @@ describe('flushing pending logs', () => {
 	it('shrugs off an events directory that is not there yet', () => {
 		fs.rmSync(eventsDir, {recursive: true, force: true});
 
-		expect(unwrap(flushPendingLogs(root))).toBe(0);
+		expect(unwrap(flushPendingLogs(root, TRACKED))).toBe(0);
 	});
 });

--- a/source/lib/event/pending-log.ts
+++ b/source/lib/event/pending-log.ts
@@ -30,10 +30,15 @@ import {getEventsDirPath} from '../storage/paths.js';
  */
 const PENDING_MARKER = '~pending';
 
-// A rotated file keeps the marker and adds a unique suffix, so it is still
-// read, still resolves to the same actor, and is still recognisably pending
-// while a flush is part-way through it.
-const PENDING_SEGMENT = /~pending(-[0-9a-z]+)?$/i;
+// The id segment of a pending file is one of three shapes, all still read and
+// all resolving to the same actor:
+//
+//   <id>~pending                 live: what `persist` appends to
+//   <id>~pending-<ulid>          rotated: a flush has renamed it and is reading it
+//   <id>~pending-<ulid>-f<bytes> folded: the first <bytes> are in the tracked log
+const PENDING_SEGMENT = /~pending(-[0-9a-z]+)*$/i;
+
+const FOLDED_SUFFIX = /-f(\d+)$/;
 
 /** `<id>.<name>.jsonl` -> `<id>~pending.<name>.jsonl`. */
 export const toPendingFileName = (trackedFileName: string): string => {
@@ -47,17 +52,21 @@ export const toPendingFileName = (trackedFileName: string): string => {
 	);
 };
 
+const splitName = (fileName: string): [string, string] => {
+	const separator = fileName.indexOf('.');
+
+	return separator === -1
+		? [fileName, '']
+		: [fileName.slice(0, separator), fileName.slice(separator)];
+};
+
 /** The tracked log a pending file belongs to, or null if it is not one. */
 export const trackedFileNameFor = (fileName: string): string | null => {
-	const separator = fileName.indexOf('.');
-	const idSegment = separator === -1 ? fileName : fileName.slice(0, separator);
+	const [idSegment, rest] = splitName(fileName);
 
 	if (!PENDING_SEGMENT.test(idSegment)) return null;
 
-	return (
-		idSegment.replace(PENDING_SEGMENT, '') +
-		(separator === -1 ? '' : fileName.slice(separator))
-	);
+	return idSegment.replace(PENDING_SEGMENT, '') + rest;
 };
 
 /**
@@ -74,17 +83,38 @@ export const stripPendingMarker = (idSegment: string): string =>
 export const isPendingFileName = (fileName: string): boolean =>
 	fileName.endsWith('.jsonl') && trackedFileNameFor(fileName) !== null;
 
+/** How many leading bytes of a folded file are already in the tracked log. */
+export const foldedBytesOf = (fileName: string): number | null => {
+	const [idSegment] = splitName(fileName);
+	const match = FOLDED_SUFFIX.exec(idSegment);
+
+	return match && isPendingFileName(fileName) ? Number(match[1]) : null;
+};
+
+const rotatedFileName = (trackedFileName: string): string =>
+	toPendingFileName(trackedFileName).replace(
+		PENDING_MARKER,
+		`${PENDING_MARKER}-${ulid().toLowerCase()}`,
+	);
+
+const foldedFileName = (rotatedName: string, bytes: number): string => {
+	const [idSegment, rest] = splitName(rotatedName);
+
+	return `${idSegment.replace(FOLDED_SUFFIX, '')}-f${bytes}${rest}`;
+};
+
 export const getPendingLogPath = (
 	eventsRoot: string,
 	trackedFileName: string,
 ): string =>
 	path.join(getEventsDirPath(eventsRoot), toPendingFileName(trackedFileName));
 
-const hasLines = (filePath: string): boolean =>
-	fs.readFileSync(filePath, 'utf8').trim().length > 0;
+/** Bytes not yet folded: all of a live or rotated file, the tail of a folded one. */
+const unfoldedBytes = (filePath: string, name: string): number =>
+	Math.max(0, fs.statSync(filePath).size - (foldedBytesOf(name) ?? 0));
 
 /**
- * Whether any pending log holds lines.
+ * Whether any pending log holds lines that are in no tracked log yet.
  *
  * Pending logs are ignored, so `git status` does not list them — but they hold
  * every event written since the last sync, and a guard that asks git whether a
@@ -101,7 +131,7 @@ export const hasPendingLines = (eventsRoot: string): boolean => {
 		return fs
 			.readdirSync(dir)
 			.filter(isPendingFileName)
-			.some(name => hasLines(path.join(dir, name)));
+			.some(name => unfoldedBytes(path.join(dir, name), name) > 0);
 	} catch {
 		return true;
 	}
@@ -114,13 +144,18 @@ const MAX_APPEND_ATTEMPTS = 3;
 /**
  * Appends one line to a pending log, and makes sure it stays reachable.
  *
- * A flush rotates the pending file by renaming it, reads the renamed file and
- * deletes it. An append is open, write, close, in a process holding no lock —
- * and O_APPEND follows the inode, so a writer preempted between its open and
- * its write lands the line in a file the flush has already read and is about
- * to delete. So after writing, check that the path still leads to the file
- * written to; if not, write again to whatever is there now. A line that lands
- * in both is deduped by id; one that lands in neither is gone.
+ * A flush rotates the pending file by renaming it. An append is open, write,
+ * close, in a process holding no lock — and O_APPEND follows the inode, so a
+ * writer preempted between its open and its write lands the line in a file the
+ * flush has already read. So after writing, check that the path still leads to
+ * the file written to; if not, write again to whatever is there now. A line
+ * that lands in both is deduped by id.
+ *
+ * This is a belt, not the braces. The comparison is by inode number, and that
+ * is not a sound oracle on its own: ext4 hands a freed number to the next file
+ * created, and APFS can resolve a just-renamed path to the old inode for a
+ * moment under concurrent lookups. What keeps the line safe is the flush never
+ * deleting a file a writer could still reach — see `flushPendingLogs`.
  */
 export const appendPendingLine = (filePath: string, line: string): void => {
 	for (let attempt = 1; ; attempt++) {
@@ -172,6 +207,45 @@ const endsCleanly = (filePath: string): boolean => {
 	}
 };
 
+const NEWLINE = 0x0a;
+
+/**
+ * Appends the whole lines in `bytes` to the tracked log and returns how many
+ * bytes that covered. A trailing fragment with no newline is a write still in
+ * flight or a crash remnant; it is not a line yet, so it is left for the next
+ * pass rather than spliced onto the log — unless this is the file's last pass
+ * (`final`), when it is appended terminated: a fragment that old is a remnant,
+ * and the loader's quarantine is the right place for it, not the bin.
+ */
+const foldLines = (
+	trackedPath: string,
+	bytes: Buffer,
+	final = false,
+): {bytes: number; lines: number} => {
+	const end = final ? bytes.length : bytes.lastIndexOf(NEWLINE) + 1;
+	if (end === 0) return {bytes: 0, lines: 0};
+
+	const whole = bytes.subarray(0, end);
+	if (whole.toString('utf8').trim().length === 0) return {bytes: end, lines: 0};
+
+	// Newline-terminated on both sides: a joined pair of lines is two events
+	// lost, and union merge relies on every line standing alone.
+	fs.appendFileSync(
+		trackedPath,
+		Buffer.concat([
+			Buffer.from(endsCleanly(trackedPath) ? '' : '\n'),
+			whole,
+			Buffer.from(whole[whole.length - 1] === NEWLINE ? '' : '\n'),
+		]),
+	);
+
+	let lines = 0;
+	for (const byte of whole) if (byte === NEWLINE) lines++;
+	if (whole[whole.length - 1] !== NEWLINE) lines++;
+
+	return {bytes: end, lines};
+};
+
 /**
  * Folds one actor's pending file(s) into the tracked log they belong to.
  *
@@ -181,15 +255,26 @@ const endsCleanly = (filePath: string): boolean => {
  * in no snapshot either — which is the loss this file exists to prevent. Theirs
  * stay pending, out of git's reach, until they sync.
  *
- * Rotate, append, delete — in that order, and never truncate. Renaming first
- * means an append landing after the rotate creates a fresh pending file rather
- * than being erased, and `appendPendingLine` covers the one that opened the
- * file before the rename. Appending before deleting means a crash leaves lines
- * in both files, and `getSortedEvents` dedupes by id, so a duplicate costs
- * nothing while a loss cannot be undone.
+ * Each pass moves a file one step along: live → rotated → folded → gone.
  *
- * A crash therefore leaves a rotated file behind, which is why this picks up
- * every pending file of the actor's rather than only the live one.
+ * Rotating first means an append landing after the rename creates a fresh live
+ * file rather than being erased. Folding appends the whole lines read and
+ * records how many bytes that was in the name, so the next pass can fold only
+ * what arrived after. Deleting waits for that next pass, and that is the
+ * load-bearing part: a writer can still reach a file that was just rotated — one
+ * preempted between opening it and writing, or one whose path lookup resolved
+ * to the old inode after the rename (measured on APFS under contention) — and
+ * a file deleted while it is reachable takes those lines with it, on ext4 past
+ * the writer's own inode check too, since the freed number goes to the next
+ * file created. The rename to the folded name purges the stale lookup, the
+ * file stays readable and attributed to the actor meanwhile, and by the next
+ * sync nothing has held it open for seconds.
+ *
+ * Appending before renaming or deleting means a crash leaves lines in both
+ * files, and `getSortedEvents` dedupes by id, so a duplicate costs nothing
+ * while a loss cannot be undone. A crash therefore leaves a rotated or folded
+ * file behind, which is why this picks up every pending file of the actor's
+ * rather than only the live one.
  *
  * Must run while this process holds the state worktree — it writes the tracked
  * log, which is exactly what a sync must not have happening underneath it.
@@ -211,38 +296,37 @@ export const flushPendingLogs = (
 		let folded = 0;
 
 		for (const name of pending) {
+			const already = foldedBytesOf(name);
+
+			if (already !== null) {
+				// Folded on the previous pass: take whatever arrived since, then
+				// it is safe to delete — nothing can reach it any more.
+				const filePath = path.join(dir, name);
+				const tail = fs.readFileSync(filePath).subarray(already);
+
+				folded += foldLines(trackedPath, tail, true).lines;
+				fs.rmSync(filePath, {force: true});
+				continue;
+			}
+
 			// One already carrying a unique suffix was left by a flush that did
 			// not finish. Take it as it stands rather than rotating a rotation.
-			const alreadyRotated = /~pending-/i.test(name);
-
-			const rotated = alreadyRotated
+			const rotated = /~pending-/i.test(name)
 				? name
-				: toPendingFileName(ownFileName).replace(
-						PENDING_MARKER,
-						`${PENDING_MARKER}-${ulid().toLowerCase()}`,
-				  );
-
+				: rotatedFileName(ownFileName);
 			const rotatedPath = path.join(dir, rotated);
 
-			if (!alreadyRotated) {
+			if (rotated !== name) {
 				fs.renameSync(path.join(dir, name), rotatedPath);
 			}
 
-			const content = fs.readFileSync(rotatedPath, 'utf8');
+			const result = foldLines(trackedPath, fs.readFileSync(rotatedPath));
+			folded += result.lines;
 
-			if (content.trim().length > 0) {
-				// Newline-terminated on both sides regardless of what either file
-				// ended with: a joined pair of lines is two events lost, and union
-				// merge relies on every line standing alone.
-				const normalized =
-					(endsCleanly(trackedPath) ? '' : '\n') +
-					(content.endsWith('\n') ? content : `${content}\n`);
-
-				fs.appendFileSync(trackedPath, normalized, 'utf8');
-				folded += content.trimEnd().split('\n').length;
-			}
-
-			fs.rmSync(rotatedPath, {force: true});
+			fs.renameSync(
+				rotatedPath,
+				path.join(dir, foldedFileName(rotated, result.bytes)),
+			);
 		}
 
 		return succeeded('Folded pending logs', folded);

--- a/source/lib/event/pending-log.ts
+++ b/source/lib/event/pending-log.ts
@@ -81,22 +81,30 @@ export const getPendingLogPath = (
 	path.join(getEventsDirPath(eventsRoot), toPendingFileName(trackedFileName));
 
 /**
- * Folds every pending file into the tracked log it belongs to.
+ * Folds one actor's pending file(s) into the tracked log they belong to.
+ *
+ * Only the syncing actor's own. A sync commits only its own file, so folding
+ * somebody else's pending lines would leave them dirty in a tracked file for
+ * the whole rebase — in no commit and, since the snapshot skips pending logs,
+ * in no snapshot either — which is the loss this file exists to prevent. Theirs
+ * stay pending, out of git's reach, until they sync.
  *
  * Rotate, append, delete — in that order, and never truncate. Renaming first
- * means an append landing mid-flush creates a fresh pending file at the
- * original path rather than being erased; the rename is atomic, so no line
- * falls between the two. Appending before deleting means a crash leaves lines
- * in both files, and `getSortedEvents` dedupes by id, so a duplicate costs
- * nothing while a loss cannot be undone.
+ * means an append landing after the rotate creates a fresh pending file rather
+ * than being erased. Appending before deleting means a crash leaves lines in
+ * both files, and `getSortedEvents` dedupes by id, so a duplicate costs nothing
+ * while a loss cannot be undone.
  *
  * A crash therefore leaves a rotated file behind, which is why this picks up
- * every pending file it finds rather than only the live one.
+ * every pending file of the actor's rather than only the live one.
  *
  * Must run while this process holds the state worktree — it writes the tracked
  * log, which is exactly what a sync must not have happening underneath it.
  */
-export const flushPendingLogs = (eventsRoot: string): Result<number> => {
+export const flushPendingLogs = (
+	eventsRoot: string,
+	ownFileName: string,
+): Result<number> => {
 	const dir = getEventsDirPath(eventsRoot);
 
 	if (!fs.existsSync(dir)) return succeeded('No events directory', 0);
@@ -104,22 +112,19 @@ export const flushPendingLogs = (eventsRoot: string): Result<number> => {
 	try {
 		const pending = fs
 			.readdirSync(dir)
-			.filter(name => name.endsWith('.jsonl'))
-			.filter(isPendingFileName);
+			.filter(name => trackedFileNameFor(name) === ownFileName);
 
+		const trackedPath = path.join(dir, ownFileName);
 		let folded = 0;
 
 		for (const name of pending) {
-			const tracked = trackedFileNameFor(name);
-			if (!tracked) continue;
-
 			// One already carrying a unique suffix was left by a flush that did
 			// not finish. Take it as it stands rather than rotating a rotation.
 			const alreadyRotated = /~pending-/i.test(name);
 
 			const rotated = alreadyRotated
 				? name
-				: toPendingFileName(tracked).replace(
+				: toPendingFileName(ownFileName).replace(
 						PENDING_MARKER,
 						`${PENDING_MARKER}-${ulid().toLowerCase()}`,
 				  );
@@ -138,7 +143,7 @@ export const flushPendingLogs = (eventsRoot: string): Result<number> => {
 				// on every line standing alone.
 				const normalized = content.endsWith('\n') ? content : `${content}\n`;
 
-				fs.appendFileSync(path.join(dir, tracked), normalized, 'utf8');
+				fs.appendFileSync(trackedPath, normalized, 'utf8');
 				folded += normalized.trimEnd().split('\n').length;
 			}
 

--- a/source/lib/event/pending-log.ts
+++ b/source/lib/event/pending-log.ts
@@ -80,6 +80,33 @@ export const getPendingLogPath = (
 ): string =>
 	path.join(getEventsDirPath(eventsRoot), toPendingFileName(trackedFileName));
 
+const hasLines = (filePath: string): boolean =>
+	fs.readFileSync(filePath, 'utf8').trim().length > 0;
+
+/**
+ * Whether any pending log holds lines.
+ *
+ * Pending logs are ignored, so `git status` does not list them — but they hold
+ * every event written since the last sync, and a guard that asks git whether a
+ * worktree still has unpublished work has to ask this too. Any actor's: the
+ * worktree is shared, and the lines are somebody's either way. Unreadable
+ * counts as held, for the same reason `findStrandedEventLogs` refuses.
+ */
+export const hasPendingLines = (eventsRoot: string): boolean => {
+	const dir = getEventsDirPath(eventsRoot);
+
+	try {
+		if (!fs.existsSync(dir)) return false;
+
+		return fs
+			.readdirSync(dir)
+			.filter(isPendingFileName)
+			.some(name => hasLines(path.join(dir, name)));
+	} catch {
+		return true;
+	}
+};
+
 // Bounded for a filesystem whose inode numbers are not stable, where the check
 // below could never agree and every append would otherwise loop.
 const MAX_APPEND_ATTEMPTS = 3;

--- a/source/lib/event/pending-log.ts
+++ b/source/lib/event/pending-log.ts
@@ -80,6 +80,44 @@ export const getPendingLogPath = (
 ): string =>
 	path.join(getEventsDirPath(eventsRoot), toPendingFileName(trackedFileName));
 
+// Bounded for a filesystem whose inode numbers are not stable, where the check
+// below could never agree and every append would otherwise loop.
+const MAX_APPEND_ATTEMPTS = 3;
+
+/**
+ * Appends one line to a pending log, and makes sure it stays reachable.
+ *
+ * A flush rotates the pending file by renaming it, reads the renamed file and
+ * deletes it. An append is open, write, close, in a process holding no lock —
+ * and O_APPEND follows the inode, so a writer preempted between its open and
+ * its write lands the line in a file the flush has already read and is about
+ * to delete. So after writing, check that the path still leads to the file
+ * written to; if not, write again to whatever is there now. A line that lands
+ * in both is deduped by id; one that lands in neither is gone.
+ */
+export const appendPendingLine = (filePath: string, line: string): void => {
+	for (let attempt = 1; ; attempt++) {
+		const fd = fs.openSync(filePath, 'a');
+		let written: number;
+
+		try {
+			fs.writeSync(fd, line);
+			written = fs.fstatSync(fd).ino;
+		} finally {
+			fs.closeSync(fd);
+		}
+
+		let current: number | null;
+		try {
+			current = fs.statSync(filePath).ino;
+		} catch {
+			current = null;
+		}
+
+		if (current === written || attempt >= MAX_APPEND_ATTEMPTS) return;
+	}
+};
+
 /**
  * Whether the log can take an appended line as a line of its own. A file that
  * is missing or empty can; one whose last byte is not a newline ends in a
@@ -118,9 +156,10 @@ const endsCleanly = (filePath: string): boolean => {
  *
  * Rotate, append, delete — in that order, and never truncate. Renaming first
  * means an append landing after the rotate creates a fresh pending file rather
- * than being erased. Appending before deleting means a crash leaves lines in
- * both files, and `getSortedEvents` dedupes by id, so a duplicate costs nothing
- * while a loss cannot be undone.
+ * than being erased, and `appendPendingLine` covers the one that opened the
+ * file before the rename. Appending before deleting means a crash leaves lines
+ * in both files, and `getSortedEvents` dedupes by id, so a duplicate costs
+ * nothing while a loss cannot be undone.
  *
  * A crash therefore leaves a rotated file behind, which is why this picks up
  * every pending file of the actor's rather than only the live one.

--- a/source/lib/event/pending-log.ts
+++ b/source/lib/event/pending-log.ts
@@ -1,0 +1,156 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import {ulid} from 'ulid';
+import {failed, Result, succeeded} from '../model/result-types.js';
+import {getEventsDirPath} from '../storage/paths.js';
+
+/**
+ * Where an append actually lands.
+ *
+ * The tracked log is a file git owns. To rebase, git stashes the working copy,
+ * checks out the remote's version and puts the stash back — and a line written
+ * while that is happening was in no stash, so the checkout writes over it. It
+ * is not a merge going wrong: `*.jsonl merge=union` handles concurrent appends
+ * correctly, but only for lines that are *committed*. An uncommitted line is
+ * invisible to the merge and is simply overwritten.
+ *
+ * So appends go to a file git does not track. Git resets around it, and a sync
+ * folds it into the tracked log once git is done with the worktree.
+ *
+ * The marker sits on the *id* segment, which is the one part of the name that
+ * cannot contain a `.` — names can ("J. Lampa" becomes `<id>.j.-lampa`), so a
+ * `.pending` suffix there would be indistinguishable from a contributor
+ * actually called "pending". `~` survives no sanitising (`sanitizeFilePart`
+ * maps everything outside `[a-z0-9._-]` to `-`), so no real id can end in one.
+ *
+ * The name still ends in `.jsonl`, which is what every reader globs for. That
+ * is deliberate and load-bearing: `mintEventId` derives an event's causal
+ * parent from the same directory, and an append it could not see would mint an
+ * id sorting before its own parent.
+ */
+const PENDING_MARKER = '~pending';
+
+// A rotated file keeps the marker and adds a unique suffix, so it is still
+// read, still resolves to the same actor, and is still recognisably pending
+// while a flush is part-way through it.
+const PENDING_SEGMENT = /~pending(-[0-9a-z]+)?$/i;
+
+/** `<id>.<name>.jsonl` -> `<id>~pending.<name>.jsonl`. */
+export const toPendingFileName = (trackedFileName: string): string => {
+	const separator = trackedFileName.indexOf('.');
+	if (separator === -1) return `${trackedFileName}${PENDING_MARKER}`;
+
+	return (
+		trackedFileName.slice(0, separator) +
+		PENDING_MARKER +
+		trackedFileName.slice(separator)
+	);
+};
+
+/** The tracked log a pending file belongs to, or null if it is not one. */
+export const trackedFileNameFor = (fileName: string): string | null => {
+	const separator = fileName.indexOf('.');
+	const idSegment = separator === -1 ? fileName : fileName.slice(0, separator);
+
+	if (!PENDING_SEGMENT.test(idSegment)) return null;
+
+	return (
+		idSegment.replace(PENDING_SEGMENT, '') +
+		(separator === -1 ? '' : fileName.slice(separator))
+	);
+};
+
+/**
+ * The actor id a segment names, with any pending marker removed.
+ *
+ * The id is the one thing read off a log's file name — a display name never is,
+ * since the name segment is a sanitized storage key that a rename leaves stale.
+ * So this has to come off before the id is used, or a pending line resolves to
+ * a contributor who does not exist.
+ */
+export const stripPendingMarker = (idSegment: string): string =>
+	idSegment.replace(PENDING_SEGMENT, '');
+
+export const isPendingFileName = (fileName: string): boolean =>
+	fileName.endsWith('.jsonl') && trackedFileNameFor(fileName) !== null;
+
+export const getPendingLogPath = (
+	eventsRoot: string,
+	trackedFileName: string,
+): string =>
+	path.join(getEventsDirPath(eventsRoot), toPendingFileName(trackedFileName));
+
+/**
+ * Folds every pending file into the tracked log it belongs to.
+ *
+ * Rotate, append, delete — in that order, and never truncate. Renaming first
+ * means an append landing mid-flush creates a fresh pending file at the
+ * original path rather than being erased; the rename is atomic, so no line
+ * falls between the two. Appending before deleting means a crash leaves lines
+ * in both files, and `getSortedEvents` dedupes by id, so a duplicate costs
+ * nothing while a loss cannot be undone.
+ *
+ * A crash therefore leaves a rotated file behind, which is why this picks up
+ * every pending file it finds rather than only the live one.
+ *
+ * Must run while this process holds the state worktree — it writes the tracked
+ * log, which is exactly what a sync must not have happening underneath it.
+ */
+export const flushPendingLogs = (eventsRoot: string): Result<number> => {
+	const dir = getEventsDirPath(eventsRoot);
+
+	if (!fs.existsSync(dir)) return succeeded('No events directory', 0);
+
+	try {
+		const pending = fs
+			.readdirSync(dir)
+			.filter(name => name.endsWith('.jsonl'))
+			.filter(isPendingFileName);
+
+		let folded = 0;
+
+		for (const name of pending) {
+			const tracked = trackedFileNameFor(name);
+			if (!tracked) continue;
+
+			// One already carrying a unique suffix was left by a flush that did
+			// not finish. Take it as it stands rather than rotating a rotation.
+			const alreadyRotated = /~pending-/i.test(name);
+
+			const rotated = alreadyRotated
+				? name
+				: toPendingFileName(tracked).replace(
+						PENDING_MARKER,
+						`${PENDING_MARKER}-${ulid().toLowerCase()}`,
+				  );
+
+			const rotatedPath = path.join(dir, rotated);
+
+			if (!alreadyRotated) {
+				fs.renameSync(path.join(dir, name), rotatedPath);
+			}
+
+			const content = fs.readFileSync(rotatedPath, 'utf8');
+
+			if (content.trim().length > 0) {
+				// Newline-terminated regardless of what the source ended with: a
+				// joined pair of lines is two events lost, and union merge relies
+				// on every line standing alone.
+				const normalized = content.endsWith('\n') ? content : `${content}\n`;
+
+				fs.appendFileSync(path.join(dir, tracked), normalized, 'utf8');
+				folded += normalized.trimEnd().split('\n').length;
+			}
+
+			fs.rmSync(rotatedPath, {force: true});
+		}
+
+		return succeeded('Folded pending logs', folded);
+	} catch (error) {
+		return failed(
+			`Unable to fold pending event logs in ${dir}: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+	}
+};

--- a/source/lib/event/pending-log.ts
+++ b/source/lib/event/pending-log.ts
@@ -81,6 +81,33 @@ export const getPendingLogPath = (
 	path.join(getEventsDirPath(eventsRoot), toPendingFileName(trackedFileName));
 
 /**
+ * Whether the log can take an appended line as a line of its own. A file that
+ * is missing or empty can; one whose last byte is not a newline ends in a
+ * partial line — a crash mid-append, or a git truncation — and a line spliced
+ * onto it would be lost with it. Reads one byte, not the file.
+ */
+const endsCleanly = (filePath: string): boolean => {
+	let fd: number;
+	try {
+		fd = fs.openSync(filePath, 'r');
+	} catch {
+		return true;
+	}
+
+	try {
+		const {size} = fs.fstatSync(fd);
+		if (size === 0) return true;
+
+		const last = Buffer.alloc(1);
+		fs.readSync(fd, last, 0, 1, size - 1);
+
+		return last[0] === 0x0a;
+	} finally {
+		fs.closeSync(fd);
+	}
+};
+
+/**
  * Folds one actor's pending file(s) into the tracked log they belong to.
  *
  * Only the syncing actor's own. A sync commits only its own file, so folding
@@ -138,13 +165,15 @@ export const flushPendingLogs = (
 			const content = fs.readFileSync(rotatedPath, 'utf8');
 
 			if (content.trim().length > 0) {
-				// Newline-terminated regardless of what the source ended with: a
-				// joined pair of lines is two events lost, and union merge relies
-				// on every line standing alone.
-				const normalized = content.endsWith('\n') ? content : `${content}\n`;
+				// Newline-terminated on both sides regardless of what either file
+				// ended with: a joined pair of lines is two events lost, and union
+				// merge relies on every line standing alone.
+				const normalized =
+					(endsCleanly(trackedPath) ? '' : '\n') +
+					(content.endsWith('\n') ? content : `${content}\n`);
 
 				fs.appendFileSync(trackedPath, normalized, 'utf8');
-				folded += normalized.trimEnd().split('\n').length;
+				folded += content.trimEnd().split('\n').length;
 			}
 
 			fs.rmSync(rotatedPath, {force: true});

--- a/source/lib/project-setup/init-project.ts
+++ b/source/lib/project-setup/init-project.ts
@@ -22,6 +22,7 @@ import {
 } from '../../git/git.js';
 import {createDefaultEvents} from '../event/event-boot.js';
 import {getPersistFileName, persist} from '../event/event-persist.js';
+import {flushPendingLogs} from '../event/pending-log.js';
 import {AppEvent} from '../event/event.model.js';
 import {failed, isFail, Result, succeeded} from '../model/result-types.js';
 import {User} from '../state/settings.state.js';
@@ -188,6 +189,14 @@ export const initProject = async ({
 		const persistResult = persist({event, rootDir: stateBranchRoot});
 		if (isFail(persistResult)) return failAt(9, persistResult.message);
 	}
+
+	// Those appends went to the pending log, which is untracked by design and
+	// ignored outright — so there would be nothing to stage, and the first
+	// commit of a new project would fail with "nothing added to commit". Folded
+	// in here for the same reason a sync folds them in: this is the moment the
+	// tracked log is about to be handed to git.
+	const flushResult = flushPendingLogs(stateBranchRoot);
+	if (isFail(flushResult)) return failAt(9, flushResult.message);
 
 	// 10. commit initial event log on state branch
 	const stageStateEventFileResult = await stageStateBranchOwnEventFile({

--- a/source/lib/project-setup/init-project.ts
+++ b/source/lib/project-setup/init-project.ts
@@ -195,13 +195,15 @@ export const initProject = async ({
 	// commit of a new project would fail with "nothing added to commit". Folded
 	// in here for the same reason a sync folds them in: this is the moment the
 	// tracked log is about to be handed to git.
-	const flushResult = flushPendingLogs(stateBranchRoot);
+	const ownEventFileName = getPersistFileName({userId, userName});
+
+	const flushResult = flushPendingLogs(stateBranchRoot, ownEventFileName);
 	if (isFail(flushResult)) return failAt(9, flushResult.message);
 
 	// 10. commit initial event log on state branch
 	const stageStateEventFileResult = await stageStateBranchOwnEventFile({
 		stateBranchRoot,
-		eventFileName: getPersistFileName({userId, userName}),
+		eventFileName: ownEventFileName,
 	});
 	if (isFail(stageStateEventFileResult)) {
 		return failAt(10, stageStateEventFileResult.message);

--- a/source/test/actor-assume.test.ts
+++ b/source/test/actor-assume.test.ts
@@ -6,6 +6,7 @@ import {createDefaultEvents} from '../lib/event/event-boot.js';
 import {materializeAndPersistAll} from '../lib/event/event-materialize-and-persist.js';
 import {getPersistFileName} from '../lib/event/event-persist.js';
 import {AppEvent} from '../lib/event/event.model.js';
+import {flushPendingLogs} from '../lib/event/pending-log.js';
 import {isFail} from '../lib/model/result-types.js';
 import {
 	assumeActor,
@@ -63,6 +64,10 @@ describe('assumeActor', () => {
 		// to read the name back from.
 		const branchRoot = getStateBranchRoot({repoRoot});
 		if (isFail(branchRoot)) throw new Error(branchRoot.message);
+
+		// Appends land in the pending log, out of reach of a sync; folding them
+		// in is what puts them in the file a replay reads.
+		flushPendingLogs(branchRoot.value);
 
 		const written = fs.readFileSync(
 			getEventsFile({
@@ -153,6 +158,8 @@ describe('assumeActor', () => {
 			parentId: swimlanes.value[0]!.id,
 		});
 		if (isFail(created)) throw new Error(created.message);
+
+		flushPendingLogs(branchRoot.value);
 
 		// Attribution is the file the event landed in: the actor id is parsed back
 		// out of the log's name, never carried in the payload.

--- a/source/test/actor-assume.test.ts
+++ b/source/test/actor-assume.test.ts
@@ -67,15 +67,17 @@ describe('assumeActor', () => {
 
 		// Appends land in the pending log, out of reach of a sync; folding them
 		// in is what puts them in the file a replay reads.
-		flushPendingLogs(branchRoot.value);
+		const peterFile = getPersistFileName({
+			userId: deriveActorId('claude/peter'),
+			userName: 'claude/peter',
+		});
+
+		flushPendingLogs(branchRoot.value, peterFile);
 
 		const written = fs.readFileSync(
 			getEventsFile({
 				root: branchRoot.value,
-				fileName: getPersistFileName({
-					userId: deriveActorId('claude/peter'),
-					userName: 'claude/peter',
-				}),
+				fileName: peterFile,
 			}),
 			'utf-8',
 		);
@@ -159,7 +161,7 @@ describe('assumeActor', () => {
 		});
 		if (isFail(created)) throw new Error(created.message);
 
-		flushPendingLogs(branchRoot.value);
+		flushPendingLogs(branchRoot.value, getPersistFileName(assumed.value));
 
 		// Attribution is the file the event landed in: the actor id is parsed back
 		// out of the log's name, never carried in the payload.

--- a/source/test/actor-env.test.ts
+++ b/source/test/actor-env.test.ts
@@ -16,6 +16,7 @@ import {
 	persist,
 	resolveActorId,
 } from '../lib/event/event-persist.js';
+import {flushPendingLogs} from '../lib/event/pending-log.js';
 import {isFail} from '../lib/model/result-types.js';
 import {patchSettingsState} from '../lib/state/settings.state.js';
 
@@ -276,6 +277,11 @@ describe('loadSettingsFromConfig', () => {
 		});
 
 		expect(isFail(written)).toBe(false);
+
+		// The append lands in the pending log; folding it in is what leaves the
+		// events directory holding one file, named for the actor who wrote it.
+		flushPendingLogs(rootDir);
+
 		expect(fs.readdirSync(path.join(rootDir, '.epiq', 'events'))).toEqual([
 			getPersistFileName(actor.value),
 		]);

--- a/source/test/actor-env.test.ts
+++ b/source/test/actor-env.test.ts
@@ -280,6 +280,8 @@ describe('loadSettingsFromConfig', () => {
 
 		// The append lands in the pending log; folding it in is what leaves the
 		// events directory holding one file, named for the actor who wrote it.
+		// Two passes: a flush keeps the file it folded until the next one.
+		flushPendingLogs(rootDir, getPersistFileName(actor.value));
 		flushPendingLogs(rootDir, getPersistFileName(actor.value));
 
 		expect(fs.readdirSync(path.join(rootDir, '.epiq', 'events'))).toEqual([

--- a/source/test/actor-env.test.ts
+++ b/source/test/actor-env.test.ts
@@ -280,7 +280,7 @@ describe('loadSettingsFromConfig', () => {
 
 		// The append lands in the pending log; folding it in is what leaves the
 		// events directory holding one file, named for the actor who wrote it.
-		flushPendingLogs(rootDir);
+		flushPendingLogs(rootDir, getPersistFileName(actor.value));
 
 		expect(fs.readdirSync(path.join(rootDir, '.epiq', 'events'))).toEqual([
 			getPersistFileName(actor.value),

--- a/source/test/e2e-collab/log-reader.ts
+++ b/source/test/e2e-collab/log-reader.ts
@@ -3,6 +3,7 @@
 // Losing one is data loss whether or not we can read it.
 import fs from 'node:fs';
 import path from 'node:path';
+import {toPendingFileName} from '../../lib/event/pending-log.js';
 
 const eventsDir = (stateBranchRoot: string): string =>
 	path.join(stateBranchRoot, '.epiq', 'events');
@@ -26,14 +27,22 @@ const idsInFile = (filePath: string): string[] => {
 	return ids;
 };
 
+/**
+ * What this actor has written — including what it has not synced yet.
+ *
+ * An append lands in the pending log and stays there until a sync folds it into
+ * the tracked one, so reading the tracked file alone answers "what have I
+ * published", which is a different question and reads as nothing at all for
+ * somebody working offline.
+ */
 export const readOwnEventIds = (
 	stateBranchRoot: string,
 	fileName: string,
-): string[] => {
-	const filePath = path.join(eventsDir(stateBranchRoot), fileName);
-
-	return fs.existsSync(filePath) ? idsInFile(filePath) : [];
-};
+): string[] =>
+	[fileName, toPendingFileName(fileName)]
+		.map(name => path.join(eventsDir(stateBranchRoot), name))
+		.filter(filePath => fs.existsSync(filePath))
+		.flatMap(idsInFile);
 
 export const readEventIds = (stateBranchRoot: string): string[] => {
 	const dir = eventsDir(stateBranchRoot);

--- a/source/test/e2e-collab/log-reader.ts
+++ b/source/test/e2e-collab/log-reader.ts
@@ -3,7 +3,7 @@
 // Losing one is data loss whether or not we can read it.
 import fs from 'node:fs';
 import path from 'node:path';
-import {toPendingFileName} from '../../lib/event/pending-log.js';
+import {trackedFileNameFor} from '../../lib/event/pending-log.js';
 
 const eventsDir = (stateBranchRoot: string): string =>
 	path.join(stateBranchRoot, '.epiq', 'events');
@@ -33,16 +33,21 @@ const idsInFile = (filePath: string): string[] => {
  * An append lands in the pending log and stays there until a sync folds it into
  * the tracked one, so reading the tracked file alone answers "what have I
  * published", which is a different question and reads as nothing at all for
- * somebody working offline.
+ * somebody working offline. Every pending file of the actor's counts — live,
+ * rotated or folded — since a flush part-way through leaves lines in any of them.
  */
 export const readOwnEventIds = (
 	stateBranchRoot: string,
 	fileName: string,
-): string[] =>
-	[fileName, toPendingFileName(fileName)]
-		.map(name => path.join(eventsDir(stateBranchRoot), name))
-		.filter(filePath => fs.existsSync(filePath))
-		.flatMap(idsInFile);
+): string[] => {
+	const dir = eventsDir(stateBranchRoot);
+	if (!fs.existsSync(dir)) return [];
+
+	return fs
+		.readdirSync(dir)
+		.filter(name => name === fileName || trackedFileNameFor(name) === fileName)
+		.flatMap(name => idsInFile(path.join(dir, name)));
+};
 
 export const readEventIds = (stateBranchRoot: string): string[] => {
 	const dir = eventsDir(stateBranchRoot);

--- a/source/test/e2e-collab/write-during-sync.test.ts
+++ b/source/test/e2e-collab/write-during-sync.test.ts
@@ -58,6 +58,43 @@ const acceptedTitles = (report: ActorReport, expected: string[]): string[] => {
 	return refused.length > 0 ? [] : expected;
 };
 
+/**
+ * A sync that lost the race to a concurrent write.
+ *
+ * Nothing holds a lock on the append path, deliberately: a write that had to
+ * wait on a sync would stall the person doing it, and this is the busiest path
+ * in the app. So git can find the log dirty at any point while it rebases and
+ * refuse — before it starts, at its pre-flight check, or part-way through the
+ * replay, which is why this matches three different refusals.
+ *
+ * The sync fails having changed nothing and the next one picks it up. That is
+ * the design, not a defect, and it is not what this file is here to catch: the
+ * contract in the header is that an accepted issue does not go missing, and
+ * that stays asserted exactly as strictly as before.
+ */
+const BLOCKED_BY_A_CONCURRENT_WRITE =
+	/unstaged changes|would be overwritten|could not detach HEAD/;
+
+/**
+ * Tolerated, but counted. An occasional blip is what the design trades for a
+ * lock-free write path; every round failing is a regression that would
+ * otherwise hide behind the same message. This is the line between them.
+ */
+const MAX_BLOCKED_SYNCS = 4;
+
+// Anything that is neither of the two known, expected outcomes. One of these
+// fails the round it appears in, on its first occurrence.
+const unexpectedProblems = (problems: string[]): string[] =>
+	problems.filter(
+		problem =>
+			!/Another process is syncing/.test(problem) &&
+			!BLOCKED_BY_A_CONCURRENT_WRITE.test(problem),
+	);
+
+const blockedSyncs = (problems: string[]): number =>
+	problems.filter(problem => BLOCKED_BY_A_CONCURRENT_WRITE.test(problem))
+		.length;
+
 const publishRemoteWork = async (peer: Actor, round: number): Promise<void> => {
 	for (let commit = 0; commit < COMMITS_PER_ROUND; commit += 1) {
 		const published = await runActor(peer, {
@@ -101,6 +138,7 @@ describe('a tool writes while another process syncs the same worktree', () => {
 			).toEqual([]);
 
 			const expected: string[] = [];
+			let blocked = 0;
 
 			for (let round = 0; round < ROUNDS; round += 1) {
 				await publishRemoteWork(bo, round);
@@ -120,13 +158,21 @@ describe('a tool writes while another process syncs the same worktree', () => {
 				]);
 
 				expect(
-					syncing.problems.filter(p => !/Another process is syncing/.test(p)),
+					unexpectedProblems(syncing.problems),
 					`ana syncing round ${round}`,
 				).toEqual([]);
+
+				blocked += blockedSyncs(syncing.problems);
 
 				expected.push(...acceptedTitles(writing, titles));
 			}
 
+			expect(
+				blocked,
+				'syncs blocked by a concurrent write',
+			).toBeLessThanOrEqual(MAX_BLOCKED_SYNCS);
+
+			// Nothing is writing any more, so this one has no excuse.
 			const settled = await runActor(agent, {actions: [], sync: true});
 			expect(settled.problems, 'agent settling').toEqual([]);
 
@@ -172,6 +218,7 @@ describe('a tool writes while another process syncs the same worktree', () => {
 			).toEqual([]);
 
 			const expected: string[] = [];
+			let blocked = 0;
 
 			for (let round = 0; round < ROUNDS; round += 1) {
 				await publishRemoteWork(elsewhere, round);
@@ -191,13 +238,21 @@ describe('a tool writes while another process syncs the same worktree', () => {
 				]);
 
 				expect(
-					syncing.problems.filter(p => !/Another process is syncing/.test(p)),
+					unexpectedProblems(syncing.problems),
 					`syncing round ${round}`,
 				).toEqual([]);
+
+				blocked += blockedSyncs(syncing.problems);
 
 				expected.push(...acceptedTitles(writing, titles));
 			}
 
+			expect(
+				blocked,
+				'syncs blocked by a concurrent write',
+			).toBeLessThanOrEqual(MAX_BLOCKED_SYNCS);
+
+			// Nothing is writing any more, so this one has no excuse.
 			const settled = await runActor(here, {actions: [], sync: true});
 			expect(settled.problems, 'settling').toEqual([]);
 

--- a/source/test/e2e/pending-log.e2e.test.ts
+++ b/source/test/e2e/pending-log.e2e.test.ts
@@ -1,0 +1,174 @@
+/**
+ * A write survives git resetting the log underneath it — deterministically.
+ *
+ * `write-during-sync.test.ts` in the collaboration suite covers the same
+ * ground by racing a real writer against a real sync, and that is worth having:
+ * it is the honest end-to-end shape. But it is a race, so it reports the bug
+ * only when the writer happens to land inside git's window. It has passed while
+ * the bug was present and failed while it was absent, which makes it useless
+ * for proving either.
+ *
+ * The destructive step is not random, though. It is git resetting a tracked
+ * file, and that can simply be done on demand. Everything here is exact: no
+ * timing, no retries, no luck.
+ */
+import {execFileSync} from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {ensureStateBranchLayout} from '../../git/git-storage.js';
+import {
+	restoreDroppedEventLines,
+	snapshotEventLogs,
+} from '../../git/log-integrity.js';
+import {isFail} from '../../lib/model/result-types.js';
+import {
+	flushPendingLogs,
+	toPendingFileName,
+} from '../../lib/event/pending-log.js';
+
+const TRACKED = '01hzzactor.ana.jsonl';
+const PENDING = toPendingFileName(TRACKED);
+
+let repo: string;
+let eventsDir: string;
+
+const git = (...args: string[]) =>
+	execFileSync('git', args, {cwd: repo, encoding: 'utf8'});
+
+const eventLine = (id: string) =>
+	`${JSON.stringify({v: 1, id: [id, null], 'issue.create': {title: id}})}\n`;
+
+const linesOf = (name: string): string[] => {
+	const filePath = path.join(eventsDir, name);
+	if (!fs.existsSync(filePath)) return [];
+
+	return fs
+		.readFileSync(filePath, 'utf8')
+		.split('\n')
+		.filter(line => line.trim().length > 0);
+};
+
+const idsIn = (name: string): string[] =>
+	linesOf(name).map(line => (JSON.parse(line) as {id: [string]}).id[0]);
+
+beforeEach(() => {
+	repo = fs.mkdtempSync(path.join(os.tmpdir(), 'epiq-pending-e2e-'));
+	eventsDir = path.join(repo, '.epiq', 'events');
+
+	git('init', '-q');
+
+	// The real layout, not a hand-rolled one: the merge attribute and the
+	// ignore rule that keeps a pending log untrackable are part of what is
+	// under test, and a test that wrote its own copy would pass while the
+	// product's version was wrong.
+	const layout = ensureStateBranchLayout(repo, repo);
+	if (isFail(layout)) throw new Error(layout.message);
+
+	git('config', 'user.email', 'test@example.com');
+	git('config', 'user.name', 'test');
+
+	// The tracked log, committed — this is the file git owns and resets.
+	fs.writeFileSync(path.join(eventsDir, TRACKED), eventLine('committed'));
+	git('add', '-A');
+	git('commit', '-q', '-m', 'the log so far');
+});
+
+afterEach(() => {
+	fs.rmSync(repo, {recursive: true, force: true});
+});
+
+describe('a write while git holds the worktree', () => {
+	// The bug, stated exactly. `git checkout -- .` is what a rebase's stash and
+	// checkout, and what `rebase --abort`, do to a tracked file: they put back
+	// the committed content and discard whatever was written since.
+	it('is destroyed when it went into the tracked log', () => {
+		fs.appendFileSync(path.join(eventsDir, TRACKED), eventLine('written'));
+		expect(idsIn(TRACKED)).toEqual(['committed', 'written']);
+
+		git('checkout', '--', '.');
+
+		// This is the data loss, reproduced without any race at all.
+		expect(idsIn(TRACKED)).toEqual(['committed']);
+	});
+
+	it('survives when it went into the pending log', () => {
+		fs.appendFileSync(path.join(eventsDir, PENDING), eventLine('written'));
+
+		git('checkout', '--', '.');
+
+		expect(idsIn(PENDING)).toEqual(['written']);
+	});
+
+	// `rebase --abort` is the harsher one: it resets rather than checks out.
+	it('survives a hard reset', () => {
+		fs.appendFileSync(path.join(eventsDir, PENDING), eventLine('written'));
+
+		git('reset', '--hard', '-q', 'HEAD');
+
+		expect(idsIn(PENDING)).toEqual(['written']);
+	});
+
+	// The autostash half of a rebase: stash the working copy, put it back.
+	it('survives a stash round trip', () => {
+		fs.appendFileSync(path.join(eventsDir, TRACKED), eventLine('dirty'));
+		fs.appendFileSync(path.join(eventsDir, PENDING), eventLine('written'));
+
+		git('stash', 'push', '-q', '-m', 'autostash');
+		git('stash', 'pop', '-q');
+
+		expect(idsIn(PENDING)).toEqual(['written']);
+	});
+
+	it('is folded into the tracked log once git is done', () => {
+		fs.appendFileSync(path.join(eventsDir, PENDING), eventLine('written'));
+
+		git('checkout', '--', '.');
+		flushPendingLogs(repo);
+
+		expect(idsIn(TRACKED)).toEqual(['committed', 'written']);
+		expect(fs.existsSync(path.join(eventsDir, PENDING))).toBe(false);
+	});
+
+	// The snapshot exists to put back lines git dropped. A pending log is not
+	// something git can drop, and a sync deliberately consumes one — so if the
+	// snapshot covered it, the restore would read the flush as loss and put the
+	// file back. The lines would then sit in both, and every later sync would
+	// append them again.
+	it('is not resurrected by the integrity snapshot after a flush', () => {
+		fs.appendFileSync(path.join(eventsDir, PENDING), eventLine('written'));
+
+		const snapshot = snapshotEventLogs(repo);
+		flushPendingLogs(repo);
+		const restored = restoreDroppedEventLines(repo, snapshot);
+
+		expect(restored).toEqual([]);
+		expect(fs.existsSync(path.join(eventsDir, PENDING))).toBe(false);
+		expect(idsIn(TRACKED)).toEqual(['committed', 'written']);
+	});
+
+	// The other half: a line the *tracked* log lost is still put back, so
+	// excluding pending files has not blunted the net.
+	it('still restores a line git dropped from the tracked log', () => {
+		fs.appendFileSync(path.join(eventsDir, TRACKED), eventLine('at-risk'));
+
+		const snapshot = snapshotEventLogs(repo);
+		git('checkout', '--', '.');
+		const restored = restoreDroppedEventLines(repo, snapshot);
+
+		// Reported as `<name> (<lines put back>)`.
+		expect(restored).toEqual([`${TRACKED} (1)`]);
+		expect(idsIn(TRACKED)).toEqual(['committed', 'at-risk']);
+	});
+
+	// The pending file must never be committed, or it stops being untracked and
+	// the whole scheme quietly reverts to the broken one.
+	it('is not something `git add -A` picks up', () => {
+		fs.appendFileSync(path.join(eventsDir, PENDING), eventLine('written'));
+
+		git('add', '-A');
+
+		expect(git('diff', '--cached', '--name-only')).not.toContain(PENDING);
+	});
+});

--- a/source/test/e2e/pending-log.e2e.test.ts
+++ b/source/test/e2e/pending-log.e2e.test.ts
@@ -125,7 +125,7 @@ describe('a write while git holds the worktree', () => {
 		fs.appendFileSync(path.join(eventsDir, PENDING), eventLine('written'));
 
 		git('checkout', '--', '.');
-		flushPendingLogs(repo);
+		flushPendingLogs(repo, TRACKED);
 
 		expect(idsIn(TRACKED)).toEqual(['committed', 'written']);
 		expect(fs.existsSync(path.join(eventsDir, PENDING))).toBe(false);
@@ -140,7 +140,7 @@ describe('a write while git holds the worktree', () => {
 		fs.appendFileSync(path.join(eventsDir, PENDING), eventLine('written'));
 
 		const snapshot = snapshotEventLogs(repo);
-		flushPendingLogs(repo);
+		flushPendingLogs(repo, TRACKED);
 		const restored = restoreDroppedEventLines(repo, snapshot);
 
 		expect(restored).toEqual([]);
@@ -170,5 +170,37 @@ describe('a write while git holds the worktree', () => {
 		git('add', '-A');
 
 		expect(git('diff', '--cached', '--name-only')).not.toContain(PENDING);
+	});
+});
+
+// The sync's order is snapshot (pending excluded), flush, stage the own file,
+// commit, hand the worktree to git, restore. Another actor sharing the worktree
+// has lines in their pending log throughout; they are committed by nobody here.
+// Folding them would put them in a tracked file with nothing behind them —
+// leaving them pending is what keeps them.
+describe("another actor's pending log during someone else's sync", () => {
+	const OTHER = '01hzzother.bo.jsonl';
+
+	it('survives the whole sequence untouched', () => {
+		fs.writeFileSync(path.join(eventsDir, OTHER), eventLine('bo-committed'));
+		git('add', '-A');
+		git('commit', '-q', '-m', 'both logs');
+
+		fs.appendFileSync(
+			path.join(eventsDir, toPendingFileName(OTHER)),
+			eventLine('bo-written'),
+		);
+		fs.appendFileSync(path.join(eventsDir, PENDING), eventLine('ana-written'));
+
+		const snapshot = snapshotEventLogs(repo);
+		flushPendingLogs(repo, TRACKED);
+		git('add', '--', `.epiq/events/${TRACKED}`);
+		git('commit', '-q', '-m', 'ana sync');
+		git('checkout', '--', '.');
+		restoreDroppedEventLines(repo, snapshot);
+
+		expect(idsIn(TRACKED)).toEqual(['committed', 'ana-written']);
+		expect(idsIn(OTHER)).toEqual(['bo-committed']);
+		expect(idsIn(toPendingFileName(OTHER))).toEqual(['bo-written']);
 	});
 });

--- a/source/test/event-persist-batch.test.ts
+++ b/source/test/event-persist-batch.test.ts
@@ -3,6 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 import {materializeAndPersistAll} from '../lib/event/event-materialize-and-persist.js';
+import {flushPendingLogs} from '../lib/event/pending-log.js';
 import {getPersistFileName} from '../lib/event/event-persist.js';
 import {AppEvent} from '../lib/event/event.model.js';
 import {isFail} from '../lib/model/result-types.js';
@@ -50,8 +51,12 @@ afterEach(() => {
 	fs.rmSync(rootDir, {recursive: true, force: true});
 });
 
-const ownLogLines = (): Array<{id: [string, string | null]}> =>
-	fs
+// Folded in first: a batch appends to the pending log, and this asks what the
+// actor's own log holds once a sync has taken it.
+const ownLogLines = (): Array<{id: [string, string | null]}> => {
+	flushPendingLogs(rootDir);
+
+	return fs
 		.readFileSync(
 			path.join(
 				rootDir,
@@ -64,6 +69,7 @@ const ownLogLines = (): Array<{id: [string, string | null]}> =>
 		.trim()
 		.split('\n')
 		.map(line => JSON.parse(line));
+};
 
 describe('materializeAndPersistAll edge threading', () => {
 	it('reads the log once per batch, not once per event', () => {

--- a/source/test/event-persist-batch.test.ts
+++ b/source/test/event-persist-batch.test.ts
@@ -54,7 +54,10 @@ afterEach(() => {
 // Folded in first: a batch appends to the pending log, and this asks what the
 // actor's own log holds once a sync has taken it.
 const ownLogLines = (): Array<{id: [string, string | null]}> => {
-	flushPendingLogs(rootDir);
+	flushPendingLogs(
+		rootDir,
+		getPersistFileName({userId: 'u1', userName: 'alice'}),
+	);
 
 	return fs
 		.readFileSync(

--- a/source/test/event-persist.test.ts
+++ b/source/test/event-persist.test.ts
@@ -9,6 +9,7 @@ import {
 	persist,
 	toPersistedEvent,
 } from '../lib/event/event-persist.js';
+import {flushPendingLogs} from '../lib/event/pending-log.js';
 import {resolveClosestEpiqRoot} from '../lib/storage/paths.js';
 import {AppEvent, StoredAppEvent} from '../lib/event/event.model.js';
 import {isFail} from '../lib/model/result-types.js';
@@ -128,6 +129,10 @@ describe('event persist', () => {
 
 		expect(isFail(result)).toBe(false);
 
+		// An append lands in the pending log, out of reach of a sync resetting
+		// the worktree; folding it in is what puts it in the actor's own log.
+		flushPendingLogs(rootDir);
+
 		const filePath = path.join(rootDir, '.epiq', 'events', 'u1.alice.jsonl');
 
 		expect(fs.existsSync(filePath)).toBe(true);
@@ -162,6 +167,8 @@ describe('event persist', () => {
 		});
 
 		expect(isFail(second)).toBe(false);
+
+		flushPendingLogs(rootDir);
 
 		const filePath = path.join(rootDir, '.epiq', 'events', 'u1.alice.jsonl');
 
@@ -229,7 +236,7 @@ describe('event persist', () => {
 
 		expect(isFail(result)).toBe(false);
 		if (isFail(result)) return;
-		expect(path.basename(result.value.path)).toBe('u1.a-jsonl.b.jsonl');
+		expect(path.basename(result.value.path)).toBe('u1~pending.a-jsonl.b.jsonl');
 	});
 });
 

--- a/source/test/event-persist.test.ts
+++ b/source/test/event-persist.test.ts
@@ -131,7 +131,7 @@ describe('event persist', () => {
 
 		// An append lands in the pending log, out of reach of a sync resetting
 		// the worktree; folding it in is what puts it in the actor's own log.
-		flushPendingLogs(rootDir);
+		flushPendingLogs(rootDir, 'u1.alice.jsonl');
 
 		const filePath = path.join(rootDir, '.epiq', 'events', 'u1.alice.jsonl');
 
@@ -168,7 +168,7 @@ describe('event persist', () => {
 
 		expect(isFail(second)).toBe(false);
 
-		flushPendingLogs(rootDir);
+		flushPendingLogs(rootDir, 'u1.alice.jsonl');
 
 		const filePath = path.join(rootDir, '.epiq', 'events', 'u1.alice.jsonl');
 

--- a/source/test/worktree-move-data-loss.test.ts
+++ b/source/test/worktree-move-data-loss.test.ts
@@ -3,6 +3,8 @@ import path from 'node:path';
 import {beforeEach, describe, expect, it} from 'vitest';
 import {execGit} from '../git/git-utils.js';
 import {ensureLocalStateBranch, ensureStateBranchWorktree} from '../git/git.js';
+import {ensureStateBranchLayout} from '../git/git-storage.js';
+import {toPendingFileName} from '../lib/event/pending-log.js';
 import {isFail} from '../lib/model/result-types.js';
 import {makeTempDir} from './helpers/git-repo.js';
 
@@ -75,6 +77,38 @@ describe('relocating the state worktree must not discard unsynced events', () =>
 
 		expect(fs.existsSync(logPath())).toBe(true);
 		expect(fs.readFileSync(logPath(), 'utf8')).toContain('UNSYNCED EVENT');
+	});
+
+	// An append lands in the pending log, which the committed layout ignores —
+	// so `git status`, which is what the guard asks, does not list it. It is
+	// still every event written since the last sync.
+	it('refuses over a pending log that git status cannot see', async () => {
+		const layout = ensureStateBranchLayout(repoRoot, originalRoot);
+		if (isFail(layout)) throw new Error(layout.message);
+
+		await execGit({args: ['add', '-A'], cwd: originalRoot});
+		await execGit({
+			args: ['commit', '-qm', 'sync', '--no-verify'],
+			cwd: originalRoot,
+		});
+
+		const pendingPath = path.join(
+			path.dirname(logPath()),
+			toPendingFileName(path.basename(LOG)),
+		);
+		fs.writeFileSync(pendingPath, 'PENDING EVENT\n');
+
+		const result = await ensureStateBranchWorktree({
+			repoRoot,
+			stateBranchRoot: otherRoot,
+			stateBranchName: BRANCH,
+		});
+
+		expect(isFail(result)).toBe(true);
+		if (!isFail(result)) return;
+		expect(result.message).toContain('not committed yet');
+
+		expect(fs.readFileSync(pendingPath, 'utf8')).toContain('PENDING EVENT');
 	});
 
 	// The other deletion on this path: a directory with no `.git` is treated as

--- a/source/test/write-identity.test.ts
+++ b/source/test/write-identity.test.ts
@@ -10,6 +10,7 @@ import {
 import {loadMergedEvents} from '../lib/event/event-load.js';
 import {materializeAndPersistAll} from '../lib/event/event-materialize-and-persist.js';
 import {getPersistFileName, persist} from '../lib/event/event-persist.js';
+import {flushPendingLogs} from '../lib/event/pending-log.js';
 import {AppEvent} from '../lib/event/event.model.js';
 import {isFail} from '../lib/model/result-types.js';
 import {nodes} from '../lib/state/node-builder.js';
@@ -96,8 +97,12 @@ afterEach(() => {
 	fs.rmSync(rootDir, {recursive: true, force: true});
 });
 
-const persistedIds = (): string[] =>
-	fs
+// Folded in first: an append lands in the pending log, where a sync resetting
+// the worktree cannot reach it, and this asks what the actor's own log holds.
+const persistedIds = (): string[] => {
+	flushPendingLogs(rootDir);
+
+	return fs
 		.readFileSync(
 			path.join(rootDir, '.epiq', 'events', getPersistFileName(actor)),
 			'utf8',
@@ -105,6 +110,7 @@ const persistedIds = (): string[] =>
 		.trim()
 		.split('\n')
 		.map(line => (JSON.parse(line) as {id: [string, string | null]}).id[0]);
+};
 
 const loggedIds = (nodeId: string): string[] =>
 	(getState().nodes[nodeId]?.log ?? []).map(event => event.id);

--- a/source/test/write-identity.test.ts
+++ b/source/test/write-identity.test.ts
@@ -100,7 +100,7 @@ afterEach(() => {
 // Folded in first: an append lands in the pending log, where a sync resetting
 // the worktree cannot reach it, and this asks what the actor's own log holds.
 const persistedIds = (): string[] => {
-	flushPendingLogs(rootDir);
+	flushPendingLogs(rootDir, getPersistFileName(actor));
 
 	return fs
 		.readFileSync(


### PR DESCRIPTION
Two commits: the collaboration suite in CI (`V8TZ5CD`), and the data-loss fix it made visible (`QRJDX9F`).

**Full write-up for review is on `QRJDX9F` — two comments headed "Handoff for review".** They carry the reasoning, the measurements, the self-review findings, and an explicit list of what I got wrong along the way. Read those before the diff.

### The bug

An append lands in a file git tracks. To rebase, git stashes the working copy, checks out the remote's version and puts the stash back — a line written while that is happening was in no stash, and the checkout writes over it. Issues the board *accepted* go missing from the machine that created them, with no error shown to whoever created them.

Not a merge or CRDT flaw: `*.jsonl merge=union` handles concurrent appends correctly, but only for lines that are **committed**. An uncommitted line is invisible to the merge.

Measured on the same suite and machine: **62 issues lost** at the commit that introduced the test, **16** on recent main, **0** here.

### The fix

Appends go to `<id>~pending.<name>.jsonl` beside the tracked log. Git does not track it, so a reset goes around it; a sync folds it in once git is finished with the worktree.

The marker sits on the id segment because names may contain dots, so a `.pending` suffix would be indistinguishable from a contributor called "pending" — and `sanitizeFilePart` can never produce a `~`. The name still ends in `.jsonl` so every reader picks it up unchanged, which matters most for `mintEventId`: it derives an event's causal parent from that directory, and an append it could not see would mint an id sorting before its own parent.

The flush rotates, appends, then deletes — never truncates. A concurrent append lands in a fresh file rather than being erased, and a crash duplicates rather than loses, which dedupe-by-id makes free.

### The test that was missing

`source/test/e2e/pending-log.e2e.test.ts` reproduces the loss **deterministically** — it does to a tracked file exactly what git does, and checks the line survives. No timing, no luck. **5 of its 6 core cases go red when the fix is sabotaged.** It runs in CI, which `test:collab` did not until this branch.

That absence is why this went unseen: `write-during-sync.test.ts` asserted "no sync errors" *before* "no lost issues", so under contention it always failed on the symptom and aborted before reaching the disease.

### Testing

Gate green: lint, typecheck, **1403 unit**, containers (**25 e2e**, up from 17; **15 collaboration**), **150 GUI**.

`write-during-sync.test.ts` now passes **bare on macOS**, the environment that failed on every previous run.

### Not fixed, deliberately

A sync can still fail when it races a writer. Per the decision on `V8TZ5CD`: a failed sync retries, a blocked write stalls a person.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Vuz7fJrAAc5jn53RsYhdX
