### PR TITLE
Y34SCVN how long tickets have sat in a lane

### DIFF
--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -1555,6 +1555,7 @@ export const App = () => {
 									<SwimlaneColumn
 										key={swimlane.id}
 										swimlane={swimlane}
+										live={state?.timeTravel?.mode !== 'scrub'}
 										selected={false}
 										selectedIssueId={selectedIssue?.id ?? null}
 										commentsByIssueId={commentsByIssueId}

--- a/source/gui/client/components/SwimlaneColumn.tsx
+++ b/source/gui/client/components/SwimlaneColumn.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import {DropIndicator} from '../App';
-import {GuiComment, GuiSwimlane} from '../lib/gui-state.model';
-import {GUI_THEME} from '../lib/gui-theme';
+import {GuiComment, GuiIssue, GuiSwimlane} from '../lib/gui-state.model';
+import {GUI_THEME, TEXT} from '../lib/gui-theme';
+import {formatDuration} from '../lib/gui-format.helper';
+import {dwellLevel, dwellOf, laneDwell} from '../lib/lane-dwell';
+import {CardDwell} from './TicketCard';
 import {IconLock} from './IconLock';
 import {Panel} from './Panel';
 import {TicketCard} from './TicketCard';
@@ -42,6 +45,7 @@ export const SwimlaneColumn = ({
 	onDragOverIssue,
 	onDragLeave,
 	theatre,
+	live,
 }: {
 	swimlane: GuiSwimlane;
 	selected: boolean;
@@ -74,7 +78,23 @@ export const SwimlaneColumn = ({
 	onDragOver: (swimlaneId: string) => void;
 	onDragOverIssue: (swimlaneId: string, targetIndex: number) => void;
 	onDragLeave: () => void;
+	// The board is showing the present. A dwell is time elapsed until now, which
+	// says nothing about a board being replayed at some other moment.
+	live: boolean;
 }) => {
+	// One reading for the whole column, so the header's figures and the clocks on
+	// the cards under it are answers to the same question.
+	const now = Date.now();
+	const dwell = live ? laneDwell(swimlane.issues, now) : null;
+
+	const cardDwell = (ticket: GuiIssue): CardDwell | null => {
+		if (!dwell) return null;
+
+		const ms = dwellOf(ticket, now);
+
+		return {ms, level: dwellLevel(ms, dwell, swimlane.issues.length)};
+	};
+
 	return (
 		<Panel
 			as="section"
@@ -193,6 +213,7 @@ export const SwimlaneColumn = ({
 						display: 'flex',
 						alignItems: 'center',
 						gap: 8,
+						minWidth: 0,
 					}}
 				>
 					<span
@@ -202,12 +223,39 @@ export const SwimlaneColumn = ({
 					</span>
 
 					<strong
-						style={{color: selected ? GUI_THEME.accent : GUI_THEME.primary}}
+						style={{
+							color: selected ? GUI_THEME.accent : GUI_THEME.primary,
+							// The lane's own figures are the fixed part of this row: a
+							// title long enough to crowd them out is cut instead.
+							overflow: 'hidden',
+							textOverflow: 'ellipsis',
+							whiteSpace: 'nowrap',
+						}}
 					>
 						{swimlane.title}
 					</strong>
 
 					<span style={{color: GUI_THEME.dim}}>({swimlane.issues.length})</span>
+
+					{dwell && (
+						<span
+							data-testid="swimlane-dwell"
+							title={`Time in this lane — median ${formatDuration(
+								dwell.median,
+							)}, average ${formatDuration(
+								dwell.mean,
+							)}, oldest ${formatDuration(dwell.max)}`}
+							style={{
+								color: GUI_THEME.dim,
+								fontSize: TEXT.meta,
+								whiteSpace: 'nowrap',
+								flexShrink: 0,
+							}}
+						>
+							{formatDuration(dwell.median) || '0s'} med ·{' '}
+							{formatDuration(dwell.max) || '0s'} max
+						</span>
+					)}
 
 					{swimlane.readonly && (
 						<span
@@ -280,6 +328,7 @@ export const SwimlaneColumn = ({
 									isPicked={pickedIssueIds.includes(ticket.id)}
 									onSelect={options => onSelectIssue(ticket.id, options)}
 									onOpenComments={onSelectIssueComments}
+									dwell={cardDwell(ticket)}
 									isolatedTagId={isolatedTagId}
 									onFilterByTag={onFilterByTag}
 									commentCount={commentsByIssueId[ticket.id]?.length ?? 0}

--- a/source/gui/client/components/TicketCard.tsx
+++ b/source/gui/client/components/TicketCard.tsx
@@ -7,9 +7,21 @@ import {
 	THEATRE_FLASH_TIMING,
 } from '../lib/theatre';
 import {isSwimlaneDrag} from '../lib/gui-move-swimlane';
+import {DwellLevel} from '../lib/lane-dwell';
+import {formatDuration} from '../lib/gui-format.helper';
 import {CopyRef} from './CopyRef';
+import {IconClock} from './IconClock';
 import {IconComment} from './IconComment';
 import {User} from './User';
+
+/** How long this ticket has sat in its lane, and how that reads beside its peers. */
+export type CardDwell = {ms: number; level: DwellLevel};
+
+const DWELL_COLOR: Record<DwellLevel, string> = {
+	none: GUI_THEME.dim,
+	warn: GUI_THEME.amber,
+	alert: GUI_THEME.red,
+};
 
 export const TicketCard = ({
 	ticket,
@@ -25,6 +37,7 @@ export const TicketCard = ({
 	onDropIssueAt,
 	theatre,
 	flashKey,
+	dwell,
 }: {
 	ticket: GuiIssue;
 	index: number;
@@ -47,6 +60,9 @@ export const TicketCard = ({
 	// is what matters, not its content: two events in a row on one ticket have
 	// to flash twice.
 	flashKey: string | null;
+	// Null while the board is not showing the present, where an elapsed time
+	// measured against now means nothing.
+	dwell: CardDwell | null;
 }) => {
 	const cardRef = useRef<HTMLDivElement | null>(null);
 
@@ -269,6 +285,30 @@ export const TicketCard = ({
 						paddingTop: 2,
 					}}
 				>
+					{dwell && dwell.level !== 'none' && (
+						<span
+							data-testid="ticket-dwell"
+							data-dwell-level={dwell.level}
+							title={`In this lane ${formatDuration(
+								dwell.ms,
+							)} — far longer than the rest of the column`}
+							style={{
+								display: 'inline-flex',
+								alignItems: 'center',
+								gap: 4,
+								color: DWELL_COLOR[dwell.level],
+								fontSize: 11,
+								fontWeight: 600,
+								lineHeight: 1,
+								marginTop: '-4px',
+								whiteSpace: 'nowrap',
+							}}
+						>
+							<IconClock size={12} />
+							<span>{formatDuration(dwell.ms)}</span>
+						</span>
+					)}
+
 					{commentCount > 0 && (
 						<button
 							type="button"

--- a/source/gui/client/components/TicketCard.tsx
+++ b/source/gui/client/components/TicketCard.tsx
@@ -300,6 +300,9 @@ export const TicketCard = ({
 								fontSize: 11,
 								fontWeight: 600,
 								lineHeight: 1,
+								// The assignee's height, so the two sit on one centre line
+								// rather than each on its own text box.
+								height: 20,
 								marginTop: '-4px',
 								whiteSpace: 'nowrap',
 							}}

--- a/source/gui/client/lib/commands/command-registry.test.ts
+++ b/source/gui/client/lib/commands/command-registry.test.ts
@@ -29,6 +29,7 @@ const issue = (overrides: Partial<GuiIssue> = {}): GuiIssue => ({
 	title: 'A ticket',
 	description: '',
 	createdAt: 0,
+	enteredLaneAt: 0,
 	readonly: false,
 	tags: [],
 	assignees: [],

--- a/source/gui/client/lib/gui-format.helper.ts
+++ b/source/gui/client/lib/gui-format.helper.ts
@@ -1,22 +1,29 @@
-export const timeAgo = (timestampMs: number): string => {
-	const diff = Date.now() - timestampMs;
+const DURATION_UNITS = [
+	{label: 'y', ms: 1000 * 60 * 60 * 24 * 365},
+	{label: 'mo', ms: 1000 * 60 * 60 * 24 * 30},
+	{label: 'w', ms: 1000 * 60 * 60 * 24 * 7},
+	{label: 'd', ms: 1000 * 60 * 60 * 24},
+	{label: 'h', ms: 1000 * 60 * 60},
+	{label: 'm', ms: 1000 * 60},
+	{label: 's', ms: 1000},
+];
 
-	const units = [
-		{label: 'y', ms: 1000 * 60 * 60 * 24 * 365},
-		{label: 'mo', ms: 1000 * 60 * 60 * 24 * 30},
-		{label: 'w', ms: 1000 * 60 * 60 * 24 * 7},
-		{label: 'd', ms: 1000 * 60 * 60 * 24},
-		{label: 'h', ms: 1000 * 60 * 60},
-		{label: 'm', ms: 1000 * 60},
-		{label: 's', ms: 1000},
-	];
-
-	for (const {label, ms} of units) {
-		const value = Math.floor(diff / ms);
-		if (value >= 1) return `${value}${label} ago`;
+// A span in its largest whole unit. Empty below a second, which is a length no
+// unit here can put a number on — callers word that end of the scale for
+// themselves.
+export const formatDuration = (ms: number): string => {
+	for (const {label, ms: unit} of DURATION_UNITS) {
+		const value = Math.floor(ms / unit);
+		if (value >= 1) return `${value}${label}`;
 	}
 
-	return 'just now';
+	return '';
+};
+
+export const timeAgo = (timestampMs: number): string => {
+	const elapsed = formatDuration(Date.now() - timestampMs);
+
+	return elapsed === '' ? 'just now' : `${elapsed} ago`;
 };
 
 // Full date for the hover title beside a relative one, so an exact timestamp is

--- a/source/gui/client/lib/gui-state-helper.test.ts
+++ b/source/gui/client/lib/gui-state-helper.test.ts
@@ -9,6 +9,7 @@ const issue = (id: string, ref: string, title: string): GuiIssue => ({
 	title,
 	description: '',
 	createdAt: 0,
+	enteredLaneAt: 0,
 	readonly: false,
 	isClosed: false,
 	tags: [],

--- a/source/gui/client/lib/gui-state.model.ts
+++ b/source/gui/client/lib/gui-state.model.ts
@@ -38,6 +38,8 @@ export type GuiIssue = {
 	description: string;
 	/** Epoch ms, decoded from the issue's own ULID. */
 	createdAt: number;
+	/** Epoch ms it last arrived in the swimlane it is in. */
+	enteredLaneAt: number;
 	readonly: boolean;
 	tags: GuiTag[];
 	assignees: GuiUser[];

--- a/source/gui/client/lib/gui-theme.tsx
+++ b/source/gui/client/lib/gui-theme.tsx
@@ -34,6 +34,9 @@ export const GUI_THEME = {
 	hover: 'rgba(255,255,255,0.04)',
 	accent: '#76d4ff',
 	green: '#8ce99a',
+	// One step short of `red`, at the same pastel weight, for anything that
+	// warns before it alarms.
+	amber: '#ffc078',
 	red: '#ff8787',
 	transparent: 'rgba(0, 0, 0, 0)',
 };

--- a/source/gui/client/lib/lane-dwell.test.ts
+++ b/source/gui/client/lib/lane-dwell.test.ts
@@ -1,0 +1,118 @@
+import {describe, expect, it} from 'vitest';
+import {GuiIssue} from './gui-state.model';
+import {dwellLevel, dwellOf, laneDwell} from './lane-dwell';
+
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+const NOW = 1_700_000_000_000;
+
+const ticket = (hoursInLane: number, overrides: Partial<GuiIssue> = {}) =>
+	({
+		id: `i${hoursInLane}`,
+		ref: 'ABC1234',
+		title: 'A ticket',
+		description: '',
+		createdAt: NOW - hoursInLane * HOUR,
+		enteredLaneAt: NOW - hoursInLane * HOUR,
+		readonly: false,
+		isClosed: false,
+		tags: [],
+		assignees: [],
+		...overrides,
+	} satisfies GuiIssue);
+
+describe('dwellOf', () => {
+	it('reads a ticket entered in the future as having just arrived', () => {
+		expect(dwellOf(ticket(-3), NOW)).toBe(0);
+	});
+});
+
+describe('laneDwell', () => {
+	it('is null for a lane with nothing open in it', () => {
+		expect(laneDwell([], NOW)).toBeNull();
+		expect(laneDwell([ticket(4, {isClosed: true})], NOW)).toBeNull();
+	});
+
+	it('leaves closed tickets out of the figures', () => {
+		const lane = laneDwell(
+			[ticket(2), ticket(4), ticket(500, {isClosed: true})],
+			NOW,
+		);
+
+		expect(lane?.max).toBe(4 * HOUR);
+	});
+
+	it('takes the middle of an odd number of tickets', () => {
+		expect(laneDwell([ticket(1), ticket(9), ticket(2)], NOW)?.median).toBe(
+			2 * HOUR,
+		);
+	});
+
+	it('averages the middle pair of an even number of tickets', () => {
+		expect(
+			laneDwell([ticket(1), ticket(3), ticket(5), ticket(9)], NOW)?.median,
+		).toBe(4 * HOUR);
+	});
+
+	it('reports a median one stuck ticket cannot drag, and a max that shows it', () => {
+		const lane = laneDwell([ticket(1), ticket(2), ticket(3), ticket(720)], NOW);
+
+		expect(lane?.median).toBe(2.5 * HOUR);
+		expect(lane?.max).toBe(720 * HOUR);
+		expect(lane?.mean).toBeGreaterThan(180 * HOUR);
+	});
+});
+
+describe('dwellLevel', () => {
+	const lane = (hours: number[]) =>
+		laneDwell(
+			hours.map(h => ticket(h)),
+			NOW,
+		)!;
+
+	it('says nothing about a lane too small to have a baseline', () => {
+		const small = lane([1, 400]);
+
+		expect(dwellLevel(400 * HOUR, small, 2)).toBe('none');
+	});
+
+	it('leaves a ticket in line with its lane alone', () => {
+		const busy = lane([10, 12, 14]);
+
+		expect(dwellLevel(14 * HOUR, busy, 3)).toBe('none');
+	});
+
+	it('warns on a ticket several times its lane median', () => {
+		const busy = lane([2, 4, 6, 40]);
+
+		expect(dwellLevel(40 * HOUR, busy, 4)).toBe('warn');
+	});
+
+	it('alerts on one far past that', () => {
+		const busy = lane([2, 4, 6, 400]);
+
+		expect(dwellLevel(400 * HOUR, busy, 4)).toBe('alert');
+	});
+
+	it('holds its tongue in a fast lane, where a multiple is still a short wait', () => {
+		const fast = lane([0.1, 0.2, 0.3, 2]);
+
+		// Twenty times the median, and still only two hours old.
+		expect(dwellLevel(2 * HOUR, fast, 4)).toBe('none');
+	});
+
+	it('warns past a day even where the floor is what carries it', () => {
+		const fast = lane([0.1, 0.2, 0.3, 30]);
+
+		expect(dwellLevel(30 * HOUR, fast, 4)).toBe('warn');
+		expect(dwellLevel(4 * DAY, fast, 4)).toBe('alert');
+	});
+
+	it('stays quiet in a slow lane where everything is old', () => {
+		const slow = lane([20 * 24, 22 * 24, 24 * 24]);
+
+		// Well past both floors, but no further out of line than its neighbours.
+		expect(dwellLevel(24 * 24 * HOUR, slow, 3)).toBe('none');
+	});
+});

--- a/source/gui/client/lib/lane-dwell.ts
+++ b/source/gui/client/lib/lane-dwell.ts
@@ -1,0 +1,64 @@
+import {GuiIssue} from './gui-state.model';
+
+const DAY = 24 * 60 * 60 * 1000;
+
+// Below three tickets a median is not a baseline, it is a coin toss.
+const MIN_LANE_SIZE = 3;
+
+// The multiple is what stops a slow lane flagging everything in it; the floor
+// is what stops a fast one flagging a ticket that arrived this morning.
+const WARN = {multiple: 3, floor: DAY};
+const ALERT = {multiple: 6, floor: 3 * DAY};
+
+export type DwellLevel = 'none' | 'warn' | 'alert';
+
+export type LaneDwell = {median: number; mean: number; max: number};
+
+// A contributor's clock can sit minutes ahead of this one, which would
+// otherwise read as a ticket that arrives in its lane in the future.
+export const dwellOf = (issue: GuiIssue, now: number): number =>
+	Math.max(0, now - issue.enteredLaneAt);
+
+const median = (sorted: readonly number[]): number => {
+	const middle = Math.floor(sorted.length / 2);
+
+	return sorted.length % 2 === 0
+		? (sorted[middle - 1]! + sorted[middle]!) / 2
+		: sorted[middle]!;
+};
+
+/** How long the lane's open tickets have been sitting in it. */
+export const laneDwell = (
+	issues: readonly GuiIssue[],
+	now: number,
+): LaneDwell | null => {
+	const dwells = issues
+		.filter(issue => !issue.isClosed)
+		.map(issue => dwellOf(issue, now))
+		.sort((a, b) => a - b);
+
+	if (dwells.length === 0) return null;
+
+	return {
+		median: median(dwells),
+		mean: dwells.reduce((total, dwell) => total + dwell, 0) / dwells.length,
+		max: dwells[dwells.length - 1]!,
+	};
+};
+
+/** How far out of line one ticket is with the rest of its own lane. */
+export const dwellLevel = (
+	dwell: number,
+	lane: LaneDwell,
+	laneSize: number,
+): DwellLevel => {
+	if (laneSize < MIN_LANE_SIZE) return 'none';
+
+	if (dwell >= Math.max(ALERT.multiple * lane.median, ALERT.floor)) {
+		return 'alert';
+	}
+
+	if (dwell >= Math.max(WARN.multiple * lane.median, WARN.floor)) return 'warn';
+
+	return 'none';
+};

--- a/source/lib/utils/lane-dwell.ts
+++ b/source/lib/utils/lane-dwell.ts
@@ -1,0 +1,41 @@
+import {clampUlidTime, getEventTime} from '../event/date-utils.js';
+import {AppEvent} from '../event/event.model.js';
+
+// The events that can put a ticket somewhere else. Closing and reopening carry
+// a parent for the same reason a move does, so both land here.
+const parentOf = (event: AppEvent): string | null => {
+	switch (event.action) {
+		case 'add.issue':
+		case 'move.node':
+		case 'close.issue':
+		case 'reopen.issue':
+			return event.payload.parent;
+		default:
+			return null;
+	}
+};
+
+/**
+ * When the ticket last arrived in the lane it is in now, read off its own log.
+ * The parent is compared rather than counted: dragging a card up its own column
+ * writes a move carrying the lane it is already in, and must not restart the
+ * clock. Falls back to `createdAt` for a log that never names a parent.
+ */
+export const laneEntryTime = (
+	log: readonly AppEvent[],
+	createdAt: number,
+): number => {
+	let parent: string | null = null;
+	let entered = createdAt;
+
+	for (const event of log) {
+		const next = parentOf(event);
+		if (next === null || next === parent) continue;
+
+		const time = getEventTime(event);
+		parent = next;
+		if (time !== null) entered = clampUlidTime(time);
+	}
+
+	return entered;
+};

--- a/source/mcp/api-state.model.ts
+++ b/source/mcp/api-state.model.ts
@@ -30,6 +30,11 @@ export type ApiIssue = {
 	description: string;
 	/** Decoded from the issue's own ULID. */
 	createdAt: number;
+	/**
+	 * When it last arrived in the swimlane it is in, from its own log. Equal to
+	 * `createdAt` for a ticket that has never moved.
+	 */
+	enteredLaneAt: number;
 	readonly: boolean;
 	/** Present only for a load-derived lock, which knows why it exists. */
 	tags: ApiTag[];

--- a/source/mcp/api/issues.ts
+++ b/source/mcp/api/issues.ts
@@ -31,6 +31,7 @@ import {
 	MAX_TITLE_LENGTH,
 	tooLong,
 } from '../../lib/utils/text.limits.js';
+import {laneEntryTime} from '../../lib/utils/lane-dwell.js';
 import {nodeRef, nodeRefMatches} from '../../lib/utils/node-ref.js';
 import {sanitizeInlineText} from '../../lib/utils/string.utils.js';
 import {
@@ -151,6 +152,7 @@ export const getIssue = async (input: GetIssueInput) => {
 		title: sanitizeInlineText(issue.title),
 		description: issue.props.description ?? '',
 		createdAt: ulidTimeMs(issue.id),
+		enteredLaneAt: laneEntryTime(issue.log ?? [], ulidTimeMs(issue.id)),
 		parentNodeId: issue.parentNodeId!,
 		isClosed: issue.parentNodeId === CLOSED_SWIMLANE_ID,
 		readonly: Boolean(issue.readonly),
@@ -238,6 +240,7 @@ export async function listIssues(
 					title: sanitizeInlineText(n.title),
 					description: n.props.description ?? '',
 					createdAt: ulidTimeMs(n.id),
+					enteredLaneAt: laneEntryTime(n.log ?? [], ulidTimeMs(n.id)),
 					parentNodeId: n.parentNodeId!,
 					isClosed: n.parentNodeId === CLOSED_SWIMLANE_ID,
 					readonly: Boolean(n.readonly),

--- a/source/mcp/api/state.ts
+++ b/source/mcp/api/state.ts
@@ -17,6 +17,7 @@ import {
 import {nodeRepo} from '../../lib/repository/node-repo.js';
 import {recordRecentProject} from '../../lib/config/recent-projects.js';
 import {getStringColor} from '../../lib/utils/color.js';
+import {laneEntryTime} from '../../lib/utils/lane-dwell.js';
 import {nodeRef} from '../../lib/utils/node-ref.js';
 import {sanitizeInlineText} from '../../lib/utils/string.utils.js';
 import {getAttachmentFileName} from '../../lib/media/media-store.js';
@@ -212,6 +213,10 @@ export const deriveGuiState = (): Result<ApiState> => {
 										title: sanitizeInlineText(issue.title),
 										description: issue.props.description ?? '',
 										createdAt: ulidTimeMs(issue.id),
+										enteredLaneAt: laneEntryTime(
+											issue.log ?? [],
+											ulidTimeMs(issue.id),
+										),
 										readonly: Boolean(issue.readonly) || forceReadonly,
 										tags: getIssueTags(issue),
 										assignees: getIssueAssignees(issue),

--- a/source/test/e2e-gui/lane-dwell.pw.ts
+++ b/source/test/e2e-gui/lane-dwell.pw.ts
@@ -1,0 +1,84 @@
+import type {Locator, Page} from '@playwright/test';
+import {expect, test} from './fixtures.js';
+
+// The lane a figure would be drawn for: an empty column carries none, so
+// asserting on the first header would pass whether the figure works or not.
+const laneWithTickets = async (page: Page): Promise<Locator> => {
+	const headers = page.getByTestId('swimlane-handle');
+
+	for (let index = 0; index < (await headers.count()); index++) {
+		const header = headers.nth(index);
+		const count = Number(
+			(await header.textContent())?.match(/\((\d+)\)/)?.[1] ?? 0,
+		);
+
+		if (count > 0) return header;
+	}
+
+	throw new Error('no swimlane on the board holds a ticket');
+};
+
+// The suite shares one server, and a board left parked in the past never
+// finishes loading for the next test.
+const returnToLive = async (page: Page) => {
+	const resume = page.getByRole('button', {name: 'Resume', exact: true});
+
+	if ((await resume.count()) > 0 && (await resume.isEnabled())) {
+		await resume.click();
+		await expect(resume).toHaveCount(0);
+	}
+};
+
+test('a lane says how long its tickets have sat in it', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	await page.getByTitle('Add issue').first().click();
+	await page.getByPlaceholder('issue name').fill(`Dwell ${Date.now()}`);
+	await page.getByPlaceholder('issue name').press('Enter');
+
+	const dwell = (await laneWithTickets(page)).getByTestId('swimlane-dwell');
+
+	await expect(dwell).toBeVisible();
+	await expect(dwell).toHaveText(/med · .+ max/);
+
+	expect(pageErrors).toEqual([]);
+});
+
+// Elapsed-until-now says nothing about a board being shown as it was at some
+// other moment, so the figure goes away rather than answering the wrong
+// question.
+test('no lane carries a dwell while the board is scrubbed', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	await expect(
+		(await laneWithTickets(page)).getByTestId('swimlane-dwell'),
+	).toBeVisible();
+
+	const track = page.getByTestId('scrubber-track');
+	const box = await track.boundingBox();
+	if (!box) throw new Error('scrubber track is not on screen');
+
+	// Near the present, so the past being drawn still has tickets on it — the
+	// assertion has to fail on a figure left behind, not on an empty board.
+	await page.mouse.click(box.x + box.width * 0.95, box.y + box.height / 2);
+	await expect(
+		page.getByRole('button', {name: 'Resume', exact: true}),
+	).toBeEnabled();
+
+	await expect(
+		(await laneWithTickets(page)).getByTestId('swimlane-dwell'),
+	).toHaveCount(0);
+
+	await returnToLive(page);
+	expect(pageErrors).toEqual([]);
+});

--- a/source/test/lane-dwell.test.ts
+++ b/source/test/lane-dwell.test.ts
@@ -1,0 +1,95 @@
+import {describe, expect, it} from 'vitest';
+import {ulid} from 'ulid';
+import {AppEvent, EventAction} from '../lib/event/event.model.js';
+import {laneEntryTime} from '../lib/utils/lane-dwell.js';
+
+const HOUR_MS = 60 * 60 * 1000;
+
+const at = (
+	time: number,
+	action: EventAction,
+	payload: Record<string, unknown>,
+): AppEvent =>
+	({
+		id: ulid(time),
+		userId: 'user-1',
+		userName: 'someone',
+		action,
+		payload,
+	} as AppEvent);
+
+describe('laneEntryTime', () => {
+	const created = Date.now() - 100 * HOUR_MS;
+
+	it('falls back to createdAt for a log that never names a parent', () => {
+		const log = [at(created + HOUR_MS, 'edit.title', {id: 'i1', name: 'Hi'})];
+
+		expect(laneEntryTime(log, created)).toBe(created);
+	});
+
+	it('takes the time of the move that put it in its current lane', () => {
+		const moved = created + 40 * HOUR_MS;
+
+		const log = [
+			at(created, 'add.issue', {id: 'i1', parent: 'backlog', rank: 'a'}),
+			at(moved, 'move.node', {id: 'i1', parent: 'review', rank: 'a'}),
+		];
+
+		expect(laneEntryTime(log, created)).toBe(moved);
+	});
+
+	it('ignores a move that only reorders the ticket within its own lane', () => {
+		const arrived = created + 10 * HOUR_MS;
+
+		const log = [
+			at(created, 'add.issue', {id: 'i1', parent: 'backlog', rank: 'a'}),
+			at(arrived, 'move.node', {id: 'i1', parent: 'review', rank: 'a'}),
+			at(created + 90 * HOUR_MS, 'move.node', {
+				id: 'i1',
+				parent: 'review',
+				rank: 'b',
+			}),
+		];
+
+		expect(laneEntryTime(log, created)).toBe(arrived);
+	});
+
+	it('counts a reopen as arriving in the lane it is reopened into', () => {
+		const reopened = created + 80 * HOUR_MS;
+
+		const log = [
+			at(created, 'add.issue', {id: 'i1', parent: 'backlog', rank: 'a'}),
+			at(created + 20 * HOUR_MS, 'close.issue', {
+				id: 'i1',
+				parent: 'closed',
+				rank: 'a',
+			}),
+			at(reopened, 'reopen.issue', {id: 'i1', parent: 'backlog', rank: 'a'}),
+		];
+
+		expect(laneEntryTime(log, created)).toBe(reopened);
+	});
+
+	it('reads a ticket created in a lane and never moved as arriving then', () => {
+		const log = [
+			at(created, 'add.issue', {id: 'i1', parent: 'backlog', rank: 'a'}),
+		];
+
+		expect(laneEntryTime(log, created)).toBe(created);
+	});
+
+	it('clamps a move stamped by a wildly fast clock to now', () => {
+		const now = Date.now();
+
+		const log = [
+			at(created, 'add.issue', {id: 'i1', parent: 'backlog', rank: 'a'}),
+			at(now + 100 * 365 * 24 * HOUR_MS, 'move.node', {
+				id: 'i1',
+				parent: 'review',
+				rank: 'a',
+			}),
+		];
+
+		expect(laneEntryTime(log, created)).toBeLessThanOrEqual(Date.now());
+	});
+});


### PR DESCRIPTION
A board says what is where, never how long it has been there — a ticket parked in Review for three weeks looks exactly like one that arrived this morning.

**Swimlane header:** `Review (4) 16h med · 2w max`, dim, uncoloured, live mode only. The median says whether the column is moving, the max says how bad its worst case is, and the two disagreeing is itself the signal. The hover title carries the average as well.

**Cards:** a clock icon, amber then red, on tickets far out of line with *their own lane* — never with the board, since Backlog is structurally the oldest column and would otherwise sit permanently red. Baseline is the lane median: amber at `max(3 × median, 24h)`, red at `max(6 × median, 72h)`, and nothing at all in a lane holding fewer than three tickets, where a median is not a baseline. The floors stop a fast lane flagging something four hours old; the multiples stop a slow lane flagging everything in it.

**Where the number comes from:** every node already carries its own `log` in materialized state, so replaying `payload.parent` over it gives the moment a ticket last entered its current lane — no new event type, no schema change, no rescan of the event log. A move that only reorders a card inside its column carries the lane it is already in and so does not restart the clock, which the fixture proves by reordering the stalest Review ticket minutes before the assertion.

Elapsed-until-now says nothing about a board being drawn as it was at some other moment, so every figure and every clock goes away while the timeline is scrubbed rather than answering the wrong question. Closed tickets are left out, and a dwell is clamped at zero — ULID times come from whichever machine authored the move, and a contributor's clock can sit minutes ahead of this one.

GUI only; the TUI draws its own lane headers and can pick the same derivation up later.

**Tests:** 19 unit tests over the derivation and the median/threshold math, plus two Playwright tests — the header renders, and no lane carries a dwell while scrubbed, asserted against a lane that still holds tickets so it cannot pass vacuously.

Ticket: `Y34SCVN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CRAYbmbfeXU2wgx25h4sUP
