### PR TITLE
K6W24FY: a scan of the events directory lists again when a file it listed has gone

### DIFF
--- a/source/git/log-integrity.ts
+++ b/source/git/log-integrity.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import {execGitAllowFail} from './git-utils.js';
 import {failed, Result, succeeded} from '../lib/model/result-types.js';
 import {isPendingFileName} from '../lib/event/pending-log.js';
+import {isVanished} from '../lib/event/log-signature.js';
 import {EPIQ_DIR_NAME, EVENTS_DIR_NAME} from '../lib/storage/paths.js';
 
 /**
@@ -94,10 +95,16 @@ export const snapshotEventLogs = (root: string): EventLogSnapshot => {
 			// append them again, every sync, forever.
 			if (isPendingFileName(name)) continue;
 
-			snapshot.set(
-				name,
-				linesIn(fs.readFileSync(path.join(dir, name), 'utf8')),
-			);
+			try {
+				snapshot.set(
+					name,
+					linesIn(fs.readFileSync(path.join(dir, name), 'utf8')),
+				);
+			} catch (error) {
+				// Gone since the listing: nothing of it to protect, and the rest
+				// of the logs still deserve the net.
+				if (!isVanished(error)) throw error;
+			}
 		}
 	} catch {
 		// Best effort by design: this is a safety net over git, and failing the

--- a/source/lib/event/event-load.ts
+++ b/source/lib/event/event-load.ts
@@ -5,7 +5,13 @@ import {z} from 'zod';
 import {logger} from '../../logger.js';
 import {failed, isFail, Result, succeeded} from '../model/result-types.js';
 import {getEventsDirPath} from '../storage/paths.js';
-import {logSignature, signatureAfterOwnAppend} from './log-signature.js';
+import {
+	isVanished,
+	listEventFiles,
+	logSignature,
+	SCAN_ATTEMPTS,
+	signatureAfterOwnAppend,
+} from './log-signature.js';
 import {toEffectiveUlidTimes} from './date-utils.js';
 import {AppEvent, AppEventMap, isKnownEventAction} from './event.model.js';
 import {
@@ -286,17 +292,22 @@ export const decodeReconstructedEvents = (
 	return succeeded('Decoded reconstructed events', decoded);
 };
 
+/** Null when the file is not there — listed a moment ago, perhaps, and gone now. */
 export const parsePersistedEventsFile = (
 	filePath: string,
 	unreadable?: UnreadableEvent[],
-): Result<ReconstructedEvent[]> => {
-	if (!fs.existsSync(filePath)) {
-		return succeeded('Event file missing', []);
-	}
+): Result<ReconstructedEvent[] | null> => {
 	const actorResult = parseEventFileActor(filePath);
 	if (isFail(actorResult)) return failed(actorResult.message);
 
-	const content = fs.readFileSync(filePath, 'utf8');
+	let content: string;
+	try {
+		content = fs.readFileSync(filePath, 'utf8');
+	} catch (error) {
+		if (isVanished(error)) return succeeded('Event file missing', null);
+		throw error;
+	}
+
 	const entries: ReconstructedEvent[] = [];
 	const fileName = path.basename(filePath);
 
@@ -359,22 +370,43 @@ function loadAllPersistedEvents(
 		return succeeded('No events found', []);
 	}
 
-	const files = fs
-		.readdirSync(dir)
-		.filter(file => file.endsWith('.jsonl'))
-		.map(file => path.join(dir, file));
+	// A file gone between the listing and its read is one a sync just renamed
+	// or git just rewrote; the listing is taken again so the read sees the
+	// directory as it is, not as it was. Quarantined lines are collected per
+	// attempt, or a listing that had to be repeated would report them twice.
+	let entries: ReconstructedEvent[] = [];
+	let quarantined: UnreadableEvent[] = [];
 
-	const entries: ReconstructedEvent[] = [];
+	for (let attempt = 1; ; attempt++) {
+		entries = [];
+		quarantined = [];
+		let listAgain = false;
 
-	for (const filePath of files) {
-		const result = parsePersistedEventsFile(filePath, unreadable);
+		for (const file of listEventFiles(dir)) {
+			const result = parsePersistedEventsFile(
+				path.join(dir, file),
+				quarantined,
+			);
 
-		if (isFail(result)) {
-			return failed(result.message);
+			if (isFail(result)) {
+				return failed(result.message);
+			}
+
+			if (result.value === null) {
+				if (attempt < SCAN_ATTEMPTS) {
+					listAgain = true;
+					break;
+				}
+				continue;
+			}
+
+			entries.push(...result.value);
 		}
 
-		entries.push(...result.value);
+		if (!listAgain) break;
 	}
+
+	unreadable?.push(...quarantined);
 
 	const sorted = getSortedEvents(entries);
 

--- a/source/lib/event/log-signature.ts
+++ b/source/lib/event/log-signature.ts
@@ -17,23 +17,53 @@
 // Taken afterwards, that write would be stored under the signature of a log it
 // does not match, and nothing would ever rebuild it.
 
-import {existsSync, readdirSync, statSync} from 'node:fs';
+import fs from 'node:fs';
 import path from 'node:path';
 import {getEventsDirPath} from '../storage/paths.js';
 
+/**
+ * A file listed a moment ago and gone now. Nothing holds the events directory
+ * still between a listing and the reads that follow it: a sync in another
+ * process renames a pending log twice and deletes it, and git rewrites a
+ * tracked log while it rebases. So a scan that meets one of these lists again
+ * rather than failing — and, having listed a few times, treats what is still
+ * gone as absent, which the next read will find out about for itself.
+ */
+export const isVanished = (error: unknown): boolean =>
+	(error as NodeJS.ErrnoException | null)?.code === 'ENOENT';
+
+export const SCAN_ATTEMPTS = 3;
+
+export const listEventFiles = (dir: string): string[] =>
+	fs
+		.readdirSync(dir)
+		.filter(file => file.endsWith('.jsonl'))
+		.sort();
+
 export const logSignature = (stateBranchRoot: string): string => {
 	const dir = getEventsDirPath(stateBranchRoot);
-	if (!existsSync(dir)) return 'none';
 
-	return readdirSync(dir)
-		.filter(file => file.endsWith('.jsonl'))
-		.sort()
-		.map(file => {
-			const {size, mtimeMs} = statSync(path.join(dir, file));
+	for (let attempt = 1; ; attempt++) {
+		if (!fs.existsSync(dir)) return 'none';
 
-			return `${file}:${size}:${mtimeMs}`;
-		})
-		.join('|');
+		const parts: string[] = [];
+		let listAgain = false;
+
+		for (const file of listEventFiles(dir)) {
+			try {
+				const {size, mtimeMs} = fs.statSync(path.join(dir, file));
+				parts.push(`${file}:${size}:${mtimeMs}`);
+			} catch (error) {
+				if (!isVanished(error)) throw error;
+				if (attempt < SCAN_ATTEMPTS) {
+					listAgain = true;
+					break;
+				}
+			}
+		}
+
+		if (!listAgain) return parts.join('|');
+	}
 };
 
 // The signature that follows an append this process made itself, or null when

--- a/source/test/epiq-time-travel.test.ts
+++ b/source/test/epiq-time-travel.test.ts
@@ -57,9 +57,12 @@ vi.mock('../lib/storage/file-manager.js', () => ({
 	},
 }));
 
-vi.mock('node:fs', () => ({
-	existsSync: vi.fn(),
-}));
+// Both shapes, since the code under test reaches fs by named import and by
+// the default object alike.
+vi.mock('node:fs', () => {
+	const existsSync = vi.fn();
+	return {existsSync, default: {existsSync}};
+});
 
 // Mocked as a unit rather than by widening the `node:fs` mock above: the
 // directory it prepares is a real one with real permissions, which is its own

--- a/source/test/event-load.test.ts
+++ b/source/test/event-load.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import {ulid} from 'ulid';
-import {describe, expect, it} from 'vitest';
+import {afterEach, describe, expect, it, vi} from 'vitest';
 import {
 	decodeReconstructedEvents,
 	getSortedEvents,
@@ -532,6 +532,74 @@ describe('loadMergedEvents with a corrupt line on disk', () => {
 		]);
 		expect(result.value.unreadable).toHaveLength(1);
 		expect(result.value.unreadable[0]?.reason).toBe('corrupt-line');
+	});
+});
+
+// Nothing holds the events directory still between listing it and reading the
+// files: a sync in another process renames a pending log and deletes it, and
+// git rewrites a tracked log while it rebases. A file gone by the time it is
+// read is a directory that moved, not a broken board.
+describe('loadMergedEvents while another process moves a file', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	const seed = (): {root: string; alice: string; bob: string} => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), 'epiq-vanish-'));
+		const eventsDir = path.join(root, '.epiq', 'events');
+		fs.mkdirSync(eventsDir, {recursive: true});
+
+		const alice = path.join(
+			eventsDir,
+			'01ARZ3NDEKTSV4RRFFQ69G5FAV.alice.jsonl',
+		);
+		const bob = path.join(eventsDir, '01BRZ3NDEKTSV4RRFFQ69G5FAV.bob.jsonl');
+
+		fs.writeFileSync(
+			alice,
+			[
+				JSON.stringify({
+					v: 1,
+					id: ['01H0000000000000000000000A', null],
+					'init.workspace': {id: 'ws1', name: 'Workspace', rank: 'a0'},
+				}),
+				'{"v":1,"id":["01H0000000000000000000000B",null],"lock.node"',
+			].join('\n') + '\n',
+		);
+		fs.writeFileSync(
+			bob,
+			JSON.stringify({
+				v: 1,
+				id: ['01H0000000000000000000000C', '01H0000000000000000000000A'],
+				'edit.title': {id: 'ws1', name: 'Renamed'},
+			}) + '\n',
+		);
+
+		return {root, alice, bob};
+	};
+
+	it('lists again rather than failing, and reports a corrupt line once', () => {
+		const {root, bob} = seed();
+
+		// Bob's log goes at the moment the scan reaches it: listed, then gone
+		// before its bytes could be read.
+		const readFileSync = fs.readFileSync;
+		vi.spyOn(fs, 'readFileSync').mockImplementation(((
+			...args: Parameters<typeof fs.readFileSync>
+		) => {
+			if (args[0] === bob) fs.rmSync(bob, {force: true});
+			return readFileSync(...args);
+		}) as typeof fs.readFileSync);
+
+		const result = loadMergedEventsWithUnreadable(root);
+
+		expect(isFail(result)).toBe(false);
+		if (isFail(result)) return;
+
+		expect(result.value.events.map(event => event.action)).toEqual([
+			'init.workspace',
+		]);
+		expect(result.value.unreadable).toHaveLength(1);
 	});
 });
 

--- a/source/test/event-persist-batch.test.ts
+++ b/source/test/event-persist-batch.test.ts
@@ -76,10 +76,19 @@ const ownLogLines = (): Array<{id: [string, string | null]}> => {
 
 describe('materializeAndPersistAll edge threading', () => {
 	it('reads the log once per batch, not once per event', () => {
-		// The dir must exist or the loads short-circuit before readdir.
-		fs.mkdirSync(path.join(rootDir, '.epiq', 'events'), {recursive: true});
+		// One log to read, so a re-read per event would show up as a count.
+		const eventsDir = path.join(rootDir, '.epiq', 'events');
+		fs.mkdirSync(eventsDir, {recursive: true});
+		fs.writeFileSync(
+			path.join(eventsDir, '01ARZ3NDEKTSV4RRFFQ69G5FAV.mallory.jsonl'),
+			JSON.stringify({
+				v: 1,
+				id: ['01H00000000000000000000099', null],
+				'init.workspace': {id: 'w', name: 'W'},
+			}) + '\n',
+		);
 
-		const readdirSpy = vi.spyOn(fs, 'readdirSync');
+		const readSpy = vi.spyOn(fs, 'readFileSync');
 
 		const result = materializeAndPersistAll(
 			[
@@ -92,10 +101,12 @@ describe('materializeAndPersistAll edge threading', () => {
 
 		expect(isFail(result)).toBe(false);
 
-		const eventDirReads = readdirSpy.mock.calls.filter(([dir]) =>
-			String(dir).endsWith(path.join('.epiq', 'events')),
+		// The signature is a listing and a stat per file, cheap and taken per
+		// write; what must not repeat is reading and parsing the logs.
+		const logReads = readSpy.mock.calls.filter(([file]) =>
+			String(file).endsWith('.jsonl'),
 		);
-		expect(eventDirReads).toHaveLength(1);
+		expect(logReads).toHaveLength(1);
 	});
 
 	it('chains every persisted event to its predecessor, starting at the loaded edge', () => {

--- a/source/test/log-signature.test.ts
+++ b/source/test/log-signature.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
 import {
 	accountedSignature,
@@ -32,7 +32,54 @@ describe('what this process has accounted for', () => {
 	});
 
 	afterEach(() => {
+		vi.restoreAllMocks();
 		fs.rmSync(root, {recursive: true, force: true});
+	});
+
+	// Nothing holds the directory still between the listing and the stats: a
+	// sync in another process renames a pending log twice and deletes it, and
+	// git rewrites a tracked log while it rebases. A file gone by then is a
+	// directory that moved, and the answer is the directory as it is now.
+	describe('when a file goes between the listing and its stat', () => {
+		it('lists again rather than throwing', () => {
+			write('u-1', 'a\n');
+			write('u-2', 'x\n');
+
+			const statSync = fs.statSync;
+			vi.spyOn(fs, 'statSync').mockImplementationOnce(((
+				...args: Parameters<typeof fs.statSync>
+			) => {
+				fs.rmSync(path.join(eventsDir(), fileFor('u-2')));
+				return statSync(...args);
+			}) as typeof fs.statSync);
+
+			const signature = logSignature(root);
+
+			expect(signature).toBe(logSignature(root));
+			expect(signature).toContain(fileFor('u-1'));
+			expect(signature).not.toContain(fileFor('u-2'));
+		});
+
+		it('treats a file still gone after listing again as absent', () => {
+			write('u-1', 'a\n');
+			write('u-2', 'x\n');
+
+			const statSync = fs.statSync;
+			vi.spyOn(fs, 'statSync').mockImplementation(((
+				...args: Parameters<typeof fs.statSync>
+			) => {
+				if (String(args[0]).endsWith(fileFor('u-2'))) {
+					throw Object.assign(new Error('ENOENT'), {code: 'ENOENT'});
+				}
+				return statSync(...args);
+			}) as typeof fs.statSync);
+
+			expect(logSignature(root)).toBe(
+				`${fileFor('u-1')}:2:${
+					statSync(path.join(eventsDir(), fileFor('u-1'))).mtimeMs
+				}`,
+			);
+		});
 	});
 
 	it('is nothing until something says so', () => {


### PR DESCRIPTION
Ticket K6W24FY. CI on main after #275 failed in `concurrent-sync.test.ts`: an actor crashed on an uncaught `ENOENT` from `logSignature`, which lists the events directory and then stats each entry. Nothing holds the directory still in between — another tool's sync renames a pending log twice and deletes it, and git rewrites tracked logs during a rebase — and the two-pass flush made that window routine.

`logSignature`, `loadAllPersistedEvents` and the integrity snapshot now treat a file gone between the listing and its read as a directory that moved: the listing is taken again (bounded), and a file still gone after that is absent. Quarantined lines are collected per attempt so a repeated listing does not report them twice.

Tests: a stat spy that removes a listed file (red on main: threw), a read spy that removes a file at the moment it is read (red on main: threw), the still-gone case. The batch-persist test now counts log reads rather than directory listings, since the signature's listing goes through the same `fs` object as the loader's. Full unit suite, lint, tsc; collaboration suite 15/15 in the container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vbyJZkFc3gjcJRGKo1Vc7