### PR TITLE
SSBW3P6 expose createBoard to agents as epiq_board_create

### DIFF
--- a/.claude/skills/epiq-architecture/SKILL.md
+++ b/.claude/skills/epiq-architecture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: epiq-architecture
-description: The distributed rules epiq's event log obeys — causal ordering by last-known edge, logical clocks, tombstones, total replay. Read before touching events, ordering, merge, replay, materialization, sync, or before adding an event type.
+description: How epiq is built — the distributed rules its event log obeys (causal ordering by last-known edge, logical clocks, tombstones, total replay), and the layers the code is arranged in. Read before touching events, ordering, merge, replay, materialization or sync, before adding an event type or a websocket message, and before adding a module, a hook or a capability that crosses layers.
 ---
 
 # The event log is a CRDT
@@ -49,6 +49,44 @@ Applied on every machine, in causal order, possibly after events it did not expe
 
 Touching ordering, merge, replay or materialization means running both.
 
+
+## The layers
+
+Dependencies point one way, and nothing lower reaches up.
+
+- **`source/lib/`** — the domain. The event log, the node repository, ranks, state, and the TUI that draws it. Knows nothing about MCP, HTTP or React, which is what lets the same code answer all three.
+- **`source/mcp/api/`** — one function per board operation: `createBoard`, `moveIssue`, `addIssueTag`. Boots, checks its preconditions, writes events, returns a `Result`. A mutation lives here and only here.
+- **`source/mcp/server.ts` and `source/gui/api/`** — the front doors. An MCP tool and a websocket message are two ways into the *same* `mcp/api` function; neither re-implements one. A guard that exists in only one door is a bug in the other.
+- **`source/gui/client/`** — React, and nothing else. It cannot import `source/lib/event/*` or anything else Node-side; the GUI build fails on it.
+
+Two rules that hold across all of them:
+
+- **Errors are returned, never thrown** — `failed()` / `succeeded()` and `isFail`, up to the front door, which turns the `Result` into a tool response or a socket frame.
+- **A change in `lib/` lands in the TUI, the MCP and the GUI at once.** Check all three before calling it done.
+
+The one inversion is `lib/state/sync-state.ts` reaching up into `gui/client/lib/gui-broadcast.js` to push a sync status. It is a wart to work around, not a pattern to copy.
+
+## Modular per concept, not per fragment
+
+The layering above is what exists; following it is the cheapest thing you can do for the next reader. What gets *added* has to keep it legible, and that means one module owning one high-level concept — a domain, a question, a screen's worth of state — rather than a slice of several.
+
+- **A capability is a vertical slice through the layers, never a shortcut across them.** Creating a board from the GUI is `createBoard` in `mcp/api/boards.ts`, a `board:create` message, a hook, and a palette entry: four small additions in four layers, not one socket handler that writes an event itself.
+- **Name a module after its concept, so somebody can guess the file.** `use-swimlane-editing.ts` owns the column editors, `use-board-creation.ts` the new-board modal, `commands/command-registry.ts` what the palette offers.
+- **State lives where it is drawn**, and a module that owns a question answers it for every caller — reuse the rule rather than restating it. `needsWrite` in the command registry is written once and used by every command that mutates.
+- **A few domain modules of a few hundred lines beat a file per fragment.** The entry file stays a brief overview of the flow.
+- **Keep the domain a value, not a React tree.** The command registry is built from injected handlers, so a test constructs the whole thing with no DOM.
+
+What the rule prevents is already on the board: `HZCA9EG` — App.tsx at 1900 lines, handing 27 hook return values down as props — and `XCNBCDB` — the same nine-line boot/actor/state preamble repeated at 21 `mcp/api` call sites. Both are what adding to a layer without giving the addition a home costs later.
+
+### Adding a websocket message
+
+Five places. Miss one and it fails quietly rather than loudly:
+
+- `gui/api/lib/websocket.model.ts` — the type
+- `gui/api/lib/websocket.schema.ts` — the zod shape; an unlisted message is refused at the door
+- `gui/client/lib/gui-mutations.ts` — if it mutates, so the client holds broadcasts until its own reply lands
+- `gui/api/lib/websocket.ts` — the handler, which calls `mcp/api` and does nothing else
+- `mcp/epiq-api.ts` — the export, when the function is new
 
 ## Workflow
 - Make branch in worktree

--- a/source/gui/api/lib/websocket.model.ts
+++ b/source/gui/api/lib/websocket.model.ts
@@ -5,6 +5,7 @@ export type GuiMessage =
 	| {type: 'project:open'; payload: {root: string}}
 	| {type: 'issues:list'}
 	| {type: 'issues:create'; payload: {title: string; parentId: string}}
+	| {type: 'board:create'; payload: {title: string}}
 	| {type: 'swimlane:create'; payload: {title: string; boardId: string}}
 	| {type: 'swimlane:edit:title'; payload: {swimlaneId: string; title: string}}
 	| {type: 'swimlane:delete'; payload: {swimlaneId: string}}

--- a/source/gui/api/lib/websocket.schema.ts
+++ b/source/gui/api/lib/websocket.schema.ts
@@ -49,6 +49,7 @@ export const GuiMessageSchema = z.discriminatedUnion('type', [
 			tagNames: z.array(z.string()).optional(),
 		}),
 	),
+	message('board:create', z.object({title: z.string()})),
 	message('swimlane:create', z.object({title: z.string(), boardId: id})),
 	message('swimlane:edit:title', z.object({swimlaneId: id, title: z.string()})),
 	message('swimlane:delete', z.object({swimlaneId: id})),

--- a/source/gui/api/lib/websocket.ts
+++ b/source/gui/api/lib/websocket.ts
@@ -8,6 +8,7 @@ import {
 	addIssueComment,
 	addIssueTag,
 	closeIssue,
+	createBoard,
 	createIssue,
 	createSwimlane,
 	deleteSwimlane,
@@ -562,6 +563,21 @@ export const setupWebsocket = (
 
 					onStateChanged();
 					return sendGuiState(socket, repoRoot);
+				}
+
+				if (type === 'board:create') {
+					const result = await createBoard({
+						...message.payload,
+						repoRoot,
+					});
+
+					return sendMutationResult(
+						socket,
+						repoRoot,
+						onStateChanged,
+						'board:create:result',
+						result,
+					);
 				}
 
 				if (type === 'swimlane:create') {

--- a/source/gui/client/App.tsx
+++ b/source/gui/client/App.tsx
@@ -92,6 +92,7 @@ import {useBoardSelection} from './lib/use-board-selection';
 import {BoardSocketActions, useBoardSocket} from './lib/use-board-socket';
 import {useIssueDetail} from './lib/use-issue-detail';
 import {useIssueMutations} from './lib/use-issue-mutations';
+import {useBoardCreation} from './lib/use-board-creation';
 import {useSwimlaneEditing} from './lib/use-swimlane-editing';
 import {createHistoryBuffer} from './lib/history-buffer';
 import {SyncStatus} from './lib/gui-sync-statusmodel';
@@ -614,6 +615,14 @@ export const App = () => {
 					},
 				});
 			}
+		}
+
+		// This client's own reply again, for the same reason: a broadcast would
+		// drag everyone else's board to whatever was created last.
+		if (message.type === 'board:create:result') {
+			const created = getResultValue<{ref: string}>(message.payload);
+
+			if (created) void navigateRef.current(`/board/${created.ref}`);
 		}
 
 		// A refused mutation is otherwise invisible: the optimistic update is
@@ -1172,6 +1181,12 @@ export const App = () => {
 		confirmDeleteSwimlane,
 	} = useSwimlaneEditing({send, setState, selectedBoard, visibleSwimlanes});
 
+	const {createBoardTitle, setCreateBoardTitle, createBoard} = useBoardCreation(
+		{
+			send,
+		},
+	);
+
 	// Flattened once per state change rather than per keystroke: the palette
 	// matches over this on every character typed into its second step.
 	const searchableTickets = useMemo(
@@ -1212,6 +1227,7 @@ export const App = () => {
 				if (swimlaneId) setCreateIssueModal({swimlaneId, title: ''});
 			},
 			createSwimlane: () => setCreateSwimlaneTitle(''),
+			createBoard: () => setCreateBoardTitle(''),
 			openIssue: (id: string, boardRef: string) =>
 				openIssueTab(id, 'overview', boardRef),
 			closeIssue,
@@ -1863,6 +1879,18 @@ export const App = () => {
 						confirmLabel="delete"
 						onConfirm={confirmDeleteSwimlane}
 						onClose={() => setDeleteSwimlaneId(null)}
+					/>
+				)}
+
+				{createBoardTitle !== null && (
+					<CreateNodeModal
+						eyebrow="New board"
+						fieldLabel="title"
+						placeholder="board name"
+						title={createBoardTitle}
+						onChangeTitle={setCreateBoardTitle}
+						onCreate={createBoard}
+						onClose={() => setCreateBoardTitle(null)}
 					/>
 				)}
 

--- a/source/gui/client/lib/commands/command-registry.test.ts
+++ b/source/gui/client/lib/commands/command-registry.test.ts
@@ -20,6 +20,7 @@ const handlers = (): CommandHandlers => ({
 	returnToLive: vi.fn(),
 	toggleLog: vi.fn(),
 	createSwimlane: vi.fn(),
+	createBoard: vi.fn(),
 });
 
 const issue = (overrides: Partial<GuiIssue> = {}): GuiIssue => ({
@@ -132,6 +133,26 @@ describe('the GUI command registry', () => {
 			expect(
 				find('gui:live').unavailable(context({scrubbing: true})),
 			).toBeNull();
+		});
+
+		// A board is not made on a ticket: unlike everything in the Ticket group
+		// this has to be offered with none open.
+		it('creates a board with no ticket open', () => {
+			const empty = context({issue: null});
+
+			expect(find('gui:board').unavailable(empty)).toBeNull();
+
+			find('gui:board').run(empty);
+			expect(empty.handlers.createBoard).toHaveBeenCalled();
+		});
+
+		it('holds a new board back offline and in the past', () => {
+			expect(find('gui:board').unavailable(context({connected: false}))).toBe(
+				'Not connected',
+			);
+			expect(find('gui:board').unavailable(context({scrubbing: true}))).toBe(
+				'Read-only while viewing history',
+			);
 		});
 
 		it('sorts what cannot run last', () => {

--- a/source/gui/client/lib/commands/command-registry.ts
+++ b/source/gui/client/lib/commands/command-registry.ts
@@ -78,6 +78,17 @@ export const buildCommandRegistry = (): GuiCommand[] => [
 		run: context => context.handlers.createSwimlane(),
 	},
 	{
+		// The TUI reaches this as `:new board`, where the modifier says which
+		// thing is being made. A palette has no modifiers, so the two creates are
+		// two commands.
+		id: 'gui:board',
+		title: 'New board',
+		group: 'Board',
+		keywords: ['create', 'add', 'project', 'another'],
+		unavailable: needsWrite,
+		run: context => context.handlers.createBoard(),
+	},
+	{
 		id: CmdKeywords.COMMENT,
 		title: 'Comment on ticket',
 		group: 'Ticket',

--- a/source/gui/client/lib/commands/command.model.ts
+++ b/source/gui/client/lib/commands/command.model.ts
@@ -68,6 +68,7 @@ export type CommandHandlers = {
 	returnToLive: () => void;
 	toggleLog: () => void;
 	createSwimlane: () => void;
+	createBoard: () => void;
 };
 
 export type GuiCommand = {

--- a/source/gui/client/lib/gui-mutations.ts
+++ b/source/gui/client/lib/gui-mutations.ts
@@ -3,6 +3,7 @@
 export const MUTATING_MESSAGE_TYPES = new Set<string>([
 	'sync',
 	'issues:create',
+	'board:create',
 	'swimlane:create',
 	'swimlane:edit:title',
 	'swimlane:delete',

--- a/source/gui/client/lib/use-board-creation.ts
+++ b/source/gui/client/lib/use-board-creation.ts
@@ -1,0 +1,28 @@
+// The new-board modal: its title, and the send that creates the board.
+//
+// No optimistic board, unlike a new swimlane: the point of creating one is to
+// go there, and a placeholder in the switcher is an entry whose route does not
+// exist yet. The board arrives with the state that follows the result, and
+// `board:create:result` is what navigates to it.
+
+import {useState} from 'react';
+import {BoardSocketActions} from './use-board-socket';
+
+export const useBoardCreation = ({
+	send,
+}: {
+	send: BoardSocketActions['send'];
+}) => {
+	const [createBoardTitle, setCreateBoardTitle] = useState<string | null>(null);
+
+	const createBoard = () => {
+		if (createBoardTitle === null) return;
+
+		const title = createBoardTitle.trim() || 'New board';
+
+		setCreateBoardTitle(null);
+		send('board:create', {title});
+	};
+
+	return {createBoardTitle, setCreateBoardTitle, createBoard};
+};

--- a/source/mcp/api/boards.ts
+++ b/source/mcp/api/boards.ts
@@ -28,6 +28,10 @@ import {
 	getStateResult,
 } from './boot.js';
 
+type CreateBoardInput = ToolInput & {
+	title: string;
+};
+
 type ListSwimlanesInput = ToolInput & {
 	boardId?: string;
 };
@@ -70,6 +74,69 @@ export const listBoards = async (input: ToolInput = {}) => {
 		}));
 
 	return succeeded('Listed boards', boards);
+};
+
+export const createBoard = async (input: CreateBoardInput) => {
+	const bootResult = await boot(input.repoRoot, {pull: false});
+	if (isFail(bootResult)) return bootResult;
+
+	const actorResult = getActor();
+	if (isFail(actorResult)) return actorResult;
+
+	const stateResult = getStateResult();
+	if (isFail(stateResult)) return stateResult;
+
+	// Boards hang off the workspace, and there is exactly one of those: the
+	// caller has no parent to pass, and could not be trusted with it anyway.
+	const workspace = stateResult.value.nodes[stateResult.value.rootNodeId];
+	if (!workspace) return failed('Workspace not found');
+
+	// The workspace carries no readonly of its own, so — as with a swimlane on a
+	// board — the scrub guard has to be this function's.
+	if (getTimeTravelStatus().mode !== 'live') {
+		return failed('Cannot add a board while time travelling');
+	}
+
+	const title = sanitizeInlineText(input.title);
+	if (!title.trim()) return failed('Board title cannot be empty');
+
+	const overLongTitle = tooLong('Board title', title, MAX_TITLE_LENGTH);
+	if (overLongTitle) return failed(overLongTitle);
+
+	const rankResult = resolveAndPersistRankForCreate(
+		workspace.id,
+		actorResult.value,
+		bootResult.value.stateBranchRoot,
+	);
+	if (isFail(rankResult)) return rankResult;
+
+	const boardId = ulid();
+
+	const event = {
+		id: ulid(),
+		...actorResult.value,
+		action: 'add.board',
+		payload: {
+			id: boardId,
+			name: title,
+			parent: workspace.id,
+			rank: rankResult.value,
+		},
+	} satisfies AppEvent<'add.board'>;
+
+	const results = materializeAndPersistAll(
+		[event],
+		bootResult.value.stateBranchRoot,
+	);
+	if (isFail(results)) return failed(results.message);
+
+	// No swimlanes: the TUI's `:new board` makes a bare one too, and the board
+	// shows the add-column ghost from empty.
+	return succeeded('Created board', {
+		id: boardId,
+		ref: nodeRef(boardId),
+		title,
+	});
 };
 
 export const listSwimlanes = async (input: ListSwimlanesInput = {}) => {

--- a/source/mcp/epiq-api.ts
+++ b/source/mcp/epiq-api.ts
@@ -12,6 +12,7 @@ export {
 } from './api/issues.js';
 export {
 	listBoards,
+	createBoard,
 	listSwimlanes,
 	createSwimlane,
 	editSwimlaneTitle,

--- a/source/mcp/test/epiq-api.test.ts
+++ b/source/mcp/test/epiq-api.test.ts
@@ -162,6 +162,16 @@ vi.mock('../../lib/repository/rank.js', () => ({
 }));
 
 const nodes: Record<string, Partial<NavNode<AnyContext>>> = {
+	// The root every board hangs off, as the real state carries it: without it
+	// there is nothing for a new board to be a child of.
+	'workspace-1': {
+		id: 'workspace-1',
+		title: 'Workspace',
+		context: 'WORKSPACE',
+		readonly: false,
+		isDeleted: false,
+		rank: 'a0',
+	},
 	'board-1': {
 		id: 'board-1',
 		title: 'Default',
@@ -626,6 +636,63 @@ describe('mcp tools', () => {
 
 			expect(isFail(result)).toBe(true);
 		});
+	});
+
+	it('creates a board on the workspace', async () => {
+		const result = await tools.createBoard({
+			repoRoot: '/repo',
+			title: 'Roadmap',
+		});
+
+		expect(isFail(result)).toBe(false);
+		if (!isFail(result)) {
+			expect(result.value).toEqual({
+				id: expect.any(String),
+				ref: expect.any(String),
+				title: 'Roadmap',
+			});
+		}
+
+		expect(persistModule.materializeAndPersistAll).toHaveBeenCalledWith(
+			[
+				expect.objectContaining({
+					action: 'add.board',
+					payload: expect.objectContaining({
+						name: 'Roadmap',
+						parent: 'workspace-1',
+						rank: expect.any(String),
+					}),
+				}),
+			],
+			'/state',
+		);
+	});
+
+	// Nothing above a board is readonly, so this guard is the only thing
+	// standing between a scrubbed checkout and a write to the state branch.
+	it('refuses a board while the checkout is in the past', async () => {
+		vi.mocked(timeTravelModule.getTimeTravelStatus).mockReturnValueOnce({
+			mode: 'scrub',
+			asOfTime: 123,
+		});
+
+		const result = await tools.createBoard({repoRoot: '/repo', title: 'Later'});
+
+		expect(isFail(result)).toBe(true);
+		if (isFail(result)) {
+			expect(result.message).toBe('Cannot add a board while time travelling');
+		}
+
+		expect(persistModule.materializeAndPersistAll).not.toHaveBeenCalled();
+	});
+
+	it('refuses a board with a blank title', async () => {
+		const result = await tools.createBoard({repoRoot: '/repo', title: '   '});
+
+		expect(isFail(result)).toBe(true);
+		if (isFail(result)) {
+			expect(result.message).toBe('Board title cannot be empty');
+		}
 	});
 
 	it('creates a swimlane on a board', async () => {

--- a/source/test/e2e-gui/command-palette.pw.ts
+++ b/source/test/e2e-gui/command-palette.pw.ts
@@ -286,3 +286,33 @@ test('what was run last leads the list, and survives a reload', async ({
 
 	expect(pageErrors).toEqual([]);
 });
+
+// The one command that leaves the board it was run from: making a board is
+// only worth anything if you land on it.
+test('a new board is created from the palette, and the switcher moves to it', async ({
+	page,
+	appUrl,
+	pageErrors,
+}) => {
+	await page.goto(appUrl);
+	await expect(page.getByTestId('board-switcher')).toContainText('Default');
+
+	const name = `Palette board ${Date.now()}`;
+
+	await openPalette(page);
+	await page.keyboard.type('new board');
+	await expect(rows(page).first()).toContainText('New board');
+	await page.keyboard.press('Enter');
+
+	await page.getByPlaceholder('board name').fill(name);
+	await page.getByPlaceholder('board name').press('Enter');
+
+	await expect(page.getByTestId('board-switcher')).toContainText(name);
+	await expect(page).toHaveURL(/\/board\//);
+
+	// Bare, the way the TUI's `:new board` leaves one — the ghost column is the
+	// way out of an empty board.
+	await expect(page.getByTestId('add-swimlane')).toBeVisible();
+
+	expect(pageErrors).toEqual([]);
+});

--- a/source/test/mcp-lock.test.ts
+++ b/source/test/mcp-lock.test.ts
@@ -14,6 +14,7 @@ vi.mock('../mcp/epiq-api.js', () => ({
 	assumeActor: vi.fn(),
 	closeIssue: vi.fn(),
 	createIssue: vi.fn(),
+	createBoard: vi.fn(),
 	createSwimlane: vi.fn(),
 	deleteIssueComment: vi.fn(),
 	editIssueComment: vi.fn(),

--- a/source/test/websocket-open-project.test.ts
+++ b/source/test/websocket-open-project.test.ts
@@ -15,6 +15,7 @@ vi.mock('../mcp/epiq-api.js', () => ({
 	addIssueTag: vi.fn(),
 	closeIssue: vi.fn(),
 	createIssue: vi.fn(),
+	createBoard: vi.fn(),
 	createSwimlane: vi.fn(),
 	deleteSwimlane: vi.fn(),
 	deleteIssueComment: vi.fn(),


### PR DESCRIPTION
Stacked on #278 (JBWQ900), which brings `createBoard` to `mcp/api/boards.ts` with its API tests and the GUI command. This adds the agent-facing tool: `epiq_board_create({title})`, registered beside `epiq_board_list`, same title limit as swimlanes; the board comes out bare and the description says so and points at `epiq_swimlane_create`. Verified over stdio that `tools/list` carries it.

Land #278 first (it is 22 commits behind main and wants a rebase); GitHub retargets this one to main when it merges. Pre-push gate green on the second run; the first failed on the same GUI load flake #278 records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016R6yL4L8zLKiPa4ikFimNr