### PR TITLE
ZHC5DYA hold a release out of `latest` until its binaries are uploaded

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,51 @@ jobs:
       # against the TypeScript sources, so `npm ci` is the whole preparation.
       - run: npm run test:collab:ci
 
+  # GitHub makes a release `latest` the moment it is published, which is the
+  # moment the tag lands — five to ten minutes before the first binary is
+  # uploaded. `install.sh` reads `releases/latest/download/<asset>` and 404s for
+  # that whole window. `latest` skips prereleases, so holding the flag until the
+  # uploads finish makes it mean "the newest release you can actually download".
+  #
+  # No `needs`, so the hold lands within a minute of the push rather than after
+  # the test suites. `release-publish` lifts it; if an upload fails, nothing
+  # lifts it and `latest` stays on the last complete release — which is also the
+  # answer to a red `gui` job silently skipping the Release jobs and leaving
+  # `latest` on a release with no assets at all.
+  release-hold:
+    name: Hold release
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    outputs:
+      was-prerelease: ${{ steps.hold.outputs.was-prerelease }}
+    steps:
+      - name: Mark the release a prerelease
+        id: hold
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          # On a 404 `gh api` prints the error body to stdout and exits 1, so the
+          # status is what says whether there is a release — not the output.
+          if ! id="$(gh api "repos/$REPO/releases/tags/$TAG" --jq .id 2>/dev/null)"; then
+            # A bare tag push with no release behind it. The upload jobs create
+            # one, and they create it as a prerelease.
+            echo "No release for $TAG yet; the upload jobs will create one."
+            echo "was-prerelease=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          was="$(gh api "repos/$REPO/releases/$id" --jq .prerelease)"
+          echo "was-prerelease=$was" >> "$GITHUB_OUTPUT"
+          if [ "$was" = "true" ]; then
+            echo "Already a prerelease; leaving it alone."
+            exit 0
+          fi
+          gh api -X PATCH "repos/$REPO/releases/$id" -F prerelease=true >/dev/null
+          echo "Held $TAG out of \`latest\` until its binaries are up." >> "$GITHUB_STEP_SUMMARY"
+
   release:
     name: Release ${{ matrix.artifact }}
     if: startsWith(github.ref, 'refs/tags/v')
@@ -144,6 +189,10 @@ jobs:
         with:
           files: dist/${{ matrix.artifact }}
           fail_on_unmatched_files: true
+          # Re-asserted on every upload rather than relying on the action to
+          # preserve what `release-hold` set, and it is what creates the release
+          # as a prerelease when the tag was pushed without one.
+          prerelease: true
 
   # macOS Intel (x64) is cross-built on the Apple-silicon runner rather than
   # on a macos-13 Intel runner, whose hosted pool is scarce and was the cause
@@ -199,3 +248,27 @@ jobs:
         with:
           files: dist/epiq-macos-x64
           fail_on_unmatched_files: true
+          prerelease: true
+
+  # Every binary is up, so the release can become `latest`. Skipped when the
+  # release was already a prerelease before CI touched it — that was somebody's
+  # deliberate choice, not this workflow's hold.
+  release-publish:
+    name: Publish release
+    if: startsWith(github.ref, 'refs/tags/v') && needs.release-hold.outputs.was-prerelease != 'true'
+    needs: [release-hold, release, release-macos-x64]
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Promote the release to latest
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          id="$(gh api "repos/$REPO/releases/tags/$TAG" --jq .id)"
+          gh api -X PATCH "repos/$REPO/releases/$id" \
+            -F prerelease=false -f make_latest=true >/dev/null
+          echo "$TAG is now \`latest\`, with all five binaries behind it." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,39 +110,47 @@ jobs:
   # lifts it and `latest` stays on the last complete release — which is also the
   # answer to a red `gui` job silently skipping the Release jobs and leaving
   # `latest` on a release with no assets at all.
+  #
+  # Nothing here reads the flag back to decide what to do, so re-running the
+  # workflow over a tag whose hold is already in place behaves exactly like the
+  # first run. Which release is a prerelease on purpose is decided by the tag —
+  # see `release-publish`.
   release-hold:
     name: Hold release
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
     runs-on: ubuntu-latest
-    outputs:
-      was-prerelease: ${{ steps.hold.outputs.was-prerelease }}
+
     steps:
       - name: Mark the release a prerelease
-        id: hold
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           REPO: ${{ github.repository }}
           TAG: ${{ github.ref_name }}
         run: |
-          # On a 404 `gh api` prints the error body to stdout and exits 1, so the
-          # status is what says whether there is a release — not the output.
-          if ! id="$(gh api "repos/$REPO/releases/tags/$TAG" --jq .id 2>/dev/null)"; then
-            # A bare tag push with no release behind it. The upload jobs create
-            # one, and they create it as a prerelease.
-            echo "No release for $TAG yet; the upload jobs will create one."
-            echo "was-prerelease=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          was="$(gh api "repos/$REPO/releases/$id" --jq .prerelease)"
-          echo "was-prerelease=$was" >> "$GITHUB_OUTPUT"
-          if [ "$was" = "true" ]; then
-            echo "Already a prerelease; leaving it alone."
-            exit 0
-          fi
-          gh api -X PATCH "repos/$REPO/releases/$id" -F prerelease=true >/dev/null
-          echo "Held $TAG out of \`latest\` until its binaries are up." >> "$GITHUB_STEP_SUMMARY"
+          # Branch on the HTTP status rather than on `gh`'s exit code: a 401, a
+          # 403 or a passing 502 all exit non-zero too, and reading them as "no
+          # release yet" would skip the hold and leave open the window this job
+          # exists to close — silently, and with a green tick.
+          status="$(gh api -i "repos/$REPO/releases/tags/$TAG" 2>/dev/null | head -n 1 || true)"
+
+          case "$status" in
+            *' 200'*)
+              gh release edit "$TAG" --prerelease
+              echo "Held $TAG out of \`latest\` until its binaries are up." >> "$GITHUB_STEP_SUMMARY"
+              ;;
+            *' 404'*)
+              # A bare tag push with no release behind it. The upload jobs
+              # create one, and they create it as a prerelease.
+              echo "No release for $TAG yet; the upload jobs will create one."
+              ;;
+            *)
+              echo "::error::Could not read the release for $TAG (${status:-no response}), so it was not held out of \`latest\`."
+              exit 1
+              ;;
+          esac
 
   release:
     name: Release ${{ matrix.artifact }}
@@ -250,13 +258,14 @@ jobs:
           fail_on_unmatched_files: true
           prerelease: true
 
-  # Every binary is up, so the release can become `latest`. Skipped when the
-  # release was already a prerelease before CI touched it — that was somebody's
-  # deliberate choice, not this workflow's hold.
+  # Every binary is up, so the release can stop being a prerelease. A tag
+  # carrying a semver prerelease suffix — `v1.9.0-rc.1` — is one on purpose and
+  # is left held; that is the tag, not a flag this workflow also writes, so it
+  # reads the same on a re-run as on the first run.
   release-publish:
     name: Publish release
-    if: startsWith(github.ref, 'refs/tags/v') && needs.release-hold.outputs.was-prerelease != 'true'
-    needs: [release-hold, release, release-macos-x64]
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
+    needs: [release, release-macos-x64]
     permissions:
       contents: write
     runs-on: ubuntu-latest
@@ -265,10 +274,43 @@ jobs:
       - name: Promote the release to latest
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           REPO: ${{ github.repository }}
           TAG: ${{ github.ref_name }}
         run: |
-          id="$(gh api "repos/$REPO/releases/tags/$TAG" --jq .id)"
-          gh api -X PATCH "repos/$REPO/releases/$id" \
-            -F prerelease=false -f make_latest=true >/dev/null
+          gh release edit "$TAG" --prerelease=false
+
+          # Clearing the flag is not what moves `latest`, and forcing it would
+          # drag `latest` backwards onto a hotfix cut from an old branch. So
+          # claim it only when this really is the highest version — reading the
+          # list after the flag is cleared, so this release is in it.
+          #
+          # Only strict `vX.Y.Z` tags are compared: the repo carries at least
+          # one historical typo, `v.1.3.2`, which `sort -V` ranks above every
+          # real tag and which would otherwise veto every promotion forever.
+          newest="v$(gh api "repos/$REPO/releases?per_page=100" \
+            --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name' \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            | sed 's/^v//' \
+            | sort -V \
+            | tail -n 1)"
+
+          if [ "$newest" != "$TAG" ]; then
+            # Loud, not just a summary line: if this ever misfires it stops
+            # every release from going live, and silence is how that lasts.
+            echo "::warning::$newest ranks above $TAG, so \`latest\` was left where it is."
+            echo "$newest ranks above $TAG; leaving \`latest\` where it is." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          gh release edit "$TAG" --latest
+
+          # And confirm it took, because a promotion that silently does nothing
+          # leaves exactly the broken `latest` this whole job is here to avoid.
+          actual="$(gh api "repos/$REPO/releases/latest" --jq .tag_name)"
+          if [ "$actual" != "$TAG" ]; then
+            echo "::error::\`latest\` is $actual, not $TAG — the promotion did not take."
+            exit 1
+          fi
+
           echo "$TAG is now \`latest\`, with all five binaries behind it." >> "$GITHUB_STEP_SUMMARY"

--- a/install.sh
+++ b/install.sh
@@ -45,9 +45,31 @@ fi
 tmp="$(mktemp)"
 trap 'rm -f "$tmp"' EXIT
 
+missing="no prebuilt binary for ${os_name}-${arch_name} (asset: $asset). It may not be published for this platform yet."
+
 printf 'Downloading %s...\n' "$asset"
-curl -fsSL "$url" -o "$tmp" \
-  || err "no prebuilt binary for ${os_name}-${arch_name} (asset: $asset). It may not be published for this platform yet."
+# The 404 is handled below, so curl's own report of it would only confuse.
+if ! curl -fsSL "$url" -o "$tmp" 2>/dev/null; then
+  if [ -n "${EPIQ_VERSION:-}" ]; then
+    err "$missing"
+  fi
+  # A release becomes `latest` when it is published, but its binaries are built
+  # afterwards. Rather than fail for those few minutes, take the newest release
+  # that actually carries this asset — the API lists releases newest first, and
+  # omits drafts, so the first matching URL is the one we want.
+  printf 'Not in the latest release yet; looking for the newest one with %s...\n' "$asset"
+  releases="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=20")" \
+    || err "cannot reach the GitHub API to look up $asset"
+  url="$(printf '%s\n' "$releases" \
+    | grep -o "\"browser_download_url\": *\"[^\"]*/${asset}\"" \
+    | sed 's/.*"\(https[^"]*\)"/\1/' \
+    | head -n 1)"
+  [ -n "$url" ] || err "$missing"
+
+  tag="${url#https://github.com/${REPO}/releases/download/}"
+  printf 'Installing %s.\n' "${tag%/*}"
+  curl -fsSL "$url" -o "$tmp" || err "$missing"
+fi
 
 mkdir -p "$INSTALL_DIR"
 chmod +x "$tmp"

--- a/install.sh
+++ b/install.sh
@@ -43,14 +43,20 @@ fi
 
 # --- Download & install ----------------------------------------------------
 tmp="$(mktemp)"
-trap 'rm -f "$tmp"' EXIT
+curl_err="$(mktemp)"
+trap 'rm -f "$tmp" "$curl_err"' EXIT
 
 missing="no prebuilt binary for ${os_name}-${arch_name} (asset: $asset). It may not be published for this platform yet."
 
 printf 'Downloading %s...\n' "$asset"
-# The 404 is handled below, so curl's own report of it would only confuse.
-if ! curl -fsSL "$url" -o "$tmp" 2>/dev/null; then
+# curl's own report is kept back rather than silenced: a 404 here is expected
+# and handled below, but DNS, TLS and proxy failures land here too and must not
+# be passed off as "not published yet". Whichever way this ends, the message
+# the user sees is the one that fits. (Exit codes cannot make that distinction:
+# a 404 on these redirected downloads reports 56, not 22.)
+if ! curl -fsSL "$url" -o "$tmp" 2>"$curl_err"; then
   if [ -n "${EPIQ_VERSION:-}" ]; then
+    cat "$curl_err" >&2
     err "$missing"
   fi
   # A release becomes `latest` when it is published, but its binaries are built
@@ -58,8 +64,12 @@ if ! curl -fsSL "$url" -o "$tmp" 2>/dev/null; then
   # that actually carries this asset — the API lists releases newest first, and
   # omits drafts, so the first matching URL is the one we want.
   printf 'Not in the latest release yet; looking for the newest one with %s...\n' "$asset"
-  releases="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=20")" \
-    || err "cannot reach the GitHub API to look up $asset"
+  releases="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=20" 2>"$curl_err")" || {
+    # Whatever stopped the download above stopped this too, and curl's account
+    # of it is the useful thing to show.
+    cat "$curl_err" >&2
+    err "cannot reach the GitHub API to look up $asset. It rate-limits unauthenticated callers, so retry shortly, or name a release directly with EPIQ_VERSION=vX.Y.Z."
+  }
   url="$(printf '%s\n' "$releases" \
     | grep -o "\"browser_download_url\": *\"[^\"]*/${asset}\"" \
     | sed 's/.*"\(https[^"]*\)"/\1/' \
@@ -68,7 +78,10 @@ if ! curl -fsSL "$url" -o "$tmp" 2>/dev/null; then
 
   tag="${url#https://github.com/${REPO}/releases/download/}"
   printf 'Installing %s.\n' "${tag%/*}"
-  curl -fsSL "$url" -o "$tmp" || err "$missing"
+  curl -fsSL "$url" -o "$tmp" 2>"$curl_err" || {
+    cat "$curl_err" >&2
+    err "could not download $asset"
+  }
 fi
 
 mkdir -p "$INSTALL_DIR"


### PR DESCRIPTION
Closes `ZHC5DYA`.

GitHub makes a release `latest` the moment it is published — and publishing is what creates the tag, which is what starts CI. So `releases/latest/download/<asset>`, which `install.sh` reads, points at a release whose binaries are five to ten minutes from existing. On v1.8.5 that was six minutes: published 22:39:30, first asset uploaded 22:45:36.

The same gap is permanent rather than transient whenever a Release job never runs: `release` and `release-macos-x64` both `needs: [test, gui]`, so a red GUI job leaves `latest` on a release with no assets at all.

**CI holds the release out of `latest` until every binary is up.** `release-hold` has no `needs`, so it marks the release a prerelease within seconds of the tag push; `latest` skips prereleases. Each upload re-asserts the flag rather than trusting the action to preserve it, and `release-publish`, gated on all five uploads, lifts it. A failed upload therefore leaves `latest` on the last release you can actually download.

Nothing reads the prerelease flag back to decide what to do, so a re-run behaves exactly like a first run. Which releases are prereleases on purpose is decided by the tag's semver suffix — `v1.9.0-rc.1` is held and never promoted.

**Promotion is guarded and verified.** Clearing the flag is not what moves `latest`, and forcing `make_latest` would drag it backwards onto a hotfix cut from an old branch, so the job claims `latest` only when the tag really is the highest version — then reads `releases/latest` back and fails if it did not move. A promotion that silently no-ops would leave exactly the broken `latest` this PR exists to prevent.

**`install.sh` no longer hard-fails on the residual race.** The `latest` fast path is unchanged; when it fails, the installer takes the newest release in the API listing that actually carries this platform's asset, and names the version it installs. curl's own diagnosis is shown whenever the failure turns out not to be a still-building release, so a proxy or DNS problem is never passed off as one.

Two visible consequences: a release carries the "Pre-release" badge for the few minutes its binaries build, and the `released` webhook activity fires when the binaries exist rather than when the tag lands.

### Verification

Installer resolution, against the live releases API and two fixtures derived from it:

| listing | result |
| --- | --- |
| newest release has all assets | every platform → v1.8.5 |
| newest release has no assets (the bug) | every platform → v1.8.4 |
| newest release mid-upload, linux only | linux → v1.8.5, macOS and windows → v1.8.4 |

All six paths through the download logic were run end to end: happy path, forced 404 into the fallback (installs a working `Mach-O 64-bit executable arm64` reporting `1.8.5`), a DNS failure on the download host, an unreachable API, a pinned `EPIQ_VERSION` whose release lacks the asset, and an asset in no release at all.

The workflow's lookups and its promotion guard were rehearsed read-only against v1.8.5, a draft release, a nonexistent tag, and a hypothetical backport tag.

Three bugs came out of that rehearsing rather than out of reading the code, which is the argument for doing it:

- `gh api --jq .id` prints the error body to stdout and exits 1 on a 404, so testing the output for emptiness never fires. The hold branches on the HTTP status line, and treats anything that is neither 200 nor 404 as a failure rather than as "no release yet".
- `sort -V` ranks this repo's historical `v.1.3.2` typo above every real tag, so the first version of the highest-version guard vetoed every promotion. Only strict `vX.Y.Z` tags are compared now, and declining to promote is a `::warning::` rather than a quiet summary line.
- curl reports exit 56, not 22, for a 404 on these redirected downloads — so classifying failures by exit code fails on the one case it exists to catch. The script shows curl's message when it matters instead.

The promotion itself only runs on a real tag, so the first live release after this merge is where it proves itself; if an upload fails, the release stays marked pre-release and says so.
