### PR TITLE
MR1Y0AP swimlane stats panel, and WY8HP62 one lane-arrival rule

### DIFF
--- a/source/gui/api/lib/websocket.model.ts
+++ b/source/gui/api/lib/websocket.model.ts
@@ -90,4 +90,5 @@ export type GuiMessage =
 	| {type: 'commit:inspect'; payload: {sha: string}}
 	| {type: 'commit:diff:get'; payload: {sha: string}}
 	| {type: 'issue:commits:get'; payload: {issueId: string}}
-	| {type: 'issue:stats:get'; payload: {issueId: string}};
+	| {type: 'issue:stats:get'; payload: {issueId: string}}
+	| {type: 'swimlane:stats:get'; payload: {swimlaneId: string}};

--- a/source/gui/api/lib/websocket.schema.ts
+++ b/source/gui/api/lib/websocket.schema.ts
@@ -119,6 +119,7 @@ export const GuiMessageSchema = z.discriminatedUnion('type', [
 	message('commit:diff:get', z.object({sha: z.string()})),
 	message('issue:commits:get', z.object({issueId: id})),
 	message('issue:stats:get', z.object({issueId: id})),
+	message('swimlane:stats:get', z.object({swimlaneId: id})),
 ]);
 
 // Proof the schema still covers the transport it validates: a message the

--- a/source/gui/api/lib/websocket.ts
+++ b/source/gui/api/lib/websocket.ts
@@ -40,6 +40,7 @@ import {
 	runExclusive,
 } from '../../../mcp/epiq-time-travel.js';
 import {getIssueStats} from '../../../mcp/epiq-issue-stats.js';
+import {getSwimlaneStats} from '../../../mcp/api/swimlane-stats.js';
 import {isFail, Result, succeeded} from '../../../lib/model/result-types.js';
 import {NO_PROJECT_MESSAGE} from '../../../lib/storage/paths.js';
 import {nodeRef} from '../../../lib/utils/node-ref.js';
@@ -288,6 +289,21 @@ export const setupWebsocket = (
 								repoRoot,
 								idOrRef: nodeRef(issueId),
 							}),
+						},
+					});
+				}
+
+				if (type === 'swimlane:stats:get') {
+					const {swimlaneId} = message.payload;
+
+					// Wrapped with the swimlaneId like the replies above: the panel
+					// stays open across a change of lane, so an older request can
+					// still be in flight when this one lands.
+					return sendSocket(socket, {
+						type: 'swimlane:stats:result',
+						payload: {
+							swimlaneId,
+							result: await getSwimlaneStats({repoRoot, swimlaneId}),
 						},
 					});
 				}

--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -37,6 +37,7 @@ import {
 } from '../../lib/utils/diff-comment.js';
 import {BulkDetails} from './components/BulkDetails';
 import {SwimlaneColumn} from './components/SwimlaneColumn';
+import {SwimlaneStats} from './components/SwimlaneStats';
 import {GlobalScrollbarStyles} from './components/GlobalScrollbarStyles';
 import {TicketRefLinksProvider} from './components/MarkdownContent';
 import {ErrorToast} from './components/ErrorToast';
@@ -91,6 +92,7 @@ import {isolateOnly, withNarrowing} from './lib/board-selection';
 import {useBoardSelection} from './lib/use-board-selection';
 import {BoardSocketActions, useBoardSocket} from './lib/use-board-socket';
 import {useIssueDetail} from './lib/use-issue-detail';
+import {useSwimlaneStats} from './lib/use-swimlane-stats';
 import {useIssueMutations} from './lib/use-issue-mutations';
 import {useSwimlaneEditing} from './lib/use-swimlane-editing';
 import {createHistoryBuffer} from './lib/history-buffer';
@@ -355,6 +357,11 @@ export const App = () => {
 		void navigate(`/board/${boardSlug}`);
 	};
 
+	// The lane whose stats the inspector is showing, if any. Not in the URL like
+	// the open ticket: it is a glance at a column rather than a place on the
+	// board worth linking somebody to.
+	const [statsSwimlaneId, setStatsSwimlaneId] = useState<string | null>(null);
+
 	const commentsByIssueId = state?.commentsByIssueId ?? EMPTY_COMMENTS;
 
 	// The board's state carries no descriptions, comment bodies or commits —
@@ -377,6 +384,9 @@ export const App = () => {
 		paused: theatre !== null,
 		sendRaw,
 	});
+	const {stats: swimlaneStats, onMessage: onSwimlaneStatsMessage} =
+		useSwimlaneStats({swimlaneId: statsSwimlaneId, sendRaw});
+
 	// The one view that costs a git scan of every commit a ticket owns, so it
 	// is asked for when it is opened rather than with the rest of the ticket.
 	//
@@ -413,6 +423,7 @@ export const App = () => {
 
 		return deriveBoardStats({
 			createdAt: selectedIssue.createdAt,
+			enteredLaneAt: selectedIssue.enteredLaneAt,
 			now: Date.now(),
 			history:
 				issueDetail?.issueId === selectedIssue.id ? issueDetail.history : [],
@@ -564,6 +575,7 @@ export const App = () => {
 		// Not exclusive: `commit:diff:result` is also read below, for the diff the
 		// scrubber's own commit dot opens.
 		onIssueDetailMessage(message);
+		onSwimlaneStatsMessage(message);
 
 		if (message.type === 'state' && !socket.holdsState()) {
 			const nextState = getResultValue<GuiState>(message.payload);
@@ -793,6 +805,9 @@ export const App = () => {
 		// The ticket panel renders only while no commit diff does, so a diff left
 		// open by an earlier dot click would hide the ticket just asked for.
 		setCommitDiff(null);
+		// One inspector, one subject: a lane's stats left open would hide the
+		// ticket just asked for the same way.
+		setStatsSwimlaneId(null);
 
 		// A plain click both opens the ticket and makes it the selection, so a
 		// following modifier-click extends from it instead of starting over.
@@ -805,6 +820,15 @@ export const App = () => {
 		void navigate(
 			`/board/${boardSlug}/issue/${nodeRef(nextIssueId)}?tab=${selectedTab}`,
 		);
+	};
+
+	// Clicking the lane's own stats icon again closes the panel, which is what
+	// a toggle on the thing itself has to do.
+	const openSwimlaneStats = (swimlaneId: string) => {
+		setCommitDiff(null);
+		clearPicked();
+		closeIssueDetails();
+		setStatsSwimlaneId(current => (current === swimlaneId ? null : swimlaneId));
 	};
 
 	// Every ref that resolves to a real ticket, across every board — a ref
@@ -1251,6 +1275,16 @@ export const App = () => {
 		[offline, visibleSwimlanes],
 	);
 
+	// The lane the stats panel is for, as the board currently has it — so the
+	// figures follow a ticket dropped into the lane while the panel is open.
+	// Absent while scrubbed: every figure on that panel is measured against
+	// now, which a board being replayed is not.
+	const statsSwimlane =
+		state?.timeTravel?.mode === 'scrub'
+			? null
+			: shownSwimlanes.find(swimlane => swimlane.id === statsSwimlaneId) ??
+			  null;
+
 	// The dragged id comes off the drop event rather than being remembered from
 	// dragstart: a drag can begin in one window and end in this one, and the
 	// dataTransfer is the only thing that crosses.
@@ -1454,7 +1488,15 @@ export const App = () => {
 				    this box, so anything spilling out would put a second scrollbar on
 				    the page next to the columns' own. */}
 						<main
-							onClick={clearPicked}
+							// The lane panel closes on a click past it, unlike the ticket
+							// panel beside it, which deliberately stays open (see
+							// details-close.pw.ts): a ticket holds a half-written
+							// description that a stray click must not throw away, and a
+							// lane's figures hold nothing at all.
+							onClick={() => {
+								clearPicked();
+								setStatsSwimlaneId(null);
+							}}
 							style={{
 								padding: '0 0 0 30px',
 								flex: 1,
@@ -1556,6 +1598,8 @@ export const App = () => {
 										key={swimlane.id}
 										swimlane={swimlane}
 										live={state?.timeTravel?.mode !== 'scrub'}
+										statsOpen={statsSwimlaneId === swimlane.id}
+										onOpenStats={openSwimlaneStats}
 										selected={false}
 										selectedIssueId={selectedIssue?.id ?? null}
 										commentsByIssueId={commentsByIssueId}
@@ -1674,47 +1718,62 @@ export const App = () => {
 						</Aside>
 					)}
 
-					{!theatre && !commitDiff && pickedIssues.length > 1 && (
-						<BulkDetails
+					{!theatre && !commitDiff && statsSwimlane && (
+						<SwimlaneStats
 							dock={asideDock}
-							issues={pickedIssues}
-							knownTags={state?.tags ?? []}
-							knownAssignees={contributors}
-							tagName={bulkTagName}
-							assigneeName={bulkAssigneeName}
-							onChangeTagName={setBulkTagName}
-							onChangeAssigneeName={setBulkAssigneeName}
-							onAddTag={name => {
-								forPicked(id => addIssueTag(id, name));
-								setBulkTagName('');
-							}}
-							onRemoveTag={tagId => forPicked(id => removeIssueTag(id, tagId))}
-							onAddAssignee={assigneeId =>
-								forPicked(id => addIssueAssignee(id, assigneeId))
-							}
-							onRemoveAssignee={assigneeId =>
-								forPicked(id => removeIssueAssignee(id, assigneeId))
-							}
-							onCloseIssues={() => {
-								// Skips the ones already closed: the event log would otherwise
-								// carry a second "Closed" for each of them.
-								for (const issue of pickedIssues) {
-									if (!issue.isClosed) closeIssue(issue.id);
-								}
-								clearPicked();
-							}}
-							onReopenIssues={() => {
-								for (const issue of pickedIssues) {
-									if (issue.isClosed) reopenIssue(issue.id);
-								}
-								clearPicked();
-							}}
-							onClear={clearPicked}
+							swimlane={statsSwimlane}
+							state={swimlaneStats}
+							onClose={() => setStatsSwimlaneId(null)}
 						/>
 					)}
 
 					{!theatre &&
 						!commitDiff &&
+						!statsSwimlane &&
+						pickedIssues.length > 1 && (
+							<BulkDetails
+								dock={asideDock}
+								issues={pickedIssues}
+								knownTags={state?.tags ?? []}
+								knownAssignees={contributors}
+								tagName={bulkTagName}
+								assigneeName={bulkAssigneeName}
+								onChangeTagName={setBulkTagName}
+								onChangeAssigneeName={setBulkAssigneeName}
+								onAddTag={name => {
+									forPicked(id => addIssueTag(id, name));
+									setBulkTagName('');
+								}}
+								onRemoveTag={tagId =>
+									forPicked(id => removeIssueTag(id, tagId))
+								}
+								onAddAssignee={assigneeId =>
+									forPicked(id => addIssueAssignee(id, assigneeId))
+								}
+								onRemoveAssignee={assigneeId =>
+									forPicked(id => removeIssueAssignee(id, assigneeId))
+								}
+								onCloseIssues={() => {
+									// Skips the ones already closed: the event log would otherwise
+									// carry a second "Closed" for each of them.
+									for (const issue of pickedIssues) {
+										if (!issue.isClosed) closeIssue(issue.id);
+									}
+									clearPicked();
+								}}
+								onReopenIssues={() => {
+									for (const issue of pickedIssues) {
+										if (issue.isClosed) reopenIssue(issue.id);
+									}
+									clearPicked();
+								}}
+								onClear={clearPicked}
+							/>
+						)}
+
+					{!theatre &&
+						!commitDiff &&
+						!statsSwimlane &&
 						pickedIssues.length <= 1 &&
 						selectedIssue &&
 						state?.user && (

--- a/source/gui/client/components/IconLaneStats.tsx
+++ b/source/gui/client/components/IconLaneStats.tsx
@@ -1,0 +1,17 @@
+export const IconLaneStats = ({size = 13}: {size?: number}) => (
+	<svg
+		width={size}
+		height={size}
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		strokeWidth="2"
+		strokeLinecap="round"
+		strokeLinejoin="round"
+		aria-hidden="true"
+	>
+		<line x1="6" y1="20" x2="6" y2="13" />
+		<line x1="12" y1="20" x2="12" y2="4" />
+		<line x1="18" y1="20" x2="18" y2="9" />
+	</svg>
+);

--- a/source/gui/client/components/IssueStats.tsx
+++ b/source/gui/client/components/IssueStats.tsx
@@ -22,6 +22,7 @@ import {ProportionBar, StackedBar} from './StatBars';
 import {BoardStats} from '../../../lib/stats/board-stats.js';
 import {Empty} from './FormPrimitives';
 import {Section} from './Section';
+import {Stat, StatRow} from './StatRow';
 
 // The timeline's own two series, so a colour means the same thing wherever it
 // appears: green is a commit, the accent is the board. A dot beside the
@@ -91,79 +92,6 @@ const FileLink = ({
 		</button>
 	);
 };
-
-const Stat = ({
-	value,
-	label,
-	note,
-}: {
-	value: string;
-	label: string;
-	note?: React.ReactNode;
-}) => (
-	<div
-		style={STAT_CELL}
-		// The same lift every hoverable surface in the app takes, so a figure
-		// under the pointer separates from the four beside it — and a path in
-		// the note below reads as part of that block rather than as loose text.
-		onMouseEnter={event => {
-			event.currentTarget.style.background = GUI_THEME.hover;
-		}}
-		onMouseLeave={event => {
-			event.currentTarget.style.background = 'transparent';
-		}}
-	>
-		<div style={STAT_VALUE}>{value}</div>
-		<div style={STAT_LABEL}>{label}</div>
-		{note && <div style={STAT_NOTE}>{note}</div>}
-	</div>
-);
-
-const Row = ({
-	left,
-	right,
-	dot,
-	last = false,
-}: {
-	left: React.ReactNode;
-	right: string;
-	dot?: string;
-	// The section below draws its own top border, so a rule under the final row
-	// is that border twice.
-	last?: boolean;
-}) => (
-	<div style={last ? {...ROW, borderBottom: 'none'} : ROW}>
-		<span
-			style={{
-				display: 'flex',
-				alignItems: 'center',
-				gap: 8,
-				color: GUI_THEME.secondary,
-				minWidth: 0,
-				overflow: 'hidden',
-				textOverflow: 'ellipsis',
-				whiteSpace: 'nowrap',
-			}}
-		>
-			{dot && (
-				// The bar above says which share is which by position; this says
-				// it again by name, so the reading never rests on colour alone.
-				<span
-					aria-hidden
-					style={{
-						width: 7,
-						height: 7,
-						borderRadius: 2,
-						background: dot,
-						flexShrink: 0,
-					}}
-				/>
-			)}
-			{left}
-		</span>
-		<span style={{color: GUI_THEME.primary, flexShrink: 0}}>{right}</span>
-	</div>
-);
 
 // A note earns a line only when it has something to say. A page of zeroes
 // reads as a checklist somebody has to work through; three lines read as
@@ -362,7 +290,7 @@ export const IssueStats = ({
 				/>
 
 				{languages.languages.map((language, index) => (
-					<Row
+					<StatRow
 						key={language.name}
 						dot={seriesColor(index)}
 						left={language.name}
@@ -407,7 +335,7 @@ export const IssueStats = ({
 				)}
 
 				{comments.byLanguage.map((language, index) => (
-					<Row
+					<StatRow
 						key={language.name}
 						left={language.name}
 						right={
@@ -459,7 +387,7 @@ export const IssueStats = ({
 			{(flaggedFiles.length > 0 || shape.binaryFiles > 0) && (
 				<Section title="Worth a look" tone={CODE_TONE}>
 					{flaggedFiles.map(({file, what}) => (
-						<Row
+						<StatRow
 							key={`${what}:${file.path}`}
 							left={<FileLink file={file} onOpen={onOpenFile} />}
 							right={what}

--- a/source/gui/client/components/StatRow.tsx
+++ b/source/gui/client/components/StatRow.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import {GUI_THEME} from '../lib/gui-theme';
+import {
+	ROW,
+	STAT_CELL,
+	STAT_LABEL,
+	STAT_NOTE,
+	STAT_VALUE,
+} from '../lib/issue-stats.style';
+
+// The two marks every stats surface is built from: a figure with its label,
+// and a named share in a list. Shared so a ticket's Stats tab and a lane's
+// panel read as one thing rather than as two takes on the same idea.
+
+export const Stat = ({
+	value,
+	label,
+	note,
+	title,
+}: {
+	value: string;
+	label: string;
+	note?: React.ReactNode;
+	title?: string;
+}) => (
+	<div
+		style={STAT_CELL}
+		title={title}
+		// The same lift every hoverable surface in the app takes, so a figure
+		// under the pointer separates from the four beside it — and a path in
+		// the note below reads as part of that block rather than as loose text.
+		onMouseEnter={event => {
+			event.currentTarget.style.background = GUI_THEME.hover;
+		}}
+		onMouseLeave={event => {
+			event.currentTarget.style.background = 'transparent';
+		}}
+	>
+		<div style={STAT_VALUE}>{value}</div>
+		<div style={STAT_LABEL}>{label}</div>
+		{note && <div style={STAT_NOTE}>{note}</div>}
+	</div>
+);
+
+export const StatRow = ({
+	left,
+	right,
+	dot,
+	last = false,
+}: {
+	left: React.ReactNode;
+	right: React.ReactNode;
+	dot?: string;
+	// The section below draws its own top border, so a rule under the final row
+	// is that border twice.
+	last?: boolean;
+}) => (
+	<div style={last ? {...ROW, borderBottom: 'none'} : ROW}>
+		<span
+			style={{
+				display: 'flex',
+				alignItems: 'center',
+				gap: 8,
+				color: GUI_THEME.secondary,
+				minWidth: 0,
+				overflow: 'hidden',
+				textOverflow: 'ellipsis',
+				whiteSpace: 'nowrap',
+			}}
+		>
+			{dot && (
+				// The bar above says which share is which by position; this says
+				// it again by name, so the reading never rests on colour alone.
+				<span
+					aria-hidden
+					style={{
+						width: 7,
+						height: 7,
+						borderRadius: 2,
+						background: dot,
+						flexShrink: 0,
+					}}
+				/>
+			)}
+			{left}
+		</span>
+		<span style={{color: GUI_THEME.primary, flexShrink: 0}}>{right}</span>
+	</div>
+);

--- a/source/gui/client/components/StayTrend.tsx
+++ b/source/gui/client/components/StayTrend.tsx
@@ -1,0 +1,267 @@
+import {useState} from 'react';
+import {LaneStayPoint} from '../../../lib/stats/swimlane-stats.model.js';
+import {formatDuration} from '../lib/gui-format.helper';
+import {GUI_THEME, TEXT} from '../lib/gui-theme';
+
+// The lane's median stay, once a day, for the last month.
+//
+// One series, so no legend: the section heading above says what is plotted, and
+// a box holding a single swatch would only repeat it. The endpoint is the only
+// labelled value — a number on every point is chaos and goes unread — and the
+// rest is a slope, which is the whole reason this is a line and not four more
+// figures.
+
+const HEIGHT = 68;
+// Room under the plot for the two date labels, and over it for the endpoint's
+// own value, so neither has to sit on the line.
+const PAD_TOP = 14;
+const PAD_BOTTOM = 16;
+const PAD_RIGHT = 40;
+
+const DAY = 24 * 60 * 60 * 1000;
+
+type Measured = LaneStayPoint & {median: number};
+
+type Plotted = {x: number; y: number; point: Measured};
+
+const dayLabel = (t: number, now: number): string => {
+	const days = Math.round((now - t) / DAY);
+
+	if (days <= 0) return 'today';
+
+	return `${formatDuration(days * DAY)} ago`;
+};
+
+export const StayTrend = ({points}: {points: LaneStayPoint[]}) => {
+	const [hovered, setHovered] = useState<Plotted | null>(null);
+	const [width, setWidth] = useState(0);
+
+	const measured = points.filter(
+		(point): point is Measured => point.median !== null,
+	);
+
+	// One reading is a dot, not a trend, and nothing at all is not a chart.
+	if (measured.length < 2 || width === 0) {
+		return (
+			<div
+				ref={element => setWidth(element?.clientWidth ?? 0)}
+				style={{height: HEIGHT, marginTop: 12}}
+			/>
+		);
+	}
+
+	const now = points.at(-1)!.t;
+	const first = points[0]!.t;
+	const span = Math.max(1, now - first);
+	const peak = Math.max(...measured.map(point => point.median));
+
+	const plotWidth = Math.max(1, width - PAD_RIGHT);
+	const plotHeight = HEIGHT - PAD_TOP - PAD_BOTTOM;
+
+	const plot = (point: Measured): Plotted => ({
+		x: ((point.t - first) / span) * plotWidth,
+		// Off a floor of zero rather than the range's own low: a line that fills
+		// the box whatever it does turns a flat month into a mountain.
+		y: PAD_TOP + plotHeight - (point.median / Math.max(1, peak)) * plotHeight,
+		point,
+	});
+
+	const plotted = measured.map(plot);
+	const last = plotted.at(-1)!;
+
+	// Gaps rather than a bridge: a day the lane stood empty is not a value to
+	// interpolate through, and joining across it would invent one. Each run of
+	// consecutive days is its own line and its own fill, so neither reaches
+	// across the hole.
+	const runs = plotted.reduce<Plotted[][]>((groups, entry, index) => {
+		const previous = measured[index - 1];
+		const broken =
+			previous !== undefined &&
+			Math.round((entry.point.t - previous.t) / DAY) > 1;
+
+		if (index === 0 || broken) groups.push([]);
+		groups.at(-1)!.push(entry);
+
+		return groups;
+	}, []);
+
+	const at = (entry: Plotted) => `${entry.x.toFixed(1)} ${entry.y.toFixed(1)}`;
+
+	// A single day's run is `M x y L x y`, which a round cap draws as a dot —
+	// an `M` on its own would draw nothing at all.
+	const lineOf = (run: Plotted[]) =>
+		run.length === 1
+			? `M${at(run[0]!)} L${at(run[0]!)}`
+			: run
+					.map((entry, index) => `${index === 0 ? 'M' : 'L'}${at(entry)}`)
+					.join(' ');
+
+	const base = PAD_TOP + plotHeight;
+
+	const areaOf = (run: Plotted[]) =>
+		`${lineOf(run)} L${run.at(-1)!.x.toFixed(1)} ${base} L${run[0]!.x.toFixed(
+			1,
+		)} ${base} Z`;
+
+	// One mark a week back from today, so a stretch of the line can be counted
+	// off the right-hand edge as this week, last week, the week before.
+	const weekMarks = Array.from(
+		{length: Math.floor((points.length - 1) / 7)},
+		(_, index) => ((span - (index + 1) * 7 * DAY) / span) * plotWidth,
+	).filter(x => x > 0);
+
+	const nearest = (offsetX: number): Plotted =>
+		plotted.reduce((best, entry) =>
+			Math.abs(entry.x - offsetX) < Math.abs(best.x - offsetX) ? entry : best,
+		);
+
+	return (
+		<div
+			ref={element => setWidth(element?.clientWidth ?? 0)}
+			style={{position: 'relative', marginTop: 12}}
+		>
+			<svg
+				width="100%"
+				height={HEIGHT}
+				role="img"
+				aria-label={`Median stay over the last ${
+					points.length
+				} days, now ${formatDuration(last.point.median)}`}
+				style={{display: 'block', overflow: 'visible'}}
+				onMouseLeave={() => setHovered(null)}
+				onMouseMove={event =>
+					setHovered(
+						nearest(
+							event.clientX - event.currentTarget.getBoundingClientRect().left,
+						),
+					)
+				}
+			>
+				{/* Behind everything, and the same recessive hairline the peak
+				    wears: a week boundary is a place to read the line against, not
+				    a thing to look at. */}
+				{weekMarks.map(x => (
+					<line
+						key={x}
+						x1={x}
+						x2={x}
+						y1={PAD_TOP}
+						y2={base}
+						stroke={GUI_THEME.line}
+						strokeWidth={1}
+					/>
+				))}
+
+				{/* One hairline at the peak, labelled, so the height of the line
+				    has a value attached to it without an axis down the side. */}
+				<line
+					x1={0}
+					x2={plotWidth}
+					y1={PAD_TOP}
+					y2={PAD_TOP}
+					stroke={GUI_THEME.line}
+					strokeWidth={1}
+				/>
+
+				{/* What the height means, and what the top of it is worth — so a
+				    line sitting high reads as a long wait rather than as a big
+				    number of something unnamed. */}
+				<text
+					x={0}
+					y={PAD_TOP - 4}
+					fill={GUI_THEME.dim}
+					fontSize={TEXT.label}
+					fontFamily="inherit"
+				>
+					median stay
+				</text>
+
+				<text
+					x={plotWidth}
+					y={PAD_TOP - 4}
+					textAnchor="end"
+					fill={GUI_THEME.dim}
+					fontSize={TEXT.label}
+					fontFamily="inherit"
+				>
+					{formatDuration(peak) || '0s'}
+				</text>
+
+				{runs.map(run => (
+					<path
+						key={`area-${run[0]!.point.t}`}
+						d={areaOf(run)}
+						fill={GUI_THEME.accent}
+						opacity={0.1}
+						stroke="none"
+					/>
+				))}
+
+				{runs.map(run => (
+					<path
+						key={`line-${run[0]!.point.t}`}
+						d={lineOf(run)}
+						fill="none"
+						stroke={GUI_THEME.accent}
+						strokeWidth={2}
+						strokeLinecap="round"
+						strokeLinejoin="round"
+					/>
+				))}
+
+				{hovered && (
+					<line
+						x1={hovered.x}
+						x2={hovered.x}
+						y1={PAD_TOP}
+						y2={base}
+						stroke={GUI_THEME.dim}
+						strokeWidth={1}
+					/>
+				)}
+
+				{/* The 2px ring is the surface showing through, so the dot stays
+				    legible where it sits on the line. */}
+				<circle
+					cx={hovered?.x ?? last.x}
+					cy={hovered?.y ?? last.y}
+					r={4}
+					fill={GUI_THEME.accent}
+					stroke={GUI_THEME.panel}
+					strokeWidth={2}
+				/>
+
+				<text
+					x={(hovered ?? last).x + 8}
+					y={(hovered ?? last).y + 4}
+					fill={GUI_THEME.primary}
+					fontSize={TEXT.meta}
+					fontFamily="inherit"
+				>
+					{formatDuration((hovered ?? last).point.median) || '0s'}
+				</text>
+
+				<text
+					x={0}
+					y={HEIGHT - 2}
+					fill={GUI_THEME.dim}
+					fontSize={TEXT.label}
+					fontFamily="inherit"
+				>
+					{dayLabel(first, now)}
+				</text>
+
+				<text
+					x={plotWidth}
+					y={HEIGHT - 2}
+					textAnchor="end"
+					fill={GUI_THEME.dim}
+					fontSize={TEXT.label}
+					fontFamily="inherit"
+				>
+					{hovered ? dayLabel(hovered.point.t, now) : 'today'}
+				</text>
+			</svg>
+		</div>
+	);
+};

--- a/source/gui/client/components/SwimlaneColumn.tsx
+++ b/source/gui/client/components/SwimlaneColumn.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import {DropIndicator} from '../App';
 import {GuiComment, GuiIssue, GuiSwimlane} from '../lib/gui-state.model';
-import {GUI_THEME, TEXT} from '../lib/gui-theme';
+import {GUI_THEME} from '../lib/gui-theme';
 import {formatDuration} from '../lib/gui-format.helper';
 import {dwellLevel, dwellOf, laneDwell} from '../lib/lane-dwell';
 import {CardDwell} from './TicketCard';
+import {IconLaneStats} from './IconLaneStats';
 import {IconLock} from './IconLock';
 import {Panel} from './Panel';
 import {TicketCard} from './TicketCard';
@@ -46,6 +47,8 @@ export const SwimlaneColumn = ({
 	onDragLeave,
 	theatre,
 	live,
+	statsOpen,
+	onOpenStats,
 }: {
 	swimlane: GuiSwimlane;
 	selected: boolean;
@@ -81,6 +84,9 @@ export const SwimlaneColumn = ({
 	// The board is showing the present. A dwell is time elapsed until now, which
 	// says nothing about a board being replayed at some other moment.
 	live: boolean;
+	// This lane's stats are the ones the inspector is showing.
+	statsOpen: boolean;
+	onOpenStats: (swimlaneId: string) => void;
 }) => {
 	// One reading for the whole column, so the header's figures and the clocks on
 	// the cards under it are answers to the same question.
@@ -238,23 +244,27 @@ export const SwimlaneColumn = ({
 					<span style={{color: GUI_THEME.dim}}>({swimlane.issues.length})</span>
 
 					{dwell && (
-						<span
-							data-testid="swimlane-dwell"
-							title={`Time in this lane — median ${formatDuration(
+						<Button
+							variant="ghost"
+							data-testid="swimlane-stats-open"
+							title={`Lane stats — tickets here have waited ${formatDuration(
 								dwell.median,
-							)}, average ${formatDuration(
-								dwell.mean,
-							)}, oldest ${formatDuration(dwell.max)}`}
+							)} on average, the longest ${formatDuration(dwell.max)}`}
+							onClick={event => {
+								// Stopped here, or the header's own click would take the
+								// selection with it.
+								event.stopPropagation();
+								onOpenStats(swimlane.id);
+							}}
 							style={{
-								color: GUI_THEME.dim,
-								fontSize: TEXT.meta,
-								whiteSpace: 'nowrap',
+								display: 'flex',
+								alignItems: 'center',
+								color: statsOpen ? GUI_THEME.accent : GUI_THEME.dim,
 								flexShrink: 0,
 							}}
 						>
-							{formatDuration(dwell.median) || '0s'} med ·{' '}
-							{formatDuration(dwell.max) || '0s'} max
-						</span>
+							<IconLaneStats />
+						</Button>
 					)}
 
 					{swimlane.readonly && (

--- a/source/gui/client/components/SwimlaneStats.tsx
+++ b/source/gui/client/components/SwimlaneStats.tsx
@@ -1,0 +1,210 @@
+import {LaneFlow} from '../../../lib/stats/swimlane-stats.model.js';
+import {AsideDock} from '../lib/aside-dock';
+import {GuiSwimlane} from '../lib/gui-state.model';
+import {formatAbsolute, formatDuration} from '../lib/gui-format.helper';
+import {GUI_THEME} from '../lib/gui-theme';
+import {laneDwell} from '../lib/lane-dwell';
+import {
+	percent,
+	plural,
+	ROW,
+	seriesColor,
+	statGrid,
+} from '../lib/issue-stats.style';
+import {SwimlaneStatsState} from '../lib/use-swimlane-stats';
+import {Aside} from './Aside';
+import {Button} from './Button';
+import {Empty} from './FormPrimitives';
+import {DiffStat} from './DiffStat';
+import {StackedBar} from './StatBars';
+import {Stat, StatRow} from './StatRow';
+import {StayTrend} from './StayTrend';
+import {Section} from './Section';
+
+// What a column says about itself: how long things sit in it, what feeds it,
+// where they go afterwards, and what the code standing in it comes to.
+//
+// The two flow lists are the point. A lane in isolation is a number; a lane
+// that takes most of its work from Ongoing and sends nearly all of it to Done
+// is a description of how the board actually runs — and the exceptions in
+// those lists are where it does not.
+
+const CODE_TONE = GUI_THEME.green;
+const BOARD_TONE = GUI_THEME.accent;
+
+const FlowList = ({flows, empty}: {flows: LaneFlow[]; empty: string}) => {
+	if (flows.length === 0) return <Empty>{empty}</Empty>;
+
+	return (
+		<>
+			{/* The same bar-then-rows the Stats tab draws its languages with: the
+			    split is a shape before it is a list of percentages, and the dots
+			    below repeat the colours so identity is never colour alone. */}
+			<StackedBar
+				segments={flows.map((flow, index) => ({
+					label: flow.title,
+					value: flow.count,
+					color: seriesColor(index),
+				}))}
+			/>
+
+			<div style={{marginTop: 12}}>
+				{flows.map((flow, index) => (
+					<StatRow
+						key={flow.laneId ?? 'filed'}
+						dot={seriesColor(index)}
+						left={flow.title}
+						last={index === flows.length - 1}
+						right={
+							<>
+								{percent(flow.share)}
+								<span style={{color: GUI_THEME.dim}}> · {flow.count}</span>
+							</>
+						}
+					/>
+				))}
+			</div>
+		</>
+	);
+};
+
+export const SwimlaneStats = ({
+	dock,
+	swimlane,
+	state,
+	onClose,
+}: {
+	dock: AsideDock;
+	swimlane: GuiSwimlane;
+	state: SwimlaneStatsState | null;
+	onClose: () => void;
+}) => {
+	// The same reading the board's own cards are drawn from, so a lane whose
+	// header said one thing cannot say another here.
+	const dwell = laneDwell(swimlane.issues, Date.now());
+	const stats = state?.stats ?? null;
+
+	return (
+		<Aside dock={dock}>
+			<div
+				data-testid="swimlane-stats"
+				style={{
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'space-between',
+					gap: 8,
+					marginBottom: 12,
+				}}
+			>
+				<div
+					style={{
+						fontSize: 13,
+						fontWeight: 600,
+						color: GUI_THEME.primary,
+						overflow: 'hidden',
+						textOverflow: 'ellipsis',
+						whiteSpace: 'nowrap',
+						minWidth: 0,
+					}}
+				>
+					{swimlane.title}
+				</div>
+
+				<Button variant="ghost" onClick={onClose} title="Close">
+					×
+				</Button>
+			</div>
+
+			<Section title="Time in this lane" tone={BOARD_TONE} first>
+				{dwell ? (
+					<div style={statGrid(true)}>
+						<Stat
+							value={formatDuration(dwell.median) || '0s'}
+							label="median stay"
+						/>
+						<Stat
+							value={formatDuration(dwell.max) || '0s'}
+							label="longest stay"
+						/>
+						<Stat
+							value={formatDuration(dwell.mean) || '0s'}
+							label="average stay"
+						/>
+						{stats && (
+							<Stat
+								value={formatDuration(Date.now() - stats.createdAt) || '0s'}
+								label="lane age"
+								title={`Opened ${formatAbsolute(stats.createdAt)}`}
+							/>
+						)}
+					</div>
+				) : (
+					<Empty>Nothing is waiting here</Empty>
+				)}
+
+				{stats && <StayTrend points={stats.stayTrend} />}
+			</Section>
+
+			<Section title="Code standing here" tone={CODE_TONE}>
+				{stats && stats.code.commits === 0 ? (
+					<Empty>No commits on the tickets in this lane</Empty>
+				) : (
+					stats && (
+						// The diff wears the same pill it wears on a commit row and a
+						// ticket's Code tab — a figure the reader already knows how to
+						// read, rather than two large numbers that have to say "added"
+						// and "removed" to mean anything.
+						<div
+							style={{
+								...ROW,
+								borderBottom: 'none',
+								marginTop: 12,
+								alignItems: 'center',
+							}}
+						>
+							{/* Shrinks first: the pill is the point of the row, and this
+							    panel is narrow enough for the two to collide. */}
+							<span
+								style={{
+									color: GUI_THEME.primary,
+									minWidth: 0,
+									overflow: 'hidden',
+									textOverflow: 'ellipsis',
+									whiteSpace: 'nowrap',
+								}}
+							>
+								{plural(stats.code.commits, 'commit')} ·{' '}
+								{plural(stats.code.tickets, 'ticket')}
+							</span>
+
+							<DiffStat
+								insertions={stats.code.insertions}
+								deletions={stats.code.deletions}
+							/>
+						</div>
+					)
+				)}
+			</Section>
+
+			<Section title="Usually arrives from" tone={BOARD_TONE}>
+				{state?.loading && <Empty>Reading the board…</Empty>}
+				{state?.error && <Empty>{state.error}</Empty>}
+				{stats && (
+					<FlowList
+						flows={stats.arrivesFrom}
+						empty="Nothing has ever been here"
+					/>
+				)}
+			</Section>
+
+			<Section title="Usually moves on to" tone={BOARD_TONE}>
+				{stats && (
+					<FlowList
+						flows={stats.movesOnTo}
+						empty="Nothing has left this lane yet"
+					/>
+				)}
+			</Section>
+		</Aside>
+	);
+};

--- a/source/gui/client/lib/lane-dwell.ts
+++ b/source/gui/client/lib/lane-dwell.ts
@@ -1,3 +1,4 @@
+import {medianOfSorted} from '../../../lib/utils/number.js';
 import {GuiIssue} from './gui-state.model';
 
 const DAY = 24 * 60 * 60 * 1000;
@@ -19,14 +20,6 @@ export type LaneDwell = {median: number; mean: number; max: number};
 export const dwellOf = (issue: GuiIssue, now: number): number =>
 	Math.max(0, now - issue.enteredLaneAt);
 
-const median = (sorted: readonly number[]): number => {
-	const middle = Math.floor(sorted.length / 2);
-
-	return sorted.length % 2 === 0
-		? (sorted[middle - 1]! + sorted[middle]!) / 2
-		: sorted[middle]!;
-};
-
 /** How long the lane's open tickets have been sitting in it. */
 export const laneDwell = (
 	issues: readonly GuiIssue[],
@@ -40,7 +33,7 @@ export const laneDwell = (
 	if (dwells.length === 0) return null;
 
 	return {
-		median: median(dwells),
+		median: medianOfSorted(dwells) ?? 0,
 		mean: dwells.reduce((total, dwell) => total + dwell, 0) / dwells.length,
 		max: dwells[dwells.length - 1]!,
 	};

--- a/source/gui/client/lib/use-swimlane-stats.ts
+++ b/source/gui/client/lib/use-swimlane-stats.ts
@@ -1,0 +1,72 @@
+// What the swimlane panel needs that the board's own state does not carry: the
+// lane's traffic, and what the code on the tickets standing in it adds up to.
+// One fetch, one reply, thrown away when the lane changes.
+
+import {useCallback, useEffect, useState} from 'react';
+// Types only, from a module that declares nothing but types and imports
+// nothing at all — the same boundary `use-issue-detail` reads IssueStats over.
+import {SwimlaneStats} from '../../../lib/stats/swimlane-stats.model.js';
+import {getResultValue} from './gui-state-helper';
+
+export type SwimlaneStatsState = {
+	swimlaneId: string;
+	loading: boolean;
+	error: string | null;
+	stats: SwimlaneStats | null;
+};
+
+export const useSwimlaneStats = ({
+	swimlaneId,
+	sendRaw,
+}: {
+	swimlaneId: string | null;
+	sendRaw: (message: unknown) => void;
+}) => {
+	const [stats, setStats] = useState<SwimlaneStatsState | null>(null);
+
+	// Asked for on opening the lane and not again: the traffic figures move
+	// only when a ticket moves, and the reader is looking at a panel, not a
+	// live gauge. Closing and opening it again is the refresh.
+	useEffect(() => {
+		if (!swimlaneId) {
+			setStats(null);
+			return;
+		}
+
+		setStats({swimlaneId, loading: true, error: null, stats: null});
+		sendRaw({type: 'swimlane:stats:get', payload: {swimlaneId}});
+	}, [swimlaneId, sendRaw]);
+
+	const onMessage = useCallback((message: any) => {
+		if (message.type !== 'swimlane:stats:result') return;
+
+		// Wrapped with the lane it was asked for: the panel stays open across a
+		// change of lane, and a failed Result carries no id to tell whose reply
+		// this is.
+		const {swimlaneId: forLane, result} = message.payload as {
+			swimlaneId: string;
+			result: {status: string; message: string; value?: SwimlaneStats};
+		};
+
+		if (result?.status === 'fail') {
+			setStats(prev =>
+				prev && prev.swimlaneId === forLane
+					? {...prev, loading: false, error: result.message}
+					: prev,
+			);
+			return;
+		}
+
+		const next = getResultValue<SwimlaneStats>(result);
+
+		if (next) {
+			setStats(prev =>
+				prev && prev.swimlaneId === forLane
+					? {...prev, loading: false, error: null, stats: next}
+					: prev,
+			);
+		}
+	}, []);
+
+	return {stats, onMessage};
+};

--- a/source/lib/stats/board-stats.ts
+++ b/source/lib/stats/board-stats.ts
@@ -45,12 +45,18 @@ const MOVE = 'move.node';
  */
 export const deriveBoardStats = ({
 	createdAt,
+	enteredLaneAt,
 	now,
 	history,
 	lanes,
 	currentLaneId,
 }: {
 	createdAt: number;
+	// When the ticket last arrived where it is, derived once from the whole log
+	// by `laneEntryTime` and carried on the ticket. Not recomputed here: this
+	// function sees only the moves, and a move within one lane looks exactly
+	// like an arrival from that angle.
+	enteredLaneAt: number;
 	now: number;
 	// Oldest first, as the ticket's log is kept.
 	history: BoardMove[];
@@ -60,7 +66,6 @@ export const deriveBoardStats = ({
 	const orderById = new Map(lanes.map((lane, index) => [lane.id, index]));
 
 	let timesSentBack = 0;
-	let landedInCurrentAt: number | null = null;
 
 	// Walked forwards, carrying where the ticket was. A ticket is filed into
 	// the board's first lane, so that is where the first move is measured
@@ -80,14 +85,13 @@ export const deriveBoardStats = ({
 			timesSentBack++;
 		}
 
-		if (event.parentId === currentLaneId) landedInCurrentAt = event.t;
 		if (index !== undefined) previousIndex = index;
 	}
 
 	return {
 		ageMs: Math.max(0, now - createdAt),
 		timesSentBack,
-		inLaneMs: Math.max(0, now - (landedInCurrentAt ?? createdAt)),
+		inLaneMs: Math.max(0, now - enteredLaneAt),
 		laneTitle: lanes.find(lane => lane.id === currentLaneId)?.title ?? '',
 	};
 };

--- a/source/lib/stats/lane-trend.ts
+++ b/source/lib/stats/lane-trend.ts
@@ -1,0 +1,56 @@
+import {LaneVisit} from '../utils/lane-dwell.js';
+import {medianOfSorted} from '../utils/number.js';
+import {LaneStayPoint} from './swimlane-stats.model.js';
+
+// Whether a lane is getting slower, which none of its current figures can say.
+//
+// A lane's median stay today is one reading; the same reading taken on each of
+// the last thirty days is a slope. Every ticket's visits say exactly which lane
+// it was in at any past moment and when it got there, so each day's figure is
+// reconstructed rather than remembered — no snapshot has to have been kept.
+
+const DAY = 24 * 60 * 60 * 1000;
+
+/** How long the ticket had been in `laneId` at `t`, or null if it was elsewhere. */
+const ageAt = (
+	visits: readonly LaneVisit[],
+	laneId: string,
+	t: number,
+): number | null => {
+	for (const [index, visit] of visits.entries()) {
+		if (visit.laneId !== laneId || visit.enteredAt > t) continue;
+
+		// Still there at `t` only if nothing moved it away before then.
+		const left = visits[index + 1]?.enteredAt;
+		if (left === undefined || left > t) return t - visit.enteredAt;
+	}
+
+	return null;
+};
+
+/**
+ * One point per day, oldest first, ending at `now`. `journeys` is every ticket's
+ * visits — including tickets that have long since left, since what makes the
+ * line move is as much what left the lane as what is standing in it.
+ */
+export const deriveLaneStayTrend = ({
+	laneId,
+	journeys,
+	now,
+	days,
+}: {
+	laneId: string;
+	journeys: ReadonlyArray<readonly LaneVisit[]>;
+	now: number;
+	days: number;
+}): LaneStayPoint[] =>
+	Array.from({length: days}, (_, index) => {
+		const t = now - (days - 1 - index) * DAY;
+
+		const ages = journeys
+			.map(visits => ageAt(visits, laneId, t))
+			.filter((age): age is number => age !== null)
+			.sort((a, b) => a - b);
+
+		return {t, median: medianOfSorted(ages), count: ages.length};
+	});

--- a/source/lib/stats/swimlane-flow.ts
+++ b/source/lib/stats/swimlane-flow.ts
@@ -1,0 +1,77 @@
+import {LaneFlow} from './swimlane-stats.model.js';
+
+// What a lane's traffic looks like, from the lane sequences its tickets have
+// been through. Sequences in, counts out: the caller derives the journeys from
+// whatever copy of the log it holds, so the GUI, the TUI and the MCP can each
+// answer this without one of them owning it.
+
+// A ticket filed straight into the lane arrived from nowhere, which is a
+// different fact from arriving from a lane and worth its own row.
+const FILED_HERE = 'Filed here';
+
+const bump = (counts: Map<string | null, number>, key: string | null) =>
+	counts.set(key, (counts.get(key) ?? 0) + 1);
+
+const ranked = (
+	counts: Map<string | null, number>,
+	total: number,
+	titleOf: (laneId: string) => string,
+): LaneFlow[] =>
+	[...counts.entries()]
+		.map(([laneId, count]) => ({
+			laneId,
+			title: laneId === null ? FILED_HERE : titleOf(laneId),
+			count,
+			share: total === 0 ? 0 : count / total,
+		}))
+		.sort((a, b) => b.count - a.count || a.title.localeCompare(b.title));
+
+/**
+ * `journeys` is one lane sequence per ticket, oldest first, over every ticket
+ * that has ever been in this lane or anywhere else — a lane's traffic is a
+ * question about the tickets that have left it, and those are elsewhere now.
+ *
+ * A ticket can pass through the same lane more than once; each pass counts,
+ * which is what makes a lane that things come back to look different from one
+ * they go through once.
+ */
+export const deriveLaneFlow = (
+	swimlaneId: string,
+	journeys: ReadonlyArray<readonly string[]>,
+	titleOf: (laneId: string) => string,
+): {
+	arrived: number;
+	departed: number;
+	arrivesFrom: LaneFlow[];
+	movesOnTo: LaneFlow[];
+} => {
+	const from = new Map<string | null, number>();
+	const to = new Map<string | null, number>();
+
+	let arrived = 0;
+	let departed = 0;
+
+	for (const journey of journeys) {
+		for (const [index, laneId] of journey.entries()) {
+			if (laneId !== swimlaneId) continue;
+
+			arrived++;
+			bump(from, journey[index - 1] ?? null);
+
+			// Still sitting in the lane: an arrival with no departure yet, and
+			// counting it as one would read as tickets that never leave.
+			const next = journey[index + 1];
+			if (next === undefined) continue;
+
+			departed++;
+			bump(to, next);
+		}
+	}
+
+	return {
+		arrived,
+		departed,
+		arrivesFrom: ranked(from, arrived, titleOf),
+		movesOnTo: ranked(to, departed, titleOf),
+	};
+};

--- a/source/lib/stats/swimlane-stats.model.ts
+++ b/source/lib/stats/swimlane-stats.model.ts
@@ -1,0 +1,53 @@
+// Everything a swimlane's stats panel is told, in one place.
+//
+// Types only, and no imports, for the same reason `issue-stats.model.ts` has
+// none: the GUI client reads this file the way the Node side does, and nothing
+// here is anything but JSON on a websocket.
+
+/**
+ * One end of a lane's traffic — where its tickets were before, or where they
+ * went after. `laneId` is null for the two cases that are not another lane:
+ * a ticket filed straight into this one, and one closed out of it.
+ */
+export type LaneFlow = {
+	laneId: string | null;
+	title: string;
+	count: number;
+	// Of every counted arrival or departure, so a lane with two sources reads
+	// as the split it is rather than as a winner.
+	share: number;
+};
+
+export type SwimlaneCode = {
+	// Of the tickets in the lane now, how many own any commits at all. The
+	// counts below are theirs, and say nothing about tickets that have moved on.
+	tickets: number;
+	commits: number;
+	insertions: number;
+	deletions: number;
+};
+
+/** One day's reading of the lane's median stay. */
+export type LaneStayPoint = {
+	t: number;
+	// Null on a day the lane stood empty — not zero, which would read as
+	// tickets being served instantly.
+	median: number | null;
+	count: number;
+};
+
+export type SwimlaneStats = {
+	swimlaneId: string;
+	// Decoded from the swimlane's own ULID.
+	createdAt: number;
+	// Tickets that have been in this lane and left it. The flows below are
+	// counted over these, since a ticket sitting in the lane now has an
+	// arrival but no departure yet.
+	departed: number;
+	arrived: number;
+	arrivesFrom: LaneFlow[];
+	movesOnTo: LaneFlow[];
+	code: SwimlaneCode;
+	// Oldest first, one point per day, ending today.
+	stayTrend: LaneStayPoint[];
+};

--- a/source/lib/utils/lane-dwell.ts
+++ b/source/lib/utils/lane-dwell.ts
@@ -15,27 +15,42 @@ const parentOf = (event: AppEvent): string | null => {
 	}
 };
 
+export type LaneVisit = {laneId: string; enteredAt: number};
+
 /**
- * When the ticket last arrived in the lane it is in now, read off its own log.
+ * Every lane the ticket has been in, oldest first, read off its own log.
+ *
  * The parent is compared rather than counted: dragging a card up its own column
- * writes a move carrying the lane it is already in, and must not restart the
- * clock. Falls back to `createdAt` for a log that never names a parent.
+ * writes a move carrying the lane it is already in, which is not a visit. One
+ * walk answers all three questions a lane gets asked — when a ticket arrived,
+ * where it came from, and where it went next.
+ */
+export const laneVisits = (
+	log: readonly AppEvent[],
+	createdAt: number,
+): LaneVisit[] => {
+	const visits: LaneVisit[] = [];
+
+	for (const event of log) {
+		const laneId = parentOf(event);
+		if (laneId === null || laneId === visits.at(-1)?.laneId) continue;
+
+		const time = getEventTime(event);
+
+		visits.push({
+			laneId,
+			enteredAt: time === null ? createdAt : clampUlidTime(time),
+		});
+	}
+
+	return visits;
+};
+
+/**
+ * When the ticket last arrived in the lane it is in now. Falls back to
+ * `createdAt` for a log that never names a parent.
  */
 export const laneEntryTime = (
 	log: readonly AppEvent[],
 	createdAt: number,
-): number => {
-	let parent: string | null = null;
-	let entered = createdAt;
-
-	for (const event of log) {
-		const next = parentOf(event);
-		if (next === null || next === parent) continue;
-
-		const time = getEventTime(event);
-		parent = next;
-		if (time !== null) entered = clampUlidTime(time);
-	}
-
-	return entered;
-};
+): number => laneVisits(log, createdAt).at(-1)?.enteredAt ?? createdAt;

--- a/source/lib/utils/number.ts
+++ b/source/lib/utils/number.ts
@@ -1,3 +1,14 @@
 export function clamp(n: number, min: number, max: number) {
 	return Math.max(min, Math.min(max, n));
 }
+
+/** The middle of an already-sorted list, averaging the middle pair of an even one. */
+export const medianOfSorted = (sorted: readonly number[]): number | null => {
+	if (sorted.length === 0) return null;
+
+	const middle = Math.floor(sorted.length / 2);
+
+	return sorted.length % 2 === 0
+		? (sorted[middle - 1]! + sorted[middle]!) / 2
+		: sorted[middle]!;
+};

--- a/source/mcp/api/swimlane-stats.ts
+++ b/source/mcp/api/swimlane-stats.ts
@@ -1,0 +1,111 @@
+// A lane's own numbers: when it was opened, what its traffic looks like, and
+// what the code on the tickets standing in it adds up to.
+//
+// The traffic half reads the materialized state, like `getIssueHistory` does,
+// so it stays correct mid-scrub. The code half goes to git through
+// `getIssueStats`, which is why the whole thing is fetched on a click rather
+// than ridden along on the board broadcast.
+
+import {ulidTimeMs} from '../../lib/event/date-utils.js';
+import {isTicketNode} from '../../lib/model/context.model.js';
+import {
+	failed,
+	isFail,
+	Result,
+	succeeded,
+} from '../../lib/model/result-types.js';
+import {deriveLaneFlow} from '../../lib/stats/swimlane-flow.js';
+import {deriveLaneStayTrend} from '../../lib/stats/lane-trend.js';
+import {
+	SwimlaneCode,
+	SwimlaneStats,
+} from '../../lib/stats/swimlane-stats.model.js';
+import {laneVisits} from '../../lib/utils/lane-dwell.js';
+import {nodeRef} from '../../lib/utils/node-ref.js';
+import {getIssueStats} from '../epiq-issue-stats.js';
+import {getStateResult} from './boot.js';
+
+// A lane can hold a great many tickets, and each one measured is a walk over
+// its patches. Past this the code figures say what they saw and stop, which is
+// a slow panel avoided rather than a number missed: the flow figures above
+// them are the point of the panel and cost no git at all.
+const CODE_TICKET_LIMIT = 40;
+
+// Long enough for a slope to be a slope rather than a wobble, short enough that
+// a lane opened last week still draws something.
+const TREND_DAYS = 30;
+
+const emptyCode = (): SwimlaneCode => ({
+	tickets: 0,
+	commits: 0,
+	insertions: 0,
+	deletions: 0,
+});
+
+const codeForLane = async (
+	repoRoot: string,
+	ticketIds: readonly string[],
+): Promise<SwimlaneCode> => {
+	const code = emptyCode();
+
+	for (const id of ticketIds.slice(0, CODE_TICKET_LIMIT)) {
+		const stats = await getIssueStats({repoRoot, idOrRef: nodeRef(id)});
+
+		// A ticket with no commits is not a failure, and neither is one whose
+		// scan could not run — either way the lane's total is over what could
+		// be measured, and one unreadable ticket must not lose the rest.
+		if (isFail(stats) || stats.value.shape.commits === 0) continue;
+
+		code.tickets++;
+		code.commits += stats.value.shape.commits;
+		code.insertions += stats.value.shape.insertions;
+		code.deletions += stats.value.shape.deletions;
+	}
+
+	return code;
+};
+
+export const getSwimlaneStats = async (input: {
+	repoRoot: string;
+	swimlaneId: string;
+}): Promise<Result<SwimlaneStats>> => {
+	const stateResult = getStateResult();
+	if (isFail(stateResult)) return stateResult;
+
+	const {nodes} = stateResult.value;
+
+	const swimlane = nodes[input.swimlaneId];
+	if (!swimlane) return failed('Swimlane not found');
+
+	const tickets = Object.values(nodes).filter(isTicketNode);
+
+	// Every ticket on the workspace, not just the ones standing here: a lane's
+	// traffic is mostly a fact about tickets that have already left it, and so
+	// is what its stay looked like a month ago.
+	const journeys = tickets.map(ticket =>
+		laneVisits(ticket.log ?? [], ulidTimeMs(ticket.id)),
+	);
+
+	const flow = deriveLaneFlow(
+		input.swimlaneId,
+		journeys.map(visits => visits.map(visit => visit.laneId)),
+		laneId => nodes[laneId]?.title ?? 'Elsewhere',
+	);
+
+	const standingHere = tickets
+		.filter(ticket => ticket.parentNodeId === input.swimlaneId)
+		.map(ticket => ticket.id);
+
+	return succeeded('Derived swimlane stats', {
+		swimlaneId: input.swimlaneId,
+		createdAt: ulidTimeMs(input.swimlaneId),
+		...flow,
+		stayTrend: deriveLaneStayTrend({
+			laneId: input.swimlaneId,
+			journeys,
+			now: Date.now(),
+			days: TREND_DAYS,
+		}),
+		code: await codeForLane(input.repoRoot, standingHere),
+	});
+};

--- a/source/test/board-stats.test.ts
+++ b/source/test/board-stats.test.ts
@@ -21,6 +21,7 @@ describe('deriveBoardStats', () => {
 	it('ages a ticket from when it was filed', () => {
 		const stats = deriveBoardStats({
 			createdAt: NOW - 3 * DAY,
+			enteredLaneAt: NOW - 3 * DAY,
 			now: NOW,
 			history: [],
 			lanes,
@@ -36,6 +37,7 @@ describe('deriveBoardStats', () => {
 	it('measures time in lane from filing when nothing has moved', () => {
 		const stats = deriveBoardStats({
 			createdAt: NOW - 3 * DAY,
+			enteredLaneAt: NOW - 3 * DAY,
 			now: NOW,
 			history: [],
 			lanes,
@@ -45,9 +47,10 @@ describe('deriveBoardStats', () => {
 		expect(stats.inLaneMs).toBe(3 * DAY);
 	});
 
-	it('measures time in lane from the move that put it there', () => {
+	it('measures time in lane from the arrival it is given', () => {
 		const stats = deriveBoardStats({
 			createdAt: NOW - 8 * DAY,
+			enteredLaneAt: NOW - 2 * DAY,
 			now: NOW,
 			history: [
 				moved(NOW - 6 * DAY, 'ongoing'),
@@ -61,9 +64,31 @@ describe('deriveBoardStats', () => {
 		expect(stats.laneTitle).toBe('Review');
 	});
 
+	// Dragging a card up its own column writes a move naming the lane it is
+	// already in. Reading the moves for an arrival cannot tell that from a real
+	// one, which is why the arrival is derived from the whole log elsewhere and
+	// handed in — tidying a column used to zero every clock in it.
+	it('is not reset by a move within the lane the ticket is already in', () => {
+		const stats = deriveBoardStats({
+			createdAt: NOW - 9 * DAY,
+			enteredLaneAt: NOW - 5 * DAY,
+			now: NOW,
+			history: [
+				moved(NOW - 5 * DAY, 'review'),
+				// A reorder, a minute ago.
+				moved(NOW - 60_000, 'review'),
+			],
+			lanes,
+			currentLaneId: 'review',
+		});
+
+		expect(stats.inLaneMs).toBe(5 * DAY);
+	});
+
 	it('counts a move to an earlier lane, and only that', () => {
 		const stats = deriveBoardStats({
 			createdAt: NOW - 8 * DAY,
+			enteredLaneAt: NOW - 3 * DAY,
 			now: NOW,
 			history: [
 				moved(NOW - 7 * DAY, 'ongoing'),
@@ -84,6 +109,7 @@ describe('deriveBoardStats', () => {
 	it('does not count going forwards, however far', () => {
 		const stats = deriveBoardStats({
 			createdAt: NOW - 2 * DAY,
+			enteredLaneAt: NOW - DAY,
 			now: NOW,
 			history: [moved(NOW - DAY, 'done')],
 			lanes,
@@ -98,6 +124,7 @@ describe('deriveBoardStats', () => {
 	it('ignores a move to a lane this board does not have', () => {
 		const stats = deriveBoardStats({
 			createdAt: NOW - 4 * DAY,
+			enteredLaneAt: NOW - 3 * DAY,
 			now: NOW,
 			history: [
 				moved(NOW - 3 * DAY, 'review'),
@@ -113,6 +140,7 @@ describe('deriveBoardStats', () => {
 	it('ignores every event that is not a move', () => {
 		const stats = deriveBoardStats({
 			createdAt: NOW - 4 * DAY,
+			enteredLaneAt: NOW - 4 * DAY,
 			now: NOW,
 			history: [
 				{t: NOW - 3 * DAY, action: 'add.comment'},

--- a/source/test/e2e-gui/lane-dwell.pw.ts
+++ b/source/test/e2e-gui/lane-dwell.pw.ts
@@ -1,8 +1,8 @@
 import type {Locator, Page} from '@playwright/test';
 import {expect, test} from './fixtures.js';
 
-// The lane a figure would be drawn for: an empty column carries none, so
-// asserting on the first header would pass whether the figure works or not.
+// The lane the icon would be drawn on: an empty column offers no stats, so
+// asserting on the first header would pass whether the feature works or not.
 const laneWithTickets = async (page: Page): Promise<Locator> => {
 	const headers = page.getByTestId('swimlane-handle');
 
@@ -29,7 +29,7 @@ const returnToLive = async (page: Page) => {
 	}
 };
 
-test('a lane says how long its tickets have sat in it', async ({
+test('a lane opens its own stats, and says how long its tickets have sat there', async ({
 	page,
 	appUrl,
 	pageErrors,
@@ -37,22 +37,61 @@ test('a lane says how long its tickets have sat in it', async ({
 	await page.goto(appUrl);
 	await expect(page.getByTestId('board-switcher')).toContainText('Default');
 
+	const title = `Dwell ${Date.now()}`;
 	await page.getByTitle('Add issue').first().click();
-	await page.getByPlaceholder('issue name').fill(`Dwell ${Date.now()}`);
+	await page.getByPlaceholder('issue name').fill(title);
 	await page.getByPlaceholder('issue name').press('Enter');
 
-	const dwell = (await laneWithTickets(page)).getByTestId('swimlane-dwell');
+	// The scan below reads each header once, so the ticket has to be on the
+	// board before it runs. Scoped to the board: creating a ticket opens its
+	// details, and the title is then on screen twice.
+	await expect(page.getByRole('main').getByText(title)).toBeVisible();
 
-	await expect(dwell).toBeVisible();
-	await expect(dwell).toHaveText(/med · .+ max/);
+	const lane = await laneWithTickets(page);
+	await lane.getByTestId('swimlane-stats-open').click();
+
+	const panel = page.getByTestId('swimlane-stats');
+	await expect(panel).toBeVisible();
+
+	// The lane's own figures, not another lane's: the panel names the column it
+	// was opened from.
+	await expect(panel).toContainText(
+		(await lane.locator('strong').textContent()) ?? '',
+	);
+
+	await expect(page.getByText('median stay', {exact: true})).toBeVisible();
+	await expect(page.getByText('Usually arrives from')).toBeVisible();
+	await expect(page.getByText('Usually moves on to')).toBeVisible();
 
 	expect(pageErrors).toEqual([]);
 });
 
-// Elapsed-until-now says nothing about a board being shown as it was at some
-// other moment, so the figure goes away rather than answering the wrong
-// question.
-test('no lane carries a dwell while the board is scrubbed', async ({
+// The ticket panel beside it deliberately survives a stray click, because it
+// holds a half-written description; a lane's figures hold nothing.
+test('a click on the board closes the lane panel', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	const lane = await laneWithTickets(page);
+	await lane.getByTestId('swimlane-stats-open').click();
+	await expect(page.getByTestId('swimlane-stats')).toBeVisible();
+
+	// The empty ground below the columns: a click that was never about a
+	// ticket, a lane header, or the panel.
+	await page.getByRole('main').click({position: {x: 40, y: 40}});
+
+	await expect(page.getByTestId('swimlane-stats')).toHaveCount(0);
+
+	expect(pageErrors).toEqual([]);
+});
+
+// Every figure on the panel is measured against now, which says nothing about
+// a board being drawn as it was at some other moment.
+test('no lane offers stats while the board is scrubbed', async ({
 	page,
 	appUrl,
 	pageErrors,
@@ -61,7 +100,7 @@ test('no lane carries a dwell while the board is scrubbed', async ({
 	await expect(page.getByTestId('board-switcher')).toContainText('Default');
 
 	await expect(
-		(await laneWithTickets(page)).getByTestId('swimlane-dwell'),
+		(await laneWithTickets(page)).getByTestId('swimlane-stats-open'),
 	).toBeVisible();
 
 	const track = page.getByTestId('scrubber-track');
@@ -69,14 +108,14 @@ test('no lane carries a dwell while the board is scrubbed', async ({
 	if (!box) throw new Error('scrubber track is not on screen');
 
 	// Near the present, so the past being drawn still has tickets on it — the
-	// assertion has to fail on a figure left behind, not on an empty board.
+	// assertion has to fail on an icon left behind, not on an empty board.
 	await page.mouse.click(box.x + box.width * 0.95, box.y + box.height / 2);
 	await expect(
 		page.getByRole('button', {name: 'Resume', exact: true}),
 	).toBeEnabled();
 
 	await expect(
-		(await laneWithTickets(page)).getByTestId('swimlane-dwell'),
+		(await laneWithTickets(page)).getByTestId('swimlane-stats-open'),
 	).toHaveCount(0);
 
 	await returnToLive(page);

--- a/source/test/lane-trend.test.ts
+++ b/source/test/lane-trend.test.ts
@@ -1,0 +1,85 @@
+import {describe, expect, it} from 'vitest';
+import {deriveLaneStayTrend} from '../lib/stats/lane-trend.js';
+import {LaneVisit} from '../lib/utils/lane-dwell.js';
+
+const DAY = 24 * 60 * 60 * 1000;
+const NOW = 100 * DAY;
+
+const trend = (journeys: LaneVisit[][], days = 5) =>
+	deriveLaneStayTrend({laneId: 'review', journeys, now: NOW, days});
+
+const visit = (laneId: string, daysAgo: number): LaneVisit => ({
+	laneId,
+	enteredAt: NOW - daysAgo * DAY,
+});
+
+describe('deriveLaneStayTrend', () => {
+	it('gives one point per day, oldest first, ending now', () => {
+		const points = trend([], 5);
+
+		expect(points).toHaveLength(5);
+		expect(points.at(-1)!.t).toBe(NOW);
+		expect(points[0]!.t).toBe(NOW - 4 * DAY);
+	});
+
+	// Not zero: nothing waiting is a different statement from everything being
+	// served instantly, and a line through zero would make the second.
+	it('leaves a day the lane stood empty unmeasured', () => {
+		const points = trend([[visit('review', 1)]], 3);
+
+		expect(points[0]!.median).toBeNull();
+		expect(points[0]!.count).toBe(0);
+		expect(points.at(-1)!.median).toBe(DAY);
+	});
+
+	it('ages a ticket that has sat still, one day per day', () => {
+		const points = trend([[visit('review', 4)]], 5);
+
+		expect(points.map(point => point.median)).toEqual([
+			0,
+			DAY,
+			2 * DAY,
+			3 * DAY,
+			4 * DAY,
+		]);
+	});
+
+	// The reading is reconstructed, so a ticket that left weeks ago still counts
+	// on the days it was there and stops counting the day it left.
+	it('counts a ticket only while it was actually in the lane', () => {
+		const points = trend([[visit('review', 4), visit('done', 2)]], 5);
+
+		expect(points.map(point => point.count)).toEqual([1, 1, 0, 0, 0]);
+		expect(points[1]!.median).toBe(DAY);
+		expect(points[2]!.median).toBeNull();
+	});
+
+	it('takes the median across everything standing there that day', () => {
+		const points = trend(
+			[[visit('review', 4)], [visit('review', 2)], [visit('review', 0)]],
+			5,
+		);
+
+		// Day 4 back: only the first, at nothing. Today: 4d, 2d and 0d.
+		expect(points[0]!.median).toBe(0);
+		expect(points.at(-1)!.count).toBe(3);
+		expect(points.at(-1)!.median).toBe(2 * DAY);
+	});
+
+	it('reads a ticket that came back as being here on both visits', () => {
+		const points = trend(
+			[[visit('review', 4), visit('ongoing', 3), visit('review', 1)]],
+			5,
+		);
+
+		expect(points.map(point => point.count)).toEqual([1, 0, 0, 1, 1]);
+		// Its second stay is measured from the day it came back, not the first.
+		expect(points.at(-1)!.median).toBe(DAY);
+	});
+
+	it('ignores tickets that have never been in the lane', () => {
+		const points = trend([[visit('todo', 3), visit('done', 1)]], 4);
+
+		expect(points.every(point => point.median === null)).toBe(true);
+	});
+});

--- a/source/test/swimlane-flow.test.ts
+++ b/source/test/swimlane-flow.test.ts
@@ -1,0 +1,110 @@
+import {describe, expect, it} from 'vitest';
+import {deriveLaneFlow} from '../lib/stats/swimlane-flow.js';
+
+const titles: Record<string, string> = {
+	backlog: 'Backlog',
+	ongoing: 'Ongoing',
+	review: 'Review',
+	done: 'Done',
+	closed: 'Closed',
+};
+
+const titleOf = (laneId: string) => titles[laneId] ?? 'Elsewhere';
+
+const flow = (journeys: string[][]) =>
+	deriveLaneFlow('review', journeys, titleOf);
+
+describe('deriveLaneFlow', () => {
+	it('says nothing about a lane nothing has been through', () => {
+		const result = flow([['backlog', 'ongoing', 'done']]);
+
+		expect(result.arrived).toBe(0);
+		expect(result.departed).toBe(0);
+		expect(result.arrivesFrom).toEqual([]);
+		expect(result.movesOnTo).toEqual([]);
+	});
+
+	it('names the lane a ticket came from and the one it went to', () => {
+		const result = flow([['backlog', 'ongoing', 'review', 'done']]);
+
+		expect(result.arrivesFrom).toEqual([
+			{laneId: 'ongoing', title: 'Ongoing', count: 1, share: 1},
+		]);
+		expect(result.movesOnTo).toEqual([
+			{laneId: 'done', title: 'Done', count: 1, share: 1},
+		]);
+	});
+
+	// A ticket filed straight into the lane came from nowhere, which is a
+	// different fact from having come from a lane.
+	it('counts a ticket filed into the lane as arriving from nowhere', () => {
+		const result = flow([['review', 'done']]);
+
+		expect(result.arrivesFrom).toEqual([
+			{laneId: null, title: 'Filed here', count: 1, share: 1},
+		]);
+	});
+
+	// The whole reason the panel ranks rather than naming a winner.
+	it('splits the sources by share rather than naming one', () => {
+		const result = flow([
+			['ongoing', 'review', 'done'],
+			['ongoing', 'review', 'done'],
+			['ongoing', 'review', 'done'],
+			['backlog', 'review', 'done'],
+		]);
+
+		expect(result.arrived).toBe(4);
+		expect(result.arrivesFrom.map(entry => [entry.title, entry.count])).toEqual(
+			[
+				['Ongoing', 3],
+				['Backlog', 1],
+			],
+		);
+		expect(result.arrivesFrom[0]!.share).toBe(0.75);
+	});
+
+	// Counting them as departures would read as a lane nothing ever leaves.
+	it('leaves tickets still sitting in the lane out of the departures', () => {
+		const result = flow([
+			['ongoing', 'review', 'done'],
+			['ongoing', 'review'],
+			['ongoing', 'review'],
+		]);
+
+		expect(result.arrived).toBe(3);
+		expect(result.departed).toBe(1);
+		expect(result.movesOnTo).toEqual([
+			{laneId: 'done', title: 'Done', count: 1, share: 1},
+		]);
+	});
+
+	// A lane work comes back to looks nothing like one it goes through once,
+	// and that only shows if both passes count.
+	it('counts every pass a ticket makes through the lane', () => {
+		const result = flow([['ongoing', 'review', 'ongoing', 'review', 'done']]);
+
+		expect(result.arrived).toBe(2);
+		expect(result.departed).toBe(2);
+		expect(result.movesOnTo.map(entry => [entry.title, entry.count])).toEqual([
+			['Done', 1],
+			['Ongoing', 1],
+		]);
+	});
+
+	it('reads a ticket closed out of the lane as going to the closed lane', () => {
+		const result = flow([['review', 'closed']]);
+
+		expect(result.movesOnTo).toEqual([
+			{laneId: 'closed', title: 'Closed', count: 1, share: 1},
+		]);
+	});
+
+	it('names a lane the board no longer has rather than dropping it', () => {
+		const result = flow([['deleted-lane', 'review']]);
+
+		expect(result.arrivesFrom).toEqual([
+			{laneId: 'deleted-lane', title: 'Elsewhere', count: 1, share: 1},
+		]);
+	});
+});


### PR DESCRIPTION
Stacked on `Y34SCVN` (#276), which this replaces the swimlane header text from. Two tickets, two commits.

## `WY8HP62` — the ticket Stats tab's time-in-lane restarts on a reorder

`deriveBoardStats` set the arrival time on every move naming the current lane. Dragging a card up one place inside its own column is such a move, so tidying a column silently zeroed how long everything in it had been waiting — the one number that says a ticket is stuck. It also read only `move.node`, so a `reopen.issue` was invisible and a reopened ticket dated from its creation.

It no longer derives the arrival at all: it takes `enteredLaneAt`, which the server already puts on every ticket from `laneEntryTime` over the whole log. Reading the moves for an arrival cannot work — from that angle a reorder and a real arrival are the same event.

`laneVisits` is the shared walk now and `laneEntryTime` is its last entry, so the board's clocks, the Stats tab's figure and the panel below are three readings of one rule rather than three implementations that disagree.

## `MR1Y0AP` — a swimlane's own stats panel

The header's `6d med · 3w max` becomes a bar-chart icon beside the ticket count, toggling a panel in the inspector. Lane stats and a ticket's details are one inspector between them, so opening either closes the other.

- **Time in this lane** — median, longest, average, and how many are waiting.
- **Usually arrives from** / **Usually moves on to** — the lanes tickets came from and went to, ranked with shares. Not a single "most common": a lane whose departures split 67% Done and 33% back to In progress has a rework rate, and naming one winner throws it away.
- **Code standing here** — commits across the lane's tickets and the diff they come to.

Split by what each half costs. The dwell figures are the client's own `laneDwell` over the lane it already holds — no request, and no second median that could disagree with the cards. The traffic and the code come over `swimlane:stats:get` on the click: the traffic off materialized state, the code through `getIssueStats` per ticket, capped at 40 so a large lane cannot hang the panel on git.

`deriveLaneFlow` counts passes rather than tickets — a ticket that comes back through a lane counts twice, which is what makes a rework path visible at all — and gives a ticket filed straight into the lane its own row instead of dropping it. Every figure is measured against now, so the icon and the panel are absent while the timeline is scrubbed.

## Tests

9 unit tests over the flow derivation, a regression test for the reorder that is red without the fix, and the two Playwright tests rewritten around the icon and the panel — the scrub one asserts against a lane that still holds tickets, so it cannot pass on an empty board.

Tickets: `WY8HP62`, `MR1Y0AP`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CRAYbmbfeXU2wgx25h4sUP
